### PR TITLE
feat(f5a-phase1): Hybrid Search — FTS + pgvector + RRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,17 @@ DB_MAX_OVERFLOW=10
 
 
 # =============================================================================
+# Hybrid Retrieval (F5-A Phase 1)
+# =============================================================================
+# Hybrid search combines keyword FTS (ts_rank_cd) with semantic pgvector
+# results via Reciprocal Rank Fusion. Disable to fall back to semantic-only.
+#
+# HYBRID_ENABLED=true
+# HYBRID_RRF_K=60                         # RRF constant; typical 30-100
+# FTS_LANGUAGES=russian,english           # Informational; baked into search_vector DDL
+
+
+# =============================================================================
 # Topicization Tuning
 # =============================================================================
 # TOPICIZATION_BATCH_SIZE=50           # Max docs per LLM call in discover_new_topics

--- a/ENV_VARIABLES_GUIDE.md
+++ b/ENV_VARIABLES_GUIDE.md
@@ -121,6 +121,14 @@ LLM_VERBOSITY=low
 # EMBEDDING_BATCH_SIZE=100
 
 # =============================================================================
+# Hybrid Retrieval (F5-A Phase 1)
+# =============================================================================
+
+# HYBRID_ENABLED=true
+# HYBRID_RRF_K=60
+# FTS_LANGUAGES=russian,english
+
+# =============================================================================
 # Multi-Tenancy (F4)
 # =============================================================================
 
@@ -516,6 +524,42 @@ Override the global LLM provider/model for specific pipeline stages. Useful for 
 - **Type**: integer
 - **Default**: `100`
 - **Description**: Number of texts to embed per API call
+
+---
+
+### Hybrid Retrieval (F5-A Phase 1)
+
+Hybrid retrieval combines keyword FTS (`ts_rank_cd`) with semantic pgvector
+similarity and fuses the two ranked lists via Reciprocal Rank Fusion (RRF).
+Use `mode` on the REST `/api/v1/search` and `/api/v1/ask` endpoints to
+override per-request (`"semantic" | "keyword" | "hybrid"`).
+
+#### `HYBRID_ENABLED`
+- **Type**: boolean
+- **Default**: `true`
+- **Description**: Master switch for hybrid retrieval. When `false`, the
+  service silently downgrades `mode="hybrid"` requests to `semantic` (useful
+  for debugging or if FTS infrastructure is unavailable).
+
+#### `HYBRID_RRF_K`
+- **Type**: integer (>= 1)
+- **Default**: `60`
+- **Description**: Reciprocal Rank Fusion constant. Lower values increase
+  discrimination between top-ranked hits; higher values flatten the curve.
+  The canonical value from Cormack et al. (SIGIR 2009) is 60.
+
+#### `FTS_LANGUAGES`
+- **Type**: string (comma-separated)
+- **Default**: `russian,english`
+- **Description**: Informational — advertises the text-search configurations
+  blended into the STORED `search_vector` columns (`simple` A + `russian` B
+  + `english` B). Changing this value alone does NOT rebuild the tsvector;
+  new languages require a migration.
+
+**Migrations:** `d4e5f6a7b8c9` (`processed_documents.search_vector`) and
+`e5f6a7b8c9d0` (`topic_cards.search_vector`). WARNING: `ADD COLUMN ...
+GENERATED ... STORED` triggers a full table rewrite in PostgreSQL. Apply
+during a maintenance window for production databases > 1M rows.
 
 ---
 

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -22,8 +22,8 @@ Auth: Bearer <MCP_AUTH_TOKEN>
 
 | Tool | Auth | Description |
 |------|------|-------------|
-| `search_knowledge_base` | any | Semantic search over processed documents |
-| `ask_question` | any | RAG-powered Q&A with source citations |
+| `search_knowledge_base` | any | Hybrid (FTS + pgvector) search over processed documents |
+| `ask_question` | any | RAG-powered Q&A with source citations (hybrid retrieval) |
 
 ### Navigation
 
@@ -105,6 +105,12 @@ Returns: list[SearchResultItem]
   text_preview: str | null
   channel_id: str | null
 ```
+
+**Retrieval mode (F5-A Phase 1):** `search_knowledge_base` uses hybrid retrieval
+by default (keyword FTS + semantic pgvector fused via Reciprocal Rank Fusion).
+The `mode` parameter (`"semantic" | "keyword" | "hybrid"`) is exposed on the
+REST `/api/v1/search` endpoint; MCP pass-through of `mode` is planned for
+Phase 2.
 
 ### `ask_question`
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -378,6 +378,46 @@ TOPICIZATION_LLM_MODEL=claude-sonnet-4-20250514
 
 ---
 
+## Hybrid Search (F5-A Phase 1)
+
+Поиск и RAG Q&A по базе знаний по умолчанию используют **hybrid retrieval** — комбинацию семантического поиска (pgvector cosine) и полнотекстового поиска (PostgreSQL FTS `ts_rank_cd`) с объединением результатов через **Reciprocal Rank Fusion (RRF)**. Это даёт лучшую отдачу на коротких запросах с редкими терминами/именами и на запросах, где семантика рушится из-за жаргона.
+
+### Режимы (`mode`)
+
+| Режим | Что делает | Когда использовать |
+|-------|-----------|--------------------|
+| `semantic` | Только pgvector cosine | Парафразы, смысловые запросы |
+| `keyword` | Только FTS (`plainto_tsquery` + `ts_rank_cd`) | Точные термины, имена, аббревиатуры |
+| `hybrid` (default) | `semantic` + `keyword` через RRF | Общий случай — безопасный дефолт |
+
+`POST /api/v1/search` и `/api/v1/ask` принимают поле `mode` в теле запроса; MCP-инструмент `search_knowledge_base` также использует `hybrid` по умолчанию (в Phase 1 `mode` ещё не пробрасывается через MCP-wrapper — ожидается в Phase 2).
+
+### Multilingual FTS
+
+STORED `tsvector` столбцы `processed_documents.search_vector` и `topic_cards.search_vector` содержат три слоя: `simple` (A-вес), `russian` (B) и `english` (B). Это позволяет одному и тому же полю матчиться как русскому, так и английскому запросу без дублирования данных.
+
+### Конфигурация
+
+```env
+HYBRID_ENABLED=true          # false → silent downgrade hybrid→semantic
+HYBRID_RRF_K=60              # RRF-константа; 60 — канонический дефолт
+FTS_LANGUAGES=russian,english  # informational; зашито в DDL search_vector
+```
+
+### Миграции и table rewrite
+
+Hybrid search требует двух миграций (`d4e5f6a7b8c9`, `e5f6a7b8c9d0`), которые добавляют STORED столбцы `search_vector` с `GENERATED ALWAYS AS ... STORED` и GIN-индексы. **Важно:** `ADD COLUMN ... GENERATED ... STORED` в PostgreSQL вызывает **table rewrite** — для продакшн-БД с > 1M строк применять в maintenance-окно.
+
+```bash
+# Применить миграции
+python -m tg_parser.cli migrate --target head
+
+# Проверить текущий head
+python -m tg_parser.cli migrate --show-current
+```
+
+---
+
 ## CLI команды
 
 Все команды запускаются через:

--- a/docs/plans/F5A_PERSISTENT_KB_PLAN.md
+++ b/docs/plans/F5A_PERSISTENT_KB_PLAN.md
@@ -192,14 +192,18 @@ fts_languages: str = "russian,english"  # информационная
 
 ### 3.6 Acceptance criteria (Session 1)
 
-- [ ] Миграции применяются без downtime (generated columns — онлайновые при STORED, но требуют REWRITE; на больших таблицах нужен план; документируем в release notes).
-- [ ] GIN индексы созданы на обеих таблицах.
-- [ ] `retrieval_service.search(mode="hybrid")` — дефолт; старые сигнатуры сохранены.
-- [ ] RRF unit-тесты проходят (≥ 10 кейсов).
-- [ ] Integration-тесты с pg+pgvector проходят в CI и локально.
-- [ ] Все существующие тесты (`test_f5a_topic_rag.py`, `test_retrieval_llm_refactor.py`, `test_rag_routes.py`, `test_rag_prompt_config.py`) проходят без модификаций логики.
-- [ ] Документация обновлена.
-- [ ] Коммит(ы) в отдельной ветке/PR для review перед merge в `main`.
+- [x] Миграции применяются без downtime (generated columns — онлайновые при STORED, но требуют REWRITE; на больших таблицах нужен план; документируем в release notes).
+- [x] GIN индексы созданы на обеих таблицах.
+- [x] `retrieval_service.search(mode="hybrid")` — дефолт; старые сигнатуры сохранены.
+- [x] RRF unit-тесты проходят (≥ 10 кейсов) — 11 тестов в `TestRRFFusion`.
+- [x] Integration-тесты с pg+pgvector проходят в CI и локально — `TestKeywordSearchRepo`, `TestMigrationIdempotency`, `TestHybridIntegration`.
+- [x] Все существующие тесты проходят без модификаций логики — 1331 → 1364 pass.
+- [x] Документация обновлена (`USER_GUIDE.md`, `MCP_AGENT_GUIDE.md`, `ENV_VARIABLES_GUIDE.md`).
+- [x] Коммит(ы) в отдельной ветке для review перед merge в `main`.
+
+**Phase 1 DONE** — ветка `feat/f5a-phase1-hybrid-search`, коммиты
+`feat(f5a-phase1): add FTS migrations, keyword_search repo, and rrf_fuse module`
+и `feat(f5a-phase1): wire hybrid mode with RRF fusion in retrieval_service and API`.
 
 ---
 

--- a/docs/plans/F5A_PHASE1_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/F5A_PHASE1_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,293 @@
+# F5-A Phase 1 — Implementation Plan (Hybrid Search)
+
+**Версия проекта:** 4.4.0+ (post F8-A Hardening, коммит `8012021`)
+**Scope:** Добавить hybrid search (FTS + pgvector через RRF) в retrieval pipeline.
+**Предыдущие фазы:** Wave 1.5 → F8-A ✅. Следующие: F5-A Phase 2 (relevance tuning), Phase 3 (dedup).
+**Design-doc:** [`F5A_PERSISTENT_KB_PLAN.md`](F5A_PERSISTENT_KB_PLAN.md)
+**Starter prompt:** [`../prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md`](../prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md)
+
+---
+
+## Контекст (после разведки)
+
+- Текущая `search()` — [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) строка 45; вызывает только `emb_repo.similarity_search` (pgvector cosine).
+- Класс repo — **`SAEmbeddingRepo`** (не `SAmbeddingRepo` как в первоначальном промпте) — [`tg_parser/storage/sqlalchemy/embedding_repo.py`](../../tg_parser/storage/sqlalchemy/embedding_repo.py).
+- `EmbeddingRepo` ABC — [`tg_parser/storage/ports.py`](../../tg_parser/storage/ports.py) строки 815–870.
+- DDL/ensure — [`tg_parser/storage/sqlalchemy/schemas/processing_storage.py`](../../tg_parser/storage/sqlalchemy/schemas/processing_storage.py): `PROCESSING_STORAGE_DDL` (15–238), `_ensure_embedding_columns` (272–314).
+- Alembic head: `c3d4e5f6a7b8` (`20260416_add_embedding_channel_ids.py`).
+- Потребители `search`/`answer`: [`tg_parser/api/routes/rag.py`](../../tg_parser/api/routes/rag.py), [`tg_parser/mcp_server.py`](../../tg_parser/mcp_server.py), [`tg_parser/bot/tools.py`](../../tg_parser/bot/tools.py), [`tg_parser/cli/app.py`](../../tg_parser/cli/app.py).
+- Существующие тесты создают `emb_repo = AsyncMock()` **без spec** — значит `.keyword_search` авто-стабится в `MagicMock`, но попытка итерации в RRF приведёт к TypeError. Решение: **патчить моки** в затронутых файлах.
+
+---
+
+## Архитектура
+
+```mermaid
+flowchart LR
+  Q[Query] --> S["retrieval_service.search mode"]
+  S -->|semantic| Sim[emb_repo.similarity_search]
+  S -->|keyword| KW["emb_repo.keyword_search FTS"]
+  S -->|hybrid| Both["asyncio.gather sim+kw"]
+  Both --> RRF["_ranking.rrf_fuse"]
+  Sim --> Build[build SearchResults]
+  KW --> Build
+  RRF --> Build
+```
+
+---
+
+## Коммит 1 — FTS слой (миграции + repo + RRF)
+
+### 1.1 Миграции и DDL
+
+**Новая миграция** `migrations/versions/processing/20260417_add_fts_to_processed_documents.py`
+- `revision="d4e5f6a7b8c9"`, `down_revision="c3d4e5f6a7b8"`.
+- `upgrade()`:
+  - Проверка через `sa.inspect(conn).get_columns("processed_documents")`; если `search_vector` отсутствует — `ALTER TABLE processed_documents ADD COLUMN search_vector tsvector GENERATED ALWAYS AS (setweight(to_tsvector('simple', coalesce(summary, '')), 'A') || setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') || setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')) STORED`.
+  - `CREATE INDEX IF NOT EXISTS idx_pd_search_vector ON processed_documents USING GIN(search_vector)`.
+- `downgrade()`: `DROP INDEX` + `DROP COLUMN`.
+
+**Новая миграция** `migrations/versions/processing/20260417_add_fts_to_topic_cards.py`
+- `revision="e5f6a7b8c9d0"`, `down_revision="d4e5f6a7b8c9"`.
+- `upgrade()` аналогично для `topic_cards`:
+  - `search_vector` = `setweight(to_tsvector('simple', coalesce(title, '')), 'A') || setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') || setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')`.
+  - `CREATE INDEX IF NOT EXISTS idx_tc_search_vector ON topic_cards USING GIN(search_vector)`.
+- `downgrade()`: drop index + column.
+
+**Правки** [`tg_parser/storage/sqlalchemy/schemas/processing_storage.py`](../../tg_parser/storage/sqlalchemy/schemas/processing_storage.py):
+- В `PROCESSING_STORAGE_DDL` добавить `search_vector tsvector GENERATED ...STORED` прямо в `CREATE TABLE processed_documents (...)` и `CREATE TABLE topic_cards (...)` — для fresh DB без ALTER.
+- Добавить `CREATE INDEX IF NOT EXISTS idx_pd_search_vector ...` и `idx_tc_search_vector ...` в DDL.
+- Новая функция `_ensure_fts_columns(engine: AsyncEngine) -> None` по паттерну `_ensure_embedding_columns` (272–314): idempotent ALTER + CREATE INDEX IF NOT EXISTS. Ловит `ProgrammingError`/`OperationalError` (для SQLite/тестовых БД без pgvector).
+- В `init_processing_storage_schema()` вызвать `await _ensure_fts_columns(engine)` после `await _ensure_embedding_columns(engine)`.
+
+> **Предупреждение (для release notes и USER_GUIDE):** `ADD COLUMN ... GENERATED ... STORED` делает **table rewrite**. На prod-инсталляциях > 1M строк применять в maintenance window.
+
+### 1.2 Repo: `keyword_search`
+
+**ABC** [`tg_parser/storage/ports.py`](../../tg_parser/storage/ports.py) — добавить после `similarity_search` (~855):
+
+```python
+@abstractmethod
+async def keyword_search(
+    self,
+    query: str,
+    limit: int = 10,
+    entry_types: list[str] | None = None,
+    channel_ids: list[str] | None = None,
+    min_rank: float = 0.0,
+) -> list[SimilarityResult]:
+    """FTS search (ts_rank_cd) across processed_documents and topic_cards (UNION ALL).
+
+    Args:
+        query: Natural-language query; tokenized via plainto_tsquery('simple', ...).
+        limit: Max rows fetched from the UNION result (before Python-side filtering).
+        entry_types: Optional post-fetch Python filter by entry_type.
+        channel_ids: SQL filter for processed_documents.channel_id; topic_cards channel
+                     filtering happens downstream in retrieval_service via card.sources.
+        min_rank: Python-side ts_rank_cd cutoff.
+    """
+    ...
+```
+
+**Реализация** в [`tg_parser/storage/sqlalchemy/embedding_repo.py`](../../tg_parser/storage/sqlalchemy/embedding_repo.py):
+
+```sql
+WITH q AS (SELECT plainto_tsquery('simple', :query) AS tsq)
+SELECT source_ref,
+       ts_rank_cd(search_vector, q.tsq) AS score,
+       'message' AS entry_type,
+       NULL::text AS topic_id
+FROM processed_documents, q
+WHERE search_vector @@ q.tsq
+  AND (:channel_ids IS NULL OR channel_id = ANY(CAST(:channel_ids AS text[])))
+UNION ALL
+SELECT id AS source_ref,
+       ts_rank_cd(search_vector, q.tsq) AS score,
+       'topic' AS entry_type,
+       id AS topic_id
+FROM topic_cards, q
+WHERE search_vector @@ q.tsq
+ORDER BY score DESC
+LIMIT :limit
+```
+
+- Python-side: применить `entry_types` фильтр и `min_rank` cutoff перед возвратом.
+- Возврат `list[SimilarityResult]`.
+
+### 1.3 Pure RRF модуль
+
+Новый файл [`tg_parser/services/_ranking.py`](../../tg_parser/services/_ranking.py):
+
+```python
+from collections.abc import Sequence
+from tg_parser.storage.ports import SimilarityResult
+
+
+def rrf_fuse(
+    *lists: Sequence[SimilarityResult],
+    k: int = 60,
+) -> list[SimilarityResult]:
+    """Reciprocal Rank Fusion.
+
+    - Rank = 1-indexed позиция в исходном (отсортированном) списке.
+    - Дубликаты по source_ref агрегируются: RRF score суммируется по всем спискам.
+    - Возвращаемый `score` — RRF score (не original cosine/ts_rank).
+    - `entry_type` и `topic_id` берутся из первого встреченного.
+    - Пустой список одного из источников — не крашит; fusion возвращает оставшиеся.
+    """
+```
+
+### 1.4 Тесты коммита 1
+
+Новый файл `tests/test_f5a_hybrid_search.py`:
+
+- **`TestRRFFusion`** (~10): одинаковый doc в обоих списках; пустой список; разные `k`; дубликаты агрегируются; стабильность сортировки; только semantic; только keyword; `entry_type`/`topic_id` preserved.
+- **`TestKeywordSearchRepo`** (pg+pgvector, skip-marker `SKIP_PGVECTOR_TESTS` по паттерну `test_f4_embedding_channel_ids.py`) ~6: FTS по `processed_documents`; FTS по `topic_cards`; UNION возвращает оба типа; `channel_id` filter; `min_rank` cutoff; ru+en запросы на смешанном корпусе.
+- **`TestMigrationIdempotency`** (pg) ~2: повторный `_ensure_fts_columns` не падает; индексы существуют.
+
+### Коммит 1 message
+
+```
+feat(f5a-phase1): add FTS migrations, keyword_search repo, and rrf_fuse module
+```
+
+---
+
+## Коммит 2 — Service + API + Wiring
+
+### 2.1 Settings
+
+В [`tg_parser/config/settings.py`](../../tg_parser/config/settings.py) после `embedding_dimension` (~470):
+
+```python
+hybrid_enabled: bool = Field(default=True, description="Enable hybrid (keyword+semantic) retrieval")
+hybrid_rrf_k: int = Field(default=60, description="RRF constant; higher = less discrimination", ge=1)
+fts_languages: str = Field(default="russian,english", description="Informational: FTS languages baked into search_vector DDL")
+```
+
+Обновить `.env.example`.
+
+### 2.2 Service: `mode` + RRF fusion
+
+В [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py):
+
+- Расширить сигнатуру `search()` (строка 45):
+
+```python
+from typing import Literal
+# ... в параметрах search():
+mode: Literal["semantic", "keyword", "hybrid"] = "hybrid",
+```
+
+- Заменить прямой вызов `similarity_search` (строки 110–116) на ветвление:
+
+```python
+effective_mode = mode
+if effective_mode == "hybrid" and not settings.hybrid_enabled:
+    effective_mode = "semantic"
+
+if effective_mode == "semantic":
+    similar = await emb_repo.similarity_search(query_vec, limit=limit * 2 if channel_id else limit, ...)
+elif effective_mode == "keyword":
+    similar = await emb_repo.keyword_search(query, limit=limit * 2 if channel_id else limit, ...)
+else:  # hybrid
+    import asyncio
+    sem_task = emb_repo.similarity_search(query_vec, limit=limit * 2, ...)
+    kw_task = emb_repo.keyword_search(query, limit=limit * 2, ...)
+    sem, kw = await asyncio.gather(sem_task, kw_task)
+    from tg_parser.services._ranking import rrf_fuse
+    similar = rrf_fuse(sem, kw, k=settings.hybrid_rrf_k)[: (limit * 2 if channel_id else limit)]
+```
+
+- Расширить `answer()` параметром `mode: Literal[...] = "hybrid"` и пробросить в `search(...)`.
+- `_build_context` не трогаем.
+
+### 2.3 API wiring
+
+[`tg_parser/api/routes/rag.py`](../../tg_parser/api/routes/rag.py):
+
+- В `SearchRequest` и `AskRequest` добавить:
+
+```python
+mode: Literal["semantic", "keyword", "hybrid"] = Field(default="hybrid", description="Retrieval mode")
+```
+
+- Пробросить `mode=body.mode` в вызовы `search(...)` (строка 76) и `answer(...)` (строка 105).
+
+**Не меняем в Phase 1:**
+- MCP tools [`tg_parser/mcp_server.py`](../../tg_parser/mcp_server.py) — дефолт hybrid неявно.
+- Bot tools [`tg_parser/bot/tools.py`](../../tg_parser/bot/tools.py).
+- CLI [`tg_parser/cli/app.py`](../../tg_parser/cli/app.py).
+
+### 2.4 Патч существующих моков
+
+Стратегия: **добавить `mock_emb_repo.keyword_search = AsyncMock(return_value=[])`** в тесты, которые используют `AsyncMock()` без spec.
+
+Затронутые файлы:
+- [`tests/test_f4_scoped_access.py`](../../tests/test_f4_scoped_access.py) — 2 места (строки 46, 71).
+- [`tests/test_f4_coverage_supplement.py`](../../tests/test_f4_coverage_supplement.py) — 2 места (строки 444, 488).
+- [`tests/test_f5a_topic_rag.py`](../../tests/test_f5a_topic_rag.py) — ~8 мест (436, 483, 511, 994, 1028, 1052, 1078 и др.).
+- [`tests/test_f4_vector_search_isolation.py`](../../tests/test_f4_vector_search_isolation.py) — при необходимости.
+
+### 2.5 Тесты коммита 2
+
+В `tests/test_f5a_hybrid_search.py`:
+
+- **`TestSearchModeSwitch`** (~6): `mode="semantic"` не вызывает `keyword_search`; `mode="keyword"` не вызывает `similarity_search`; `mode="hybrid"` вызывает оба через `asyncio.gather`; `hybrid_enabled=False` + `mode="hybrid"` → fallback semantic; неверный `mode` → Pydantic ValidationError на уровне API.
+- **`TestHybridIntegration`** (pg+pgvector, ~4): hybrid без дубликатов; редкий термин доминирует через keyword; семантический запрос без exact match; пустой корпус.
+- **`TestSettings`** (~3): `hybrid_enabled`, `hybrid_rrf_k`, `fts_languages` из env; дефолты.
+
+### 2.6 Документация
+
+- [`docs/USER_GUIDE.md`](../../docs/USER_GUIDE.md) — новая секция "Hybrid Search" (режимы, env vars, multilingual, table-rewrite warning).
+- [`docs/MCP_AGENT_GUIDE.md`](../../docs/MCP_AGENT_GUIDE.md) — заметка: `search_knowledge_base` теперь hybrid по умолчанию.
+- [`ENV_VARIABLES_GUIDE.md`](../../ENV_VARIABLES_GUIDE.md) — `HYBRID_ENABLED`, `HYBRID_RRF_K`, `FTS_LANGUAGES`.
+- [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](F5A_PERSISTENT_KB_PLAN.md) — пометить "Phase 1: DONE" со ссылкой на коммиты.
+
+### Коммит 2 message
+
+```
+feat(f5a-phase1): wire hybrid mode with RRF fusion in retrieval_service and API
+```
+
+---
+
+## Порядок работы
+
+1. Ветка `feat/f5a-phase1-hybrid-search` от актуального `main`.
+2. **Коммит 1** (TDD: сначала `rrf_fuse` + unit-тесты, затем миграции + DDL, затем `keyword_search` + pg-тесты).
+3. `.venv/bin/pytest tests/test_f5a_hybrid_search.py::TestRRFFusion -x -q`
+4. `TEST_POSTGRES=1 .venv/bin/pytest tests/test_f5a_hybrid_search.py::TestKeywordSearchRepo tests/test_f5a_hybrid_search.py::TestMigrationIdempotency -x -q`
+5. **Коммит 2** (settings → service → API → моки → integration тесты → доки).
+6. Финальный regression: `TEST_POSTGRES=1 .venv/bin/pytest tests/ -x -q` — ожидаемо ~1362 теста (1331 + ~31).
+
+---
+
+## Критерии готовности
+
+1. Обе FTS-миграции применяются идемпотентно на fresh и existing БД.
+2. GIN-индексы `idx_pd_search_vector` и `idx_tc_search_vector` созданы.
+3. `SAEmbeddingRepo.keyword_search()` возвращает `list[SimilarityResult]` с `ts_rank_cd` score.
+4. `EmbeddingRepo` ABC содержит abstract `keyword_search`.
+5. `retrieval_service.search(mode=...)` и `answer(mode=...)` поддерживают `"semantic" | "keyword" | "hybrid"`; дефолт `hybrid`.
+6. [`tg_parser/services/_ranking.py`](../../tg_parser/services/_ranking.py) содержит `rrf_fuse()` + ≥10 unit-тестов.
+7. Settings `hybrid_enabled`, `hybrid_rrf_k`, `fts_languages` читаются; `hybrid_enabled=False` отключает keyword path.
+8. `POST /api/v1/search` и `/ask` принимают опциональный `mode` (Pydantic Literal validation).
+9. `tests/test_f5a_hybrid_search.py` ~31 тест; все проходят.
+10. Существующие тесты проходят с минимальным добавлением `keyword_search` stub в 3–4 файлах.
+11. Документация обновлена.
+12. Два коммита с message выше.
+
+---
+
+## Что НЕ входит в scope Phase 1
+
+- Relevance tuning / topic quotas / min_score cutoff в hybrid — Phase 2.
+- Topic-weighted RAG context — Phase 2.
+- Deduplication (content hash, near-duplicate) — Phase 3.
+- Cross-encoder / LLM re-ranking — вне F5-A.
+- Linear fusion (alpha-weighted) — не добавляем.
+- GIN по `topic_cards.channel_ids` для SQL-level tenancy — Phase 2/3.
+- Автодетекция языка запроса — универсальный `plainto_tsquery('simple', ...)`.
+- Добавление `mode` в MCP tools / bot tools / CLI — Phase 2.
+- Rename `SAEmbeddingRepo` — не трогаем.

--- a/docs/prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md
+++ b/docs/prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,246 @@
+# F5-A Phase 1 Implementation — Стартовый промпт
+
+**Версия проекта:** 4.4.0+ (post F8-A Hardening, коммит `8012021`)
+**Ветка:** `feat/f5a-phase1-hybrid-search` (создать от `main`)
+**План реализации:** [`docs/plans/F5A_PHASE1_IMPLEMENTATION_PLAN.md`](../plans/F5A_PHASE1_IMPLEMENTATION_PLAN.md) — **читать первым**
+**Design-doc:** [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](../plans/F5A_PERSISTENT_KB_PLAN.md)
+**Исходный промпт:** [`F5A_PHASE1_HYBRID_SEARCH_PROMPT.md`](F5A_PHASE1_HYBRID_SEARCH_PROMPT.md)
+
+---
+
+## Цель
+
+Добавить hybrid search (keyword FTS + semantic pgvector) в retrieval pipeline. Дефолтный режим `retrieval_service.search()` становится `"hybrid"` — объединение через Reciprocal Rank Fusion (RRF). Мультиязычная FTS (`russian + english`) через generated `tsvector` колонку.
+
+---
+
+## Коротко об архитектуре
+
+```
+query → retrieval_service.search(mode)
+         ├── semantic → emb_repo.similarity_search (pgvector cosine)
+         ├── keyword  → emb_repo.keyword_search (FTS, ts_rank_cd)
+         └── hybrid   → asyncio.gather(both) → _ranking.rrf_fuse → top-N
+```
+
+Новая pure-function `rrf_fuse(*lists, k=60)` в `tg_parser/services/_ranking.py`: 1-indexed rank, дубликаты по `source_ref` агрегируются.
+
+---
+
+## Ключевые уточнения (после разведки)
+
+- Класс repo — **`SAEmbeddingRepo`** (не `SAmbeddingRepo` как в оригинальном промпте).
+- `EmbeddingRepo` ABC в [`tg_parser/storage/ports.py`](../../tg_parser/storage/ports.py) строки 815–870.
+- Текущая `search()` — [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) строка 45.
+- Alembic head: `c3d4e5f6a7b8` → новые ревизии `d4e5f6a7b8c9` (processed_documents) → `e5f6a7b8c9d0` (topic_cards).
+- Существующие тесты используют `AsyncMock()` без spec → нужно добавить `mock_emb_repo.keyword_search = AsyncMock(return_value=[])` в:
+  - [`tests/test_f4_scoped_access.py`](../../tests/test_f4_scoped_access.py)
+  - [`tests/test_f4_coverage_supplement.py`](../../tests/test_f4_coverage_supplement.py)
+  - [`tests/test_f5a_topic_rag.py`](../../tests/test_f5a_topic_rag.py)
+  - [`tests/test_f4_vector_search_isolation.py`](../../tests/test_f4_vector_search_isolation.py) (если применимо)
+
+---
+
+## Структура работы (2 коммита)
+
+### Коммит 1 — FTS слой
+
+**Файлы:**
+- `migrations/versions/processing/20260417_add_fts_to_processed_documents.py` (new)
+- `migrations/versions/processing/20260417_add_fts_to_topic_cards.py` (new)
+- [`tg_parser/storage/sqlalchemy/schemas/processing_storage.py`](../../tg_parser/storage/sqlalchemy/schemas/processing_storage.py) — DDL + новая `_ensure_fts_columns()`
+- [`tg_parser/storage/ports.py`](../../tg_parser/storage/ports.py) — abstract `keyword_search`
+- [`tg_parser/storage/sqlalchemy/embedding_repo.py`](../../tg_parser/storage/sqlalchemy/embedding_repo.py) — реализация `keyword_search`
+- `tg_parser/services/_ranking.py` (new) — pure `rrf_fuse`
+- `tests/test_f5a_hybrid_search.py` (new) — классы `TestRRFFusion`, `TestKeywordSearchRepo`, `TestMigrationIdempotency`
+
+**Commit message:**
+```
+feat(f5a-phase1): add FTS migrations, keyword_search repo, and rrf_fuse module
+```
+
+### Коммит 2 — Service + API + wiring
+
+**Файлы:**
+- [`tg_parser/config/settings.py`](../../tg_parser/config/settings.py) — `hybrid_enabled`, `hybrid_rrf_k`, `fts_languages`.
+- `.env.example` — новые переменные.
+- [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) — параметр `mode: Literal[...]` в `search()` и `answer()`, RRF wiring.
+- [`tg_parser/api/routes/rag.py`](../../tg_parser/api/routes/rag.py) — `mode` в `SearchRequest`/`AskRequest`.
+- Патч моков в существующих тестах (см. выше).
+- `tests/test_f5a_hybrid_search.py` — классы `TestSearchModeSwitch`, `TestHybridIntegration`, `TestSettings`.
+- Doc updates: [`docs/USER_GUIDE.md`](../../docs/USER_GUIDE.md), [`docs/MCP_AGENT_GUIDE.md`](../../docs/MCP_AGENT_GUIDE.md), [`ENV_VARIABLES_GUIDE.md`](../../ENV_VARIABLES_GUIDE.md), [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](../plans/F5A_PERSISTENT_KB_PLAN.md) (Phase 1: DONE).
+
+**Commit message:**
+```
+feat(f5a-phase1): wire hybrid mode with RRF fusion in retrieval_service and API
+```
+
+---
+
+## DDL шпаргалка
+
+**`processed_documents.search_vector`:**
+```sql
+tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') ||
+  setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') ||
+  setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')
+) STORED
+```
+
+**`topic_cards.search_vector`:**
+```sql
+tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('simple',  coalesce(title, '')), 'A') ||
+  setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') ||
+  setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')
+) STORED
+```
+
+**Индексы:** `idx_pd_search_vector`, `idx_tc_search_vector` (GIN).
+
+> Table rewrite на ALTER! Для prod > 1M строк — применять в maintenance window. Упомянуть в USER_GUIDE.
+
+---
+
+## SQL для `keyword_search`
+
+```sql
+WITH q AS (SELECT plainto_tsquery('simple', :query) AS tsq)
+SELECT source_ref, ts_rank_cd(search_vector, q.tsq) AS score,
+       'message' AS entry_type, NULL::text AS topic_id
+FROM processed_documents, q
+WHERE search_vector @@ q.tsq
+  AND (:channel_ids IS NULL OR channel_id = ANY(CAST(:channel_ids AS text[])))
+UNION ALL
+SELECT id AS source_ref, ts_rank_cd(search_vector, q.tsq) AS score,
+       'topic' AS entry_type, id AS topic_id
+FROM topic_cards, q
+WHERE search_vector @@ q.tsq
+ORDER BY score DESC
+LIMIT :limit
+```
+
+- `entry_types` фильтр и `min_rank` cutoff — Python-side.
+- Channel filter для `topic_cards` — не в этом запросе; downstream в `retrieval_service` через `card.sources`.
+
+---
+
+## Service: сигнатура `search()`
+
+```python
+from typing import Literal
+
+async def search(
+    query: str,
+    channel_id: str | None = None,
+    limit: int = 10,
+    threshold: float = 0.0,
+    include_topics: bool = True,
+    allowed_channel_ids: list[str] | None = None,
+    mode: Literal["semantic", "keyword", "hybrid"] = "hybrid",  # NEW
+    *,
+    emb_repo: EmbeddingRepo | None = None,
+    proc_repo: ProcessedDocumentRepo | None = None,
+    topic_card_repo: TopicCardRepo | None = None,
+) -> list[SearchResult]:
+    ...
+```
+
+Логика ветвления:
+```python
+effective_mode = mode
+if effective_mode == "hybrid" and not settings.hybrid_enabled:
+    effective_mode = "semantic"
+
+if effective_mode == "semantic":
+    similar = await emb_repo.similarity_search(query_vec, ...)
+elif effective_mode == "keyword":
+    similar = await emb_repo.keyword_search(query, ...)
+else:  # hybrid
+    sem, kw = await asyncio.gather(
+        emb_repo.similarity_search(query_vec, limit=limit * 2, ...),
+        emb_repo.keyword_search(query, limit=limit * 2, ...),
+    )
+    similar = rrf_fuse(sem, kw, k=settings.hybrid_rrf_k)[:limit]
+```
+
+`answer()` принимает `mode` и пробрасывает в `search`.
+
+---
+
+## Settings
+
+```python
+hybrid_enabled: bool = Field(default=True, description="Enable hybrid (keyword+semantic) retrieval")
+hybrid_rrf_k: int = Field(default=60, description="RRF constant; higher = less discrimination", ge=1)
+fts_languages: str = Field(default="russian,english", description="Informational: FTS languages baked into search_vector DDL")
+```
+
+---
+
+## Тесты
+
+Новый файл `tests/test_f5a_hybrid_search.py` по образцу [`tests/test_f8a_hardening.py`](../../tests/test_f8a_hardening.py):
+
+| Класс | Кейсов | Requires pg? |
+|---|---|---|
+| `TestRRFFusion` | ~10 | no |
+| `TestKeywordSearchRepo` | ~6 | yes (`SKIP_PGVECTOR_TESTS`) |
+| `TestMigrationIdempotency` | ~2 | yes |
+| `TestSearchModeSwitch` | ~6 | no |
+| `TestHybridIntegration` | ~4 | yes |
+| `TestSettings` | ~3 | no |
+
+**Запуск:**
+```bash
+# Unit only
+.venv/bin/pytest tests/test_f5a_hybrid_search.py -x -q
+
+# С Postgres + pgvector
+TEST_POSTGRES=1 .venv/bin/pytest tests/test_f5a_hybrid_search.py -x -q
+
+# Полный regression
+TEST_POSTGRES=1 .venv/bin/pytest tests/ -x -q
+```
+
+**Ожидаемо:** 1331 → ~1362 тестов.
+
+---
+
+## Критерии готовности
+
+1. Обе FTS-миграции применяются идемпотентно (fresh + existing БД).
+2. GIN-индексы `idx_pd_search_vector`, `idx_tc_search_vector` созданы.
+3. `SAEmbeddingRepo.keyword_search()` работает, возвращает `list[SimilarityResult]` с `ts_rank_cd`.
+4. `EmbeddingRepo` ABC содержит abstract `keyword_search`.
+5. `search(mode=...)` и `answer(mode=...)` поддерживают 3 режима; дефолт `hybrid`.
+6. `tg_parser/services/_ranking.py` содержит `rrf_fuse` + ≥10 unit-тестов.
+7. Settings читаются из env; `hybrid_enabled=False` отключает keyword path в hybrid.
+8. `POST /api/v1/search` и `/ask` принимают опциональный `mode` (Pydantic Literal validation).
+9. ~31 новый тест; все проходят.
+10. Существующие тесты проходят с минимальным добавлением `keyword_search` stub.
+11. Документация обновлена (USER_GUIDE, MCP_AGENT_GUIDE, ENV_VARIABLES_GUIDE, F5A_PERSISTENT_KB_PLAN).
+12. Два коммита с указанными messages.
+
+---
+
+## Что НЕ входит в scope
+
+- Relevance tuning, topic quotas, topic-weighted context — Phase 2.
+- Dedup — Phase 3.
+- Re-ranking (cross-encoder / LLM) — вне F5-A.
+- `mode` в MCP tools / bot tools / CLI — Phase 2.
+- Linear fusion как альтернатива RRF.
+- GIN по `topic_cards.channel_ids` — Phase 2/3.
+
+---
+
+## Рекомендации исполнения
+
+1. **Начать с Plan mode** → сверка плана с актуальным `main`, не появилось ли расхождений.
+2. **TDD для `rrf_fuse`** — pure function, 10+ кейсов, пишутся и гоняются без БД.
+3. **Миграции вторыми** — без `search_vector` integration-тесты keyword_search не пройдут.
+4. **Skip-marker для pg-тестов** — использовать `SKIP_PGVECTOR_TESTS` по паттерну `tests/test_f4_embedding_channel_ids.py`.
+5. **Идемпотентность `_ensure_fts_columns`** протестировать явно (двойной вызов не падает).
+6. **Release notes** — про table-rewrite при ALTER GENERATED STORED на больших таблицах.

--- a/migrations/versions/processing/20260417_add_fts_to_processed_documents.py
+++ b/migrations/versions/processing/20260417_add_fts_to_processed_documents.py
@@ -1,0 +1,54 @@
+"""add FTS search_vector + GIN index to processed_documents
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-17
+
+F5-A Phase 1: Hybrid search (FTS + pgvector).  Adds a STORED
+tsvector column over (summary A / text_clean B) using simple + russian +
+english text-search configurations, plus a GIN index for fast @@ lookups.
+
+WARNING: ``ADD COLUMN ... GENERATED ... STORED`` triggers a table rewrite
+on PostgreSQL.  For production databases > 1M rows apply during a
+maintenance window.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    inspector = sa.inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("processed_documents")]
+
+    if "search_vector" not in columns:
+        conn.execute(sa.text(
+            "ALTER TABLE processed_documents ADD COLUMN search_vector tsvector "
+            "GENERATED ALWAYS AS ("
+            "setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') || "
+            "setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') || "
+            "setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')"
+            ") STORED"
+        ))
+
+    conn.execute(sa.text(
+        "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
+        "ON processed_documents USING GIN(search_vector)"
+    ))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_pd_search_vector"))
+    conn.execute(sa.text(
+        "ALTER TABLE processed_documents DROP COLUMN IF EXISTS search_vector"
+    ))

--- a/migrations/versions/processing/20260417_add_fts_to_processed_documents.py
+++ b/migrations/versions/processing/20260417_add_fts_to_processed_documents.py
@@ -12,16 +12,16 @@ WARNING: ``ADD COLUMN ... GENERATED ... STORED`` triggers a table rewrite
 on PostgreSQL.  For production databases > 1M rows apply during a
 maintenance window.
 """
-from typing import Sequence, Union
+
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
-
 revision: str = "d4e5f6a7b8c9"
-down_revision: Union[str, None] = "c3d4e5f6a7b8"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "c3d4e5f6a7b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -31,24 +31,26 @@ def upgrade() -> None:
     columns = [c["name"] for c in inspector.get_columns("processed_documents")]
 
     if "search_vector" not in columns:
-        conn.execute(sa.text(
-            "ALTER TABLE processed_documents ADD COLUMN search_vector tsvector "
-            "GENERATED ALWAYS AS ("
-            "setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') || "
-            "setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') || "
-            "setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')"
-            ") STORED"
-        ))
+        conn.execute(
+            sa.text(
+                "ALTER TABLE processed_documents ADD COLUMN search_vector tsvector "
+                "GENERATED ALWAYS AS ("
+                "setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') || "
+                "setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') || "
+                "setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')"
+                ") STORED"
+            )
+        )
 
-    conn.execute(sa.text(
-        "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
-        "ON processed_documents USING GIN(search_vector)"
-    ))
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
+            "ON processed_documents USING GIN(search_vector)"
+        )
+    )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
     conn.execute(sa.text("DROP INDEX IF EXISTS idx_pd_search_vector"))
-    conn.execute(sa.text(
-        "ALTER TABLE processed_documents DROP COLUMN IF EXISTS search_vector"
-    ))
+    conn.execute(sa.text("ALTER TABLE processed_documents DROP COLUMN IF EXISTS search_vector"))

--- a/migrations/versions/processing/20260417_add_fts_to_topic_cards.py
+++ b/migrations/versions/processing/20260417_add_fts_to_topic_cards.py
@@ -13,16 +13,16 @@ WARNING: ``ADD COLUMN ... GENERATED ... STORED`` triggers a table rewrite
 on PostgreSQL.  For production databases > 1M rows apply during a
 maintenance window.
 """
-from typing import Sequence, Union
+
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
-
 revision: str = "e5f6a7b8c9d0"
-down_revision: Union[str, None] = "d4e5f6a7b8c9"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "d4e5f6a7b8c9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -32,24 +32,26 @@ def upgrade() -> None:
     columns = [c["name"] for c in inspector.get_columns("topic_cards")]
 
     if "search_vector" not in columns:
-        conn.execute(sa.text(
-            "ALTER TABLE topic_cards ADD COLUMN search_vector tsvector "
-            "GENERATED ALWAYS AS ("
-            "setweight(to_tsvector('simple',  coalesce(title, '')), 'A') || "
-            "setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') || "
-            "setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')"
-            ") STORED"
-        ))
+        conn.execute(
+            sa.text(
+                "ALTER TABLE topic_cards ADD COLUMN search_vector tsvector "
+                "GENERATED ALWAYS AS ("
+                "setweight(to_tsvector('simple',  coalesce(title, '')), 'A') || "
+                "setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') || "
+                "setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')"
+                ") STORED"
+            )
+        )
 
-    conn.execute(sa.text(
-        "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
-        "ON topic_cards USING GIN(search_vector)"
-    ))
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
+            "ON topic_cards USING GIN(search_vector)"
+        )
+    )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
     conn.execute(sa.text("DROP INDEX IF EXISTS idx_tc_search_vector"))
-    conn.execute(sa.text(
-        "ALTER TABLE topic_cards DROP COLUMN IF EXISTS search_vector"
-    ))
+    conn.execute(sa.text("ALTER TABLE topic_cards DROP COLUMN IF EXISTS search_vector"))

--- a/migrations/versions/processing/20260417_add_fts_to_topic_cards.py
+++ b/migrations/versions/processing/20260417_add_fts_to_topic_cards.py
@@ -1,0 +1,55 @@
+"""add FTS search_vector + GIN index to topic_cards
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-04-17
+
+F5-A Phase 1: Hybrid search (FTS + pgvector).  Adds a STORED
+tsvector column over (title A / summary + scope_in_json B) using
+simple + russian + english text-search configurations, plus a GIN
+index for fast @@ lookups.
+
+WARNING: ``ADD COLUMN ... GENERATED ... STORED`` triggers a table rewrite
+on PostgreSQL.  For production databases > 1M rows apply during a
+maintenance window.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    inspector = sa.inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("topic_cards")]
+
+    if "search_vector" not in columns:
+        conn.execute(sa.text(
+            "ALTER TABLE topic_cards ADD COLUMN search_vector tsvector "
+            "GENERATED ALWAYS AS ("
+            "setweight(to_tsvector('simple',  coalesce(title, '')), 'A') || "
+            "setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') || "
+            "setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')"
+            ") STORED"
+        ))
+
+    conn.execute(sa.text(
+        "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
+        "ON topic_cards USING GIN(search_vector)"
+    ))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_tc_search_vector"))
+    conn.execute(sa.text(
+        "ALTER TABLE topic_cards DROP COLUMN IF EXISTS search_vector"
+    ))

--- a/tests/test_f4_coverage_supplement.py
+++ b/tests/test_f4_coverage_supplement.py
@@ -477,6 +477,7 @@ class TestSearchEdgeCases:
         """allowed_channel_ids=None + channel_id='ch1' → channel_ids=['ch1']."""
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
 
         from tg_parser.services.retrieval_service import search
@@ -530,6 +531,7 @@ class TestSearchEdgeCases:
         )
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = [sim]
+        mock_emb_repo.keyword_search.return_value = []
 
         mock_tc_repo = AsyncMock()
         mock_tc_repo.get_by_id.return_value = card

--- a/tests/test_f4_scoped_access.py
+++ b/tests/test_f4_scoped_access.py
@@ -54,6 +54,7 @@ class TestSearchScoping:
         """channel_id + allowed intersection should not raise."""
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
         mock_proc_repo.get_by_source_refs.return_value = {}
 
@@ -80,6 +81,7 @@ class TestSearchScoping:
     async def test_admin_no_filter(self):
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
 
         from tg_parser.services.retrieval_service import search

--- a/tests/test_f4_vector_search_isolation.py
+++ b/tests/test_f4_vector_search_isolation.py
@@ -43,6 +43,7 @@ class TestSimilaritySearchChannelFilter:
         """Verify that channel_ids parameter is forwarded to similarity_search."""
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
 
         from tg_parser.services.retrieval_service import search
@@ -72,6 +73,7 @@ class TestSimilaritySearchChannelFilter:
     async def test_none_channel_ids_no_filter(self):
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
 
         from tg_parser.services.retrieval_service import search
@@ -102,6 +104,7 @@ class TestChannelIdIntersection:
     async def test_single_channel_in_allowed(self):
         mock_emb_repo = AsyncMock()
         mock_emb_repo.similarity_search.return_value = []
+        mock_emb_repo.keyword_search.return_value = []
         mock_proc_repo = AsyncMock()
 
         from tg_parser.services.retrieval_service import search
@@ -206,6 +209,7 @@ class TestCrossChannelTopicEmbedding:
             topic_id="t-cross",
         )
         mock_emb_repo.similarity_search.return_value = [sim_result]
+        mock_emb_repo.keyword_search.return_value = []
 
         anchor1 = Anchor(
             channel_id="ch1",
@@ -271,6 +275,7 @@ class TestCrossChannelTopicEmbedding:
             topic_id="t-hidden",
         )
         mock_emb_repo.similarity_search.return_value = [sim_result]
+        mock_emb_repo.keyword_search.return_value = []
 
         anchor = Anchor(
             channel_id="ch3",

--- a/tests/test_f5a_hybrid_search.py
+++ b/tests/test_f5a_hybrid_search.py
@@ -1,13 +1,17 @@
 """
 Tests for F5-A Phase 1: Hybrid Search (FTS + pgvector + RRF).
 
-Commit 1 coverage:
+Structure:
 - TestRRFFusion           : pure unit tests for rrf_fuse (no DB).
 - TestKeywordSearchRepo   : SAEmbeddingRepo.keyword_search against live Postgres.
 - TestMigrationIdempotency: _ensure_fts_columns and GIN-index idempotency.
+- TestSearchModeSwitch    : retrieval_service.search(mode=...) branching (mocked repo).
+- TestHybridIntegration   : end-to-end hybrid path against live Postgres.
+- TestSettings            : env-var driven hybrid_enabled / hybrid_rrf_k / fts_languages.
 """
 
 import os
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -318,3 +322,242 @@ class TestMigrationIdempotency:
         assert "idx_pd_search_vector" in names
         assert "idx_tc_search_vector" in names
 
+# ---------------------------------------------------------------------------
+# 4. TestSearchModeSwitch — retrieval_service.search(mode=...) branching
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbClient:
+    async def embed(self, texts):
+        return [[0.1] * 1536 for _ in texts]
+
+    async def close(self):
+        return None
+
+
+@pytest.fixture
+def patch_embedding_client(monkeypatch):
+    def _factory():
+        return _FakeEmbClient()
+    monkeypatch.setattr(
+        "tg_parser.services.retrieval_service.create_embedding_client",
+        _factory,
+    )
+
+
+class TestSearchModeSwitch:
+    async def test_semantic_mode_does_not_call_keyword(self, patch_embedding_client):
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "query", mode="semantic",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.called
+        assert not emb_repo.keyword_search.called
+
+    async def test_keyword_mode_does_not_call_semantic(self, patch_embedding_client):
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "query", mode="keyword",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.keyword_search.called
+        assert not emb_repo.similarity_search.called
+
+    async def test_hybrid_mode_calls_both(self, patch_embedding_client):
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[
+            SimilarityResult(source_ref="a", score=0.9, entry_type="message"),
+        ])
+        emb_repo.keyword_search = AsyncMock(return_value=[
+            SimilarityResult(source_ref="b", score=0.5, entry_type="message"),
+        ])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        results = await search(
+            "query", mode="hybrid",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.called
+        assert emb_repo.keyword_search.called
+        refs = {r.source_ref for r in results}
+        assert refs == {"a", "b"}
+
+    async def test_hybrid_falls_back_to_semantic_when_disabled(self, patch_embedding_client, monkeypatch):
+        from tg_parser.services import retrieval_service
+        from tg_parser.services.retrieval_service import search
+
+        monkeypatch.setattr(retrieval_service.settings, "hybrid_enabled", False)
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "query", mode="hybrid",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.called
+        assert not emb_repo.keyword_search.called
+
+    async def test_default_mode_is_hybrid(self, patch_embedding_client):
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "query",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.called
+        assert emb_repo.keyword_search.called
+
+    async def test_api_rejects_invalid_mode(self):
+        from pydantic import ValidationError
+
+        from tg_parser.api.routes.rag import SearchRequest
+
+        with pytest.raises(ValidationError):
+            SearchRequest(query="hello", mode="fuzzy")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 5. TestHybridIntegration — live Postgres
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(_SKIP_PG, reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)")
+class TestHybridIntegration:
+    @pytest.fixture
+    async def emb_repo(self, test_db):
+        from tg_parser.storage.sqlalchemy.embedding_repo import SAEmbeddingRepo
+        from tg_parser.storage.sqlalchemy.schemas.processing_storage import (
+            init_processing_storage_schema,
+        )
+
+        await init_processing_storage_schema(test_db.processing_storage_engine)
+
+        session = test_db.processing_storage_session()
+        try:
+            yield SAEmbeddingRepo(session)
+        finally:
+            await session.close()
+
+    async def test_hybrid_fuses_without_duplicates(self, test_db, emb_repo):
+        from tg_parser.services._ranking import rrf_fuse
+
+        sem = [SimilarityResult(source_ref="dup", score=0.9),
+               SimilarityResult(source_ref="sem_only", score=0.8)]
+        kw = [SimilarityResult(source_ref="dup", score=0.5),
+              SimilarityResult(source_ref="kw_only", score=0.3)]
+        fused = rrf_fuse(sem, kw)
+        refs = [r.source_ref for r in fused]
+        assert len(refs) == len(set(refs))
+        assert refs[0] == "dup"
+
+    async def test_hybrid_rare_term_dominates_via_keyword(self, test_db, emb_repo):
+        from sqlalchemy import text
+        async with test_db.processing_storage_engine.begin() as conn:
+            await conn.execute(text(
+                "INSERT INTO processed_documents "
+                "(source_ref, id, source_message_id, channel_id, processed_at, "
+                " text_clean, summary, topics_json, entities_json, language, metadata_json) "
+                "VALUES ('tg:f5a_hyb:post:1', 'tg:f5a_hyb:post:1', '1', 'f5a_hyb', "
+                "'2026-04-17T00:00:00Z', 'xyzzyrareterm appears here', "
+                "'xyzzyrareterm summary', '[]', '[]', 'en', NULL) "
+                "ON CONFLICT (source_ref) DO NOTHING"
+            ))
+        try:
+            results = await emb_repo.keyword_search(query="xyzzyrareterm", limit=5)
+            assert any(r.source_ref == "tg:f5a_hyb:post:1" for r in results)
+        finally:
+            async with test_db.processing_storage_engine.begin() as conn:
+                await conn.execute(text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:1'"))
+
+    async def test_hybrid_empty_corpus_returns_empty(self, test_db, emb_repo):
+        results = await emb_repo.keyword_search(query="zzzz_does_not_exist_zzzz", limit=5)
+        assert results == []
+
+    async def test_keyword_search_returns_similarity_result_instances(self, test_db, emb_repo):
+        from sqlalchemy import text
+        async with test_db.processing_storage_engine.begin() as conn:
+            await conn.execute(text(
+                "INSERT INTO processed_documents "
+                "(source_ref, id, source_message_id, channel_id, processed_at, "
+                " text_clean, summary, topics_json, entities_json, language, metadata_json) "
+                "VALUES ('tg:f5a_hyb:post:2', 'tg:f5a_hyb:post:2', '2', 'f5a_hyb', "
+                "'2026-04-17T00:00:00Z', 'python programming language', "
+                "'python', '[]', '[]', 'en', NULL) "
+                "ON CONFLICT (source_ref) DO NOTHING"
+            ))
+        try:
+            results = await emb_repo.keyword_search(query="python", limit=5)
+            assert all(isinstance(r, SimilarityResult) for r in results)
+        finally:
+            async with test_db.processing_storage_engine.begin() as conn:
+                await conn.execute(text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:2'"))
+
+
+# ---------------------------------------------------------------------------
+# 6. TestSettings
+# ---------------------------------------------------------------------------
+
+
+class TestSettings:
+    def test_defaults(self):
+        from tg_parser.config.settings import Settings
+        s = Settings(
+            telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+            openai_api_key="sk-x",
+        )
+        assert s.hybrid_enabled is True
+        assert s.hybrid_rrf_k == 60
+        assert "russian" in s.fts_languages
+        assert "english" in s.fts_languages
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("HYBRID_ENABLED", "false")
+        monkeypatch.setenv("HYBRID_RRF_K", "120")
+        monkeypatch.setenv("FTS_LANGUAGES", "russian")
+        from tg_parser.config.settings import Settings
+        s = Settings(
+            telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+            openai_api_key="sk-x",
+        )
+        assert s.hybrid_enabled is False
+        assert s.hybrid_rrf_k == 120
+        assert s.fts_languages == "russian"
+
+    def test_hybrid_rrf_k_requires_positive(self):
+        from pydantic import ValidationError
+
+        from tg_parser.config.settings import Settings
+        with pytest.raises(ValidationError):
+            Settings(
+                telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+                openai_api_key="sk-x",
+                hybrid_rrf_k=0,
+            )

--- a/tests/test_f5a_hybrid_search.py
+++ b/tests/test_f5a_hybrid_search.py
@@ -18,7 +18,6 @@ import pytest
 from tg_parser.services._ranking import rrf_fuse
 from tg_parser.storage.ports import SimilarityResult
 
-
 # ---------------------------------------------------------------------------
 # 1. TestRRFFusion — pure unit tests for rrf_fuse
 # ---------------------------------------------------------------------------
@@ -121,6 +120,20 @@ class TestRRFFusion:
         k = 60
         assert fused[0].score == pytest.approx(1 / (k + 1))
         assert fused[0].score != 0.99
+
+    def test_does_not_mutate_inputs(self):
+        """Pure function contract: inputs must not be modified."""
+        semantic = [_sim("a", score=0.9), _sim("b", score=0.7)]
+        keyword = [_sim("b", score=0.5), _sim("c", score=0.3)]
+        sem_snapshot = [(r.source_ref, r.score) for r in semantic]
+        kw_snapshot = [(r.source_ref, r.score) for r in keyword]
+        rrf_fuse(semantic, keyword)
+        assert [(r.source_ref, r.score) for r in semantic] == sem_snapshot
+        assert [(r.source_ref, r.score) for r in keyword] == kw_snapshot
+
+    def test_negative_k_raises(self):
+        with pytest.raises(ValueError):
+            rrf_fuse([_sim("a")], k=-5)
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +279,11 @@ class TestKeywordSearchRepo:
         assert "tg:f5a_kw:post:6" in en_refs
         assert "tg:f5a_kw:post:7" in ru_refs
         await self._cleanup(test_db)
+
+    async def test_keyword_search_empty_query_returns_empty(self, test_db, emb_repo):
+        """Guard against a crash / full-table scan on blank input."""
+        assert await emb_repo.keyword_search(query="", limit=10) == []
+        assert await emb_repo.keyword_search(query="   ", limit=10) == []
 
     async def test_keyword_search_entry_types_filter(self, test_db, emb_repo):
         await self._cleanup(test_db)
@@ -442,6 +460,215 @@ class TestSearchModeSwitch:
 
         with pytest.raises(ValidationError):
             SearchRequest(query="hello", mode="fuzzy")  # type: ignore[arg-type]
+
+    async def test_keyword_mode_skips_embedding_client(self, monkeypatch):
+        """Keyword mode must not create an embedding client (avoids API cost)."""
+        from tg_parser.services import retrieval_service
+        from tg_parser.services.retrieval_service import search
+
+        created: list[bool] = []
+
+        def _factory():
+            created.append(True)
+            return _FakeEmbClient()
+
+        monkeypatch.setattr(retrieval_service, "create_embedding_client", _factory)
+
+        emb_repo = AsyncMock()
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "query", mode="keyword",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert created == [], "embedding client should not be created in keyword mode"
+
+    async def test_hybrid_include_topics_false_limits_entry_types(self, patch_embedding_client):
+        """When include_topics=False, both branches must receive entry_types=['message']."""
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q", mode="hybrid", include_topics=False,
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.call_args.kwargs["entry_types"] == ["message"]
+        assert emb_repo.keyword_search.call_args.kwargs["entry_types"] == ["message"]
+
+    async def test_hybrid_channel_ids_passthrough(self, patch_embedding_client):
+        """channel_ids must reach both similarity_search and keyword_search."""
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q", channel_id="ch_x", mode="hybrid",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.call_args.kwargs["channel_ids"] == ["ch_x"]
+        assert emb_repo.keyword_search.call_args.kwargs["channel_ids"] == ["ch_x"]
+
+    async def test_hybrid_fetch_limit_doubled_when_channel_id(self, patch_embedding_client):
+        """With channel_id set, fetch_limit = limit * 2 in both branches (for post-filter headroom)."""
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q", channel_id="ch_x", limit=5, mode="hybrid",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.call_args.kwargs["limit"] == 10
+        assert emb_repo.keyword_search.call_args.kwargs["limit"] == 10
+
+    async def test_hybrid_score_is_rrf_not_original(self, patch_embedding_client):
+        """SearchResult.score must carry the fused RRF score, not the original similarity."""
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[
+            SimilarityResult(source_ref="doc1", score=0.99, entry_type="message"),
+        ])
+        emb_repo.keyword_search = AsyncMock(return_value=[
+            SimilarityResult(source_ref="doc1", score=0.01, entry_type="message"),
+        ])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        results = await search(
+            "q", mode="hybrid",
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert len(results) == 1
+        k = 60
+        assert results[0].score == pytest.approx(2 / (k + 1))
+        assert results[0].score != 0.99
+        assert results[0].score != 0.01
+
+    async def test_answer_forwards_mode_to_search(self, patch_embedding_client, monkeypatch):
+        """answer() must forward mode= to search()."""
+        from tg_parser.services import retrieval_service
+
+        captured: dict = {}
+
+        async def _fake_search(query, **kwargs):
+            captured["mode"] = kwargs.get("mode")
+            captured["channel_id"] = kwargs.get("channel_id")
+            return []
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        result = await retrieval_service.answer(
+            "hello?", channel_id="ch1", mode="keyword",
+            emb_repo=AsyncMock(), proc_repo=AsyncMock(),
+        )
+        assert captured["mode"] == "keyword"
+        assert captured["channel_id"] == "ch1"
+        assert result.sources == []
+
+    async def test_answer_default_mode_is_hybrid(self, patch_embedding_client, monkeypatch):
+        from tg_parser.services import retrieval_service
+
+        captured: dict = {}
+
+        async def _fake_search(query, **kwargs):
+            captured["mode"] = kwargs.get("mode")
+            return []
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        await retrieval_service.answer(
+            "q?", emb_repo=AsyncMock(), proc_repo=AsyncMock(),
+        )
+        assert captured["mode"] == "hybrid"
+
+    @pytest.mark.parametrize("mode", ["semantic", "keyword", "hybrid"])
+    async def test_search_request_accepts_valid_modes(self, mode):
+        from tg_parser.api.routes.rag import SearchRequest
+
+        req = SearchRequest(query="hello", mode=mode)
+        assert req.mode == mode
+
+    @pytest.mark.parametrize("mode", ["semantic", "keyword", "hybrid"])
+    async def test_ask_request_accepts_valid_modes(self, mode):
+        from tg_parser.api.routes.rag import AskRequest
+
+        req = AskRequest(question="hello?", mode=mode)
+        assert req.mode == mode
+
+    async def test_ask_request_rejects_invalid_mode(self):
+        from pydantic import ValidationError
+
+        from tg_parser.api.routes.rag import AskRequest
+
+        with pytest.raises(ValidationError):
+            AskRequest(question="q?", mode="bm25")  # type: ignore[arg-type]
+
+    async def test_allowed_channel_ids_empty_short_circuits_in_all_modes(self, patch_embedding_client):
+        """allowed_channel_ids=[] → early return [] regardless of mode; repos never called."""
+        from tg_parser.services.retrieval_service import search
+
+        for mode in ("semantic", "keyword", "hybrid"):
+            emb_repo = AsyncMock()
+            emb_repo.similarity_search = AsyncMock(return_value=[])
+            emb_repo.keyword_search = AsyncMock(return_value=[])
+            proc_repo = AsyncMock()
+            proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+            results = await search(
+                "q", mode=mode, allowed_channel_ids=[],
+                emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            )
+            assert results == []
+            assert not emb_repo.similarity_search.called
+            assert not emb_repo.keyword_search.called
+
+    async def test_permission_denied_when_channel_not_in_allowed_hybrid(self, patch_embedding_client):
+        from tg_parser.auth.ownership import PermissionDenied
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        proc_repo = AsyncMock()
+
+        with pytest.raises(PermissionDenied):
+            await search(
+                "q", channel_id="secret_channel", mode="hybrid",
+                allowed_channel_ids=["other_channel"],
+                emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            )
+
+    async def test_threshold_only_applied_to_semantic_branch_in_hybrid(self, patch_embedding_client):
+        """threshold is a pgvector-specific param: should be forwarded to similarity_search only."""
+        from tg_parser.services.retrieval_service import search
+
+        emb_repo = AsyncMock()
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q", mode="hybrid", threshold=0.77,
+            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.similarity_search.call_args.kwargs["threshold"] == 0.77
+        assert "threshold" not in emb_repo.keyword_search.call_args.kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f5a_hybrid_search.py
+++ b/tests/test_f5a_hybrid_search.py
@@ -23,7 +23,9 @@ from tg_parser.storage.ports import SimilarityResult
 # ---------------------------------------------------------------------------
 
 
-def _sim(source_ref: str, score: float = 1.0, entry_type: str = "message", topic_id: str | None = None) -> SimilarityResult:
+def _sim(
+    source_ref: str, score: float = 1.0, entry_type: str = "message", topic_id: str | None = None
+) -> SimilarityResult:
     return SimilarityResult(
         source_ref=source_ref,
         score=score,
@@ -84,10 +86,14 @@ class TestRRFFusion:
             rrf_fuse([_sim("a")], k=0)
 
     def test_entry_type_and_topic_id_preserved_from_first_seen(self):
-        semantic = [_sim("doc1", entry_type="message"),
-                    _sim("topic1", entry_type="topic", topic_id="topic1")]
-        keyword = [_sim("topic1", entry_type="topic", topic_id="topic1"),
-                   _sim("doc1", entry_type="message")]
+        semantic = [
+            _sim("doc1", entry_type="message"),
+            _sim("topic1", entry_type="topic", topic_id="topic1"),
+        ]
+        keyword = [
+            _sim("topic1", entry_type="topic", topic_id="topic1"),
+            _sim("doc1", entry_type="message"),
+        ]
         fused = rrf_fuse(semantic, keyword)
         mapping = {r.source_ref: r for r in fused}
         assert mapping["doc1"].entry_type == "message"
@@ -162,9 +168,11 @@ class TestKeywordSearchRepo:
         finally:
             await session.close()
 
-    async def _insert_processed(self, test_db, source_ref: str, channel_id: str,
-                                text_clean: str, summary: str | None = None):
+    async def _insert_processed(
+        self, test_db, source_ref: str, channel_id: str, text_clean: str, summary: str | None = None
+    ):
         from sqlalchemy import text
+
         async with test_db.processing_storage_engine.begin() as conn:
             await conn.execute(
                 text(
@@ -174,13 +182,20 @@ class TestKeywordSearchRepo:
                     "VALUES (:sr, :id, :smid, :ch, :ts, :tc, :sum, '[]', '[]', 'ru', NULL) "
                     "ON CONFLICT (source_ref) DO UPDATE SET text_clean=EXCLUDED.text_clean, summary=EXCLUDED.summary"
                 ),
-                {"sr": source_ref, "id": source_ref, "smid": source_ref.split(":")[-1],
-                 "ch": channel_id, "ts": "2026-04-17T00:00:00Z",
-                 "tc": text_clean, "sum": summary},
+                {
+                    "sr": source_ref,
+                    "id": source_ref,
+                    "smid": source_ref.split(":")[-1],
+                    "ch": channel_id,
+                    "ts": "2026-04-17T00:00:00Z",
+                    "tc": text_clean,
+                    "sum": summary,
+                },
             )
 
     async def _insert_topic(self, test_db, tid: str, title: str, summary: str, scope_in: str):
         from sqlalchemy import text
+
         async with test_db.processing_storage_engine.begin() as conn:
             await conn.execute(
                 text(
@@ -189,21 +204,27 @@ class TestKeywordSearchRepo:
                     "VALUES (:id, :t, :s, :si, '[]', 'singleton', '[]', '[]', :ts) "
                     "ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title, summary=EXCLUDED.summary"
                 ),
-                {"id": tid, "t": title, "s": summary, "si": scope_in,
-                 "ts": "2026-04-17T00:00:00Z"},
+                {"id": tid, "t": title, "s": summary, "si": scope_in, "ts": "2026-04-17T00:00:00Z"},
             )
 
     async def _cleanup(self, test_db):
         from sqlalchemy import text
+
         async with test_db.processing_storage_engine.begin() as conn:
-            await conn.execute(text("DELETE FROM processed_documents WHERE source_ref LIKE 'tg:f5a_kw:%'"))
+            await conn.execute(
+                text("DELETE FROM processed_documents WHERE source_ref LIKE 'tg:f5a_kw:%'")
+            )
             await conn.execute(text("DELETE FROM topic_cards WHERE id LIKE 'f5a_kw_topic:%'"))
 
     async def test_keyword_search_on_processed_documents_ru(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:1", "f5a_kw",
-                                     "Анализ крови показывает повышенный холестерин",
-                                     summary="Холестерин и анализ крови")
+        await self._insert_processed(
+            test_db,
+            "tg:f5a_kw:post:1",
+            "f5a_kw",
+            "Анализ крови показывает повышенный холестерин",
+            summary="Холестерин и анализ крови",
+        )
         results = await emb_repo.keyword_search(query="холестерин", limit=10)
         refs = [r.source_ref for r in results]
         assert "tg:f5a_kw:post:1" in refs
@@ -214,10 +235,13 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_on_topic_cards(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_topic(test_db, "f5a_kw_topic:t1",
-                                 title="Кардиология",
-                                 summary="Сердечно-сосудистая система, давление, пульс",
-                                 scope_in='["heart","pressure"]')
+        await self._insert_topic(
+            test_db,
+            "f5a_kw_topic:t1",
+            title="Кардиология",
+            summary="Сердечно-сосудистая система, давление, пульс",
+            scope_in='["heart","pressure"]',
+        )
         results = await emb_repo.keyword_search(query="давление", limit=10)
         refs = [r.source_ref for r in results]
         assert "f5a_kw_topic:t1" in refs
@@ -228,12 +252,20 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_union_returns_both_types(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:2", "f5a_kw",
-                                     "кофеин влияет на давление", summary="кофе и давление")
-        await self._insert_topic(test_db, "f5a_kw_topic:t2",
-                                 title="Напитки и давление",
-                                 summary="Кофе, чай и артериальное давление",
-                                 scope_in='["coffee"]')
+        await self._insert_processed(
+            test_db,
+            "tg:f5a_kw:post:2",
+            "f5a_kw",
+            "кофеин влияет на давление",
+            summary="кофе и давление",
+        )
+        await self._insert_topic(
+            test_db,
+            "f5a_kw_topic:t2",
+            title="Напитки и давление",
+            summary="Кофе, чай и артериальное давление",
+            scope_in='["coffee"]',
+        )
         results = await emb_repo.keyword_search(query="давление", limit=10)
         types = {r.entry_type for r in results}
         assert "message" in types
@@ -242,10 +274,12 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_channel_filter_scopes_messages(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:3", "f5a_kw_a",
-                                     "редкоеслово_alpha важное", summary=None)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:4", "f5a_kw_b",
-                                     "редкоеслово_alpha другое", summary=None)
+        await self._insert_processed(
+            test_db, "tg:f5a_kw:post:3", "f5a_kw_a", "редкоеслово_alpha важное", summary=None
+        )
+        await self._insert_processed(
+            test_db, "tg:f5a_kw:post:4", "f5a_kw_b", "редкоеслово_alpha другое", summary=None
+        )
         results = await emb_repo.keyword_search(
             query="редкоеслово_alpha", limit=10, channel_ids=["f5a_kw_a"]
         )
@@ -256,8 +290,13 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_min_rank_cutoff(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:5", "f5a_kw",
-                                     "уникальное слово_beta встречается однажды", summary=None)
+        await self._insert_processed(
+            test_db,
+            "tg:f5a_kw:post:5",
+            "f5a_kw",
+            "уникальное слово_beta встречается однажды",
+            summary=None,
+        )
         loose = await emb_repo.keyword_search(query="слово_beta", limit=10, min_rank=0.0)
         assert any(r.source_ref == "tg:f5a_kw:post:5" for r in loose)
         strict = await emb_repo.keyword_search(query="слово_beta", limit=10, min_rank=10.0)
@@ -266,12 +305,20 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_mixed_ru_en_corpus(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:6", "f5a_kw",
-                                     "Machine learning pipeline for anomaly detection",
-                                     summary="ML anomaly detection")
-        await self._insert_processed(test_db, "tg:f5a_kw:post:7", "f5a_kw",
-                                     "Обнаружение аномалий в данных с помощью машинного обучения",
-                                     summary="Аномалии в данных")
+        await self._insert_processed(
+            test_db,
+            "tg:f5a_kw:post:6",
+            "f5a_kw",
+            "Machine learning pipeline for anomaly detection",
+            summary="ML anomaly detection",
+        )
+        await self._insert_processed(
+            test_db,
+            "tg:f5a_kw:post:7",
+            "f5a_kw",
+            "Обнаружение аномалий в данных с помощью машинного обучения",
+            summary="Аномалии в данных",
+        )
         en = await emb_repo.keyword_search(query="anomaly detection", limit=10)
         ru = await emb_repo.keyword_search(query="аномалий", limit=10)
         en_refs = {r.source_ref for r in en}
@@ -287,11 +334,16 @@ class TestKeywordSearchRepo:
 
     async def test_keyword_search_entry_types_filter(self, test_db, emb_repo):
         await self._cleanup(test_db)
-        await self._insert_processed(test_db, "tg:f5a_kw:post:8", "f5a_kw",
-                                     "редкое_gamma термин", summary=None)
-        await self._insert_topic(test_db, "f5a_kw_topic:t3",
-                                 title="редкое_gamma",
-                                 summary="про редкое_gamma", scope_in="[]")
+        await self._insert_processed(
+            test_db, "tg:f5a_kw:post:8", "f5a_kw", "редкое_gamma термин", summary=None
+        )
+        await self._insert_topic(
+            test_db,
+            "f5a_kw_topic:t3",
+            title="редкое_gamma",
+            summary="про редкое_gamma",
+            scope_in="[]",
+        )
         only_msgs = await emb_repo.keyword_search(
             query="редкое_gamma", limit=10, entry_types=["message"]
         )
@@ -332,13 +384,16 @@ class TestMigrationIdempotency:
         await init_processing_storage_schema(test_db.processing_storage_engine)
 
         async with test_db.processing_storage_engine.begin() as conn:
-            result = await conn.execute(text(
-                "SELECT indexname FROM pg_indexes "
-                "WHERE indexname IN ('idx_pd_search_vector', 'idx_tc_search_vector')"
-            ))
+            result = await conn.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE indexname IN ('idx_pd_search_vector', 'idx_tc_search_vector')"
+                )
+            )
             names = {row[0] for row in result.fetchall()}
         assert "idx_pd_search_vector" in names
         assert "idx_tc_search_vector" in names
+
 
 # ---------------------------------------------------------------------------
 # 4. TestSearchModeSwitch — retrieval_service.search(mode=...) branching
@@ -357,6 +412,7 @@ class _FakeEmbClient:
 def patch_embedding_client(monkeypatch):
     def _factory():
         return _FakeEmbClient()
+
     monkeypatch.setattr(
         "tg_parser.services.retrieval_service.create_embedding_client",
         _factory,
@@ -374,8 +430,11 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "query", mode="semantic",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "query",
+            mode="semantic",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.called
         assert not emb_repo.keyword_search.called
@@ -390,8 +449,11 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "query", mode="keyword",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "query",
+            mode="keyword",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.keyword_search.called
         assert not emb_repo.similarity_search.called
@@ -400,25 +462,34 @@ class TestSearchModeSwitch:
         from tg_parser.services.retrieval_service import search
 
         emb_repo = AsyncMock()
-        emb_repo.similarity_search = AsyncMock(return_value=[
-            SimilarityResult(source_ref="a", score=0.9, entry_type="message"),
-        ])
-        emb_repo.keyword_search = AsyncMock(return_value=[
-            SimilarityResult(source_ref="b", score=0.5, entry_type="message"),
-        ])
+        emb_repo.similarity_search = AsyncMock(
+            return_value=[
+                SimilarityResult(source_ref="a", score=0.9, entry_type="message"),
+            ]
+        )
+        emb_repo.keyword_search = AsyncMock(
+            return_value=[
+                SimilarityResult(source_ref="b", score=0.5, entry_type="message"),
+            ]
+        )
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         results = await search(
-            "query", mode="hybrid",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "query",
+            mode="hybrid",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.called
         assert emb_repo.keyword_search.called
         refs = {r.source_ref for r in results}
         assert refs == {"a", "b"}
 
-    async def test_hybrid_falls_back_to_semantic_when_disabled(self, patch_embedding_client, monkeypatch):
+    async def test_hybrid_falls_back_to_semantic_when_disabled(
+        self, patch_embedding_client, monkeypatch
+    ):
         from tg_parser.services import retrieval_service
         from tg_parser.services.retrieval_service import search
 
@@ -431,8 +502,11 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "query", mode="hybrid",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "query",
+            mode="hybrid",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.called
         assert not emb_repo.keyword_search.called
@@ -448,7 +522,9 @@ class TestSearchModeSwitch:
 
         await search(
             "query",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.called
         assert emb_repo.keyword_search.called
@@ -481,8 +557,11 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "query", mode="keyword",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "query",
+            mode="keyword",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert created == [], "embedding client should not be created in keyword mode"
 
@@ -497,8 +576,12 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "q", mode="hybrid", include_topics=False,
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "q",
+            mode="hybrid",
+            include_topics=False,
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.call_args.kwargs["entry_types"] == ["message"]
         assert emb_repo.keyword_search.call_args.kwargs["entry_types"] == ["message"]
@@ -514,8 +597,12 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "q", channel_id="ch_x", mode="hybrid",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "q",
+            channel_id="ch_x",
+            mode="hybrid",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.call_args.kwargs["channel_ids"] == ["ch_x"]
         assert emb_repo.keyword_search.call_args.kwargs["channel_ids"] == ["ch_x"]
@@ -531,8 +618,13 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "q", channel_id="ch_x", limit=5, mode="hybrid",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "q",
+            channel_id="ch_x",
+            limit=5,
+            mode="hybrid",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.call_args.kwargs["limit"] == 10
         assert emb_repo.keyword_search.call_args.kwargs["limit"] == 10
@@ -542,18 +634,25 @@ class TestSearchModeSwitch:
         from tg_parser.services.retrieval_service import search
 
         emb_repo = AsyncMock()
-        emb_repo.similarity_search = AsyncMock(return_value=[
-            SimilarityResult(source_ref="doc1", score=0.99, entry_type="message"),
-        ])
-        emb_repo.keyword_search = AsyncMock(return_value=[
-            SimilarityResult(source_ref="doc1", score=0.01, entry_type="message"),
-        ])
+        emb_repo.similarity_search = AsyncMock(
+            return_value=[
+                SimilarityResult(source_ref="doc1", score=0.99, entry_type="message"),
+            ]
+        )
+        emb_repo.keyword_search = AsyncMock(
+            return_value=[
+                SimilarityResult(source_ref="doc1", score=0.01, entry_type="message"),
+            ]
+        )
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         results = await search(
-            "q", mode="hybrid",
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "q",
+            mode="hybrid",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert len(results) == 1
         k = 60
@@ -575,8 +674,11 @@ class TestSearchModeSwitch:
         monkeypatch.setattr(retrieval_service, "search", _fake_search)
 
         result = await retrieval_service.answer(
-            "hello?", channel_id="ch1", mode="keyword",
-            emb_repo=AsyncMock(), proc_repo=AsyncMock(),
+            "hello?",
+            channel_id="ch1",
+            mode="keyword",
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
         )
         assert captured["mode"] == "keyword"
         assert captured["channel_id"] == "ch1"
@@ -594,7 +696,9 @@ class TestSearchModeSwitch:
         monkeypatch.setattr(retrieval_service, "search", _fake_search)
 
         await retrieval_service.answer(
-            "q?", emb_repo=AsyncMock(), proc_repo=AsyncMock(),
+            "q?",
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
         )
         assert captured["mode"] == "hybrid"
 
@@ -620,7 +724,9 @@ class TestSearchModeSwitch:
         with pytest.raises(ValidationError):
             AskRequest(question="q?", mode="bm25")  # type: ignore[arg-type]
 
-    async def test_allowed_channel_ids_empty_short_circuits_in_all_modes(self, patch_embedding_client):
+    async def test_allowed_channel_ids_empty_short_circuits_in_all_modes(
+        self, patch_embedding_client
+    ):
         """allowed_channel_ids=[] → early return [] regardless of mode; repos never called."""
         from tg_parser.services.retrieval_service import search
 
@@ -632,14 +738,20 @@ class TestSearchModeSwitch:
             proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
             results = await search(
-                "q", mode=mode, allowed_channel_ids=[],
-                emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+                "q",
+                mode=mode,
+                allowed_channel_ids=[],
+                emb_repo=emb_repo,
+                proc_repo=proc_repo,
+                topic_card_repo=AsyncMock(),
             )
             assert results == []
             assert not emb_repo.similarity_search.called
             assert not emb_repo.keyword_search.called
 
-    async def test_permission_denied_when_channel_not_in_allowed_hybrid(self, patch_embedding_client):
+    async def test_permission_denied_when_channel_not_in_allowed_hybrid(
+        self, patch_embedding_client
+    ):
         from tg_parser.auth.ownership import PermissionDenied
         from tg_parser.services.retrieval_service import search
 
@@ -648,12 +760,18 @@ class TestSearchModeSwitch:
 
         with pytest.raises(PermissionDenied):
             await search(
-                "q", channel_id="secret_channel", mode="hybrid",
+                "q",
+                channel_id="secret_channel",
+                mode="hybrid",
                 allowed_channel_ids=["other_channel"],
-                emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+                emb_repo=emb_repo,
+                proc_repo=proc_repo,
+                topic_card_repo=AsyncMock(),
             )
 
-    async def test_threshold_only_applied_to_semantic_branch_in_hybrid(self, patch_embedding_client):
+    async def test_threshold_only_applied_to_semantic_branch_in_hybrid(
+        self, patch_embedding_client
+    ):
         """threshold is a pgvector-specific param: should be forwarded to similarity_search only."""
         from tg_parser.services.retrieval_service import search
 
@@ -664,8 +782,12 @@ class TestSearchModeSwitch:
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
         await search(
-            "q", mode="hybrid", threshold=0.77,
-            emb_repo=emb_repo, proc_repo=proc_repo, topic_card_repo=AsyncMock(),
+            "q",
+            mode="hybrid",
+            threshold=0.77,
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
         )
         assert emb_repo.similarity_search.call_args.kwargs["threshold"] == 0.77
         assert "threshold" not in emb_repo.keyword_search.call_args.kwargs
@@ -696,10 +818,14 @@ class TestHybridIntegration:
     async def test_hybrid_fuses_without_duplicates(self, test_db, emb_repo):
         from tg_parser.services._ranking import rrf_fuse
 
-        sem = [SimilarityResult(source_ref="dup", score=0.9),
-               SimilarityResult(source_ref="sem_only", score=0.8)]
-        kw = [SimilarityResult(source_ref="dup", score=0.5),
-              SimilarityResult(source_ref="kw_only", score=0.3)]
+        sem = [
+            SimilarityResult(source_ref="dup", score=0.9),
+            SimilarityResult(source_ref="sem_only", score=0.8),
+        ]
+        kw = [
+            SimilarityResult(source_ref="dup", score=0.5),
+            SimilarityResult(source_ref="kw_only", score=0.3),
+        ]
         fused = rrf_fuse(sem, kw)
         refs = [r.source_ref for r in fused]
         assert len(refs) == len(set(refs))
@@ -707,22 +833,27 @@ class TestHybridIntegration:
 
     async def test_hybrid_rare_term_dominates_via_keyword(self, test_db, emb_repo):
         from sqlalchemy import text
+
         async with test_db.processing_storage_engine.begin() as conn:
-            await conn.execute(text(
-                "INSERT INTO processed_documents "
-                "(source_ref, id, source_message_id, channel_id, processed_at, "
-                " text_clean, summary, topics_json, entities_json, language, metadata_json) "
-                "VALUES ('tg:f5a_hyb:post:1', 'tg:f5a_hyb:post:1', '1', 'f5a_hyb', "
-                "'2026-04-17T00:00:00Z', 'xyzzyrareterm appears here', "
-                "'xyzzyrareterm summary', '[]', '[]', 'en', NULL) "
-                "ON CONFLICT (source_ref) DO NOTHING"
-            ))
+            await conn.execute(
+                text(
+                    "INSERT INTO processed_documents "
+                    "(source_ref, id, source_message_id, channel_id, processed_at, "
+                    " text_clean, summary, topics_json, entities_json, language, metadata_json) "
+                    "VALUES ('tg:f5a_hyb:post:1', 'tg:f5a_hyb:post:1', '1', 'f5a_hyb', "
+                    "'2026-04-17T00:00:00Z', 'xyzzyrareterm appears here', "
+                    "'xyzzyrareterm summary', '[]', '[]', 'en', NULL) "
+                    "ON CONFLICT (source_ref) DO NOTHING"
+                )
+            )
         try:
             results = await emb_repo.keyword_search(query="xyzzyrareterm", limit=5)
             assert any(r.source_ref == "tg:f5a_hyb:post:1" for r in results)
         finally:
             async with test_db.processing_storage_engine.begin() as conn:
-                await conn.execute(text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:1'"))
+                await conn.execute(
+                    text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:1'")
+                )
 
     async def test_hybrid_empty_corpus_returns_empty(self, test_db, emb_repo):
         results = await emb_repo.keyword_search(query="zzzz_does_not_exist_zzzz", limit=5)
@@ -730,22 +861,27 @@ class TestHybridIntegration:
 
     async def test_keyword_search_returns_similarity_result_instances(self, test_db, emb_repo):
         from sqlalchemy import text
+
         async with test_db.processing_storage_engine.begin() as conn:
-            await conn.execute(text(
-                "INSERT INTO processed_documents "
-                "(source_ref, id, source_message_id, channel_id, processed_at, "
-                " text_clean, summary, topics_json, entities_json, language, metadata_json) "
-                "VALUES ('tg:f5a_hyb:post:2', 'tg:f5a_hyb:post:2', '2', 'f5a_hyb', "
-                "'2026-04-17T00:00:00Z', 'python programming language', "
-                "'python', '[]', '[]', 'en', NULL) "
-                "ON CONFLICT (source_ref) DO NOTHING"
-            ))
+            await conn.execute(
+                text(
+                    "INSERT INTO processed_documents "
+                    "(source_ref, id, source_message_id, channel_id, processed_at, "
+                    " text_clean, summary, topics_json, entities_json, language, metadata_json) "
+                    "VALUES ('tg:f5a_hyb:post:2', 'tg:f5a_hyb:post:2', '2', 'f5a_hyb', "
+                    "'2026-04-17T00:00:00Z', 'python programming language', "
+                    "'python', '[]', '[]', 'en', NULL) "
+                    "ON CONFLICT (source_ref) DO NOTHING"
+                )
+            )
         try:
             results = await emb_repo.keyword_search(query="python", limit=5)
             assert all(isinstance(r, SimilarityResult) for r in results)
         finally:
             async with test_db.processing_storage_engine.begin() as conn:
-                await conn.execute(text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:2'"))
+                await conn.execute(
+                    text("DELETE FROM processed_documents WHERE source_ref = 'tg:f5a_hyb:post:2'")
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -756,8 +892,11 @@ class TestHybridIntegration:
 class TestSettings:
     def test_defaults(self):
         from tg_parser.config.settings import Settings
+
         s = Settings(
-            telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
             openai_api_key="sk-x",
         )
         assert s.hybrid_enabled is True
@@ -770,8 +909,11 @@ class TestSettings:
         monkeypatch.setenv("HYBRID_RRF_K", "120")
         monkeypatch.setenv("FTS_LANGUAGES", "russian")
         from tg_parser.config.settings import Settings
+
         s = Settings(
-            telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
             openai_api_key="sk-x",
         )
         assert s.hybrid_enabled is False
@@ -782,9 +924,12 @@ class TestSettings:
         from pydantic import ValidationError
 
         from tg_parser.config.settings import Settings
+
         with pytest.raises(ValidationError):
             Settings(
-                telegram_api_id=1, telegram_api_hash="h", telegram_phone="+1",
+                telegram_api_id=1,
+                telegram_api_hash="h",
+                telegram_phone="+1",
                 openai_api_key="sk-x",
                 hybrid_rrf_k=0,
             )

--- a/tests/test_f5a_hybrid_search.py
+++ b/tests/test_f5a_hybrid_search.py
@@ -1,0 +1,320 @@
+"""
+Tests for F5-A Phase 1: Hybrid Search (FTS + pgvector + RRF).
+
+Commit 1 coverage:
+- TestRRFFusion           : pure unit tests for rrf_fuse (no DB).
+- TestKeywordSearchRepo   : SAEmbeddingRepo.keyword_search against live Postgres.
+- TestMigrationIdempotency: _ensure_fts_columns and GIN-index idempotency.
+"""
+
+import os
+
+import pytest
+
+from tg_parser.services._ranking import rrf_fuse
+from tg_parser.storage.ports import SimilarityResult
+
+
+# ---------------------------------------------------------------------------
+# 1. TestRRFFusion — pure unit tests for rrf_fuse
+# ---------------------------------------------------------------------------
+
+
+def _sim(source_ref: str, score: float = 1.0, entry_type: str = "message", topic_id: str | None = None) -> SimilarityResult:
+    return SimilarityResult(
+        source_ref=source_ref,
+        score=score,
+        entry_type=entry_type,
+        topic_id=topic_id,
+    )
+
+
+class TestRRFFusion:
+    def test_empty_inputs_return_empty(self):
+        assert rrf_fuse() == []
+        assert rrf_fuse([], []) == []
+
+    def test_single_list_preserves_order(self):
+        semantic = [_sim("a", 0.9), _sim("b", 0.7), _sim("c", 0.5)]
+        fused = rrf_fuse(semantic)
+        assert [r.source_ref for r in fused] == ["a", "b", "c"]
+        k = 60
+        assert fused[0].score == pytest.approx(1 / (k + 1))
+        assert fused[1].score == pytest.approx(1 / (k + 2))
+        assert fused[2].score == pytest.approx(1 / (k + 3))
+
+    def test_one_list_empty_other_non_empty_does_not_crash(self):
+        kw = [_sim("x"), _sim("y")]
+        fused = rrf_fuse([], kw)
+        assert [r.source_ref for r in fused] == ["x", "y"]
+
+    def test_duplicates_aggregate_across_lists(self):
+        semantic = [_sim("shared"), _sim("only_sem")]
+        keyword = [_sim("shared"), _sim("only_kw")]
+        fused = rrf_fuse(semantic, keyword)
+        scores = {r.source_ref: r.score for r in fused}
+        k = 60
+        expected_shared = 1 / (k + 1) + 1 / (k + 1)
+        expected_only_sem = 1 / (k + 2)
+        expected_only_kw = 1 / (k + 2)
+        assert scores["shared"] == pytest.approx(expected_shared)
+        assert scores["only_sem"] == pytest.approx(expected_only_sem)
+        assert scores["only_kw"] == pytest.approx(expected_only_kw)
+        assert fused[0].source_ref == "shared"
+
+    def test_rank_is_one_indexed(self):
+        first = [_sim("top")]
+        k = 60
+        fused = rrf_fuse(first)
+        assert fused[0].score == pytest.approx(1 / (k + 1))
+
+    def test_different_k_changes_discrimination(self):
+        semantic = [_sim("a"), _sim("b")]
+        low_k = rrf_fuse(semantic, k=1)
+        high_k = rrf_fuse(semantic, k=1000)
+        gap_low = low_k[0].score - low_k[1].score
+        gap_high = high_k[0].score - high_k[1].score
+        assert gap_low > gap_high
+
+    def test_invalid_k_raises(self):
+        with pytest.raises(ValueError):
+            rrf_fuse([_sim("a")], k=0)
+
+    def test_entry_type_and_topic_id_preserved_from_first_seen(self):
+        semantic = [_sim("doc1", entry_type="message"),
+                    _sim("topic1", entry_type="topic", topic_id="topic1")]
+        keyword = [_sim("topic1", entry_type="topic", topic_id="topic1"),
+                   _sim("doc1", entry_type="message")]
+        fused = rrf_fuse(semantic, keyword)
+        mapping = {r.source_ref: r for r in fused}
+        assert mapping["doc1"].entry_type == "message"
+        assert mapping["topic1"].entry_type == "topic"
+        assert mapping["topic1"].topic_id == "topic1"
+
+    def test_more_than_two_lists_supported(self):
+        a = [_sim("x"), _sim("y")]
+        b = [_sim("y"), _sim("z")]
+        c = [_sim("z"), _sim("x")]
+        fused = rrf_fuse(a, b, c)
+        refs = {r.source_ref for r in fused}
+        assert refs == {"x", "y", "z"}
+        for result in fused:
+            assert result.score > 0
+
+    def test_stable_ordering_on_tie(self):
+        a = [_sim("first"), _sim("second")]
+        b = [_sim("third"), _sim("fourth")]
+        fused = rrf_fuse(a, b)
+        refs = [r.source_ref for r in fused]
+        assert refs.index("first") < refs.index("third")
+        assert refs.index("second") < refs.index("fourth")
+
+    def test_return_type_and_score_replaces_original(self):
+        semantic = [_sim("a", score=0.99)]
+        fused = rrf_fuse(semantic)
+        assert isinstance(fused, list)
+        assert all(isinstance(r, SimilarityResult) for r in fused)
+        k = 60
+        assert fused[0].score == pytest.approx(1 / (k + 1))
+        assert fused[0].score != 0.99
+
+
+# ---------------------------------------------------------------------------
+# 2. TestKeywordSearchRepo — live Postgres FTS
+# ---------------------------------------------------------------------------
+
+_SKIP_PG = not os.environ.get("TEST_POSTGRES")
+
+
+@pytest.mark.skipif(_SKIP_PG, reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)")
+class TestKeywordSearchRepo:
+    """FTS (ts_rank_cd) over processed_documents and topic_cards."""
+
+    @pytest.fixture
+    async def emb_repo(self, test_db):
+        from tg_parser.storage.sqlalchemy.embedding_repo import SAEmbeddingRepo
+        from tg_parser.storage.sqlalchemy.schemas.processing_storage import (
+            init_processing_storage_schema,
+        )
+
+        await init_processing_storage_schema(test_db.processing_storage_engine)
+
+        session = test_db.processing_storage_session()
+        try:
+            yield SAEmbeddingRepo(session)
+        finally:
+            await session.close()
+
+    async def _insert_processed(self, test_db, source_ref: str, channel_id: str,
+                                text_clean: str, summary: str | None = None):
+        from sqlalchemy import text
+        async with test_db.processing_storage_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO processed_documents "
+                    "(source_ref, id, source_message_id, channel_id, processed_at, "
+                    " text_clean, summary, topics_json, entities_json, language, metadata_json) "
+                    "VALUES (:sr, :id, :smid, :ch, :ts, :tc, :sum, '[]', '[]', 'ru', NULL) "
+                    "ON CONFLICT (source_ref) DO UPDATE SET text_clean=EXCLUDED.text_clean, summary=EXCLUDED.summary"
+                ),
+                {"sr": source_ref, "id": source_ref, "smid": source_ref.split(":")[-1],
+                 "ch": channel_id, "ts": "2026-04-17T00:00:00Z",
+                 "tc": text_clean, "sum": summary},
+            )
+
+    async def _insert_topic(self, test_db, tid: str, title: str, summary: str, scope_in: str):
+        from sqlalchemy import text
+        async with test_db.processing_storage_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO topic_cards "
+                    "(id, title, summary, scope_in_json, scope_out_json, type, anchors_json, sources_json, updated_at) "
+                    "VALUES (:id, :t, :s, :si, '[]', 'singleton', '[]', '[]', :ts) "
+                    "ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title, summary=EXCLUDED.summary"
+                ),
+                {"id": tid, "t": title, "s": summary, "si": scope_in,
+                 "ts": "2026-04-17T00:00:00Z"},
+            )
+
+    async def _cleanup(self, test_db):
+        from sqlalchemy import text
+        async with test_db.processing_storage_engine.begin() as conn:
+            await conn.execute(text("DELETE FROM processed_documents WHERE source_ref LIKE 'tg:f5a_kw:%'"))
+            await conn.execute(text("DELETE FROM topic_cards WHERE id LIKE 'f5a_kw_topic:%'"))
+
+    async def test_keyword_search_on_processed_documents_ru(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:1", "f5a_kw",
+                                     "Анализ крови показывает повышенный холестерин",
+                                     summary="Холестерин и анализ крови")
+        results = await emb_repo.keyword_search(query="холестерин", limit=10)
+        refs = [r.source_ref for r in results]
+        assert "tg:f5a_kw:post:1" in refs
+        match = next(r for r in results if r.source_ref == "tg:f5a_kw:post:1")
+        assert match.entry_type == "message"
+        assert match.score > 0
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_on_topic_cards(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_topic(test_db, "f5a_kw_topic:t1",
+                                 title="Кардиология",
+                                 summary="Сердечно-сосудистая система, давление, пульс",
+                                 scope_in='["heart","pressure"]')
+        results = await emb_repo.keyword_search(query="давление", limit=10)
+        refs = [r.source_ref for r in results]
+        assert "f5a_kw_topic:t1" in refs
+        match = next(r for r in results if r.source_ref == "f5a_kw_topic:t1")
+        assert match.entry_type == "topic"
+        assert match.topic_id == "f5a_kw_topic:t1"
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_union_returns_both_types(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:2", "f5a_kw",
+                                     "кофеин влияет на давление", summary="кофе и давление")
+        await self._insert_topic(test_db, "f5a_kw_topic:t2",
+                                 title="Напитки и давление",
+                                 summary="Кофе, чай и артериальное давление",
+                                 scope_in='["coffee"]')
+        results = await emb_repo.keyword_search(query="давление", limit=10)
+        types = {r.entry_type for r in results}
+        assert "message" in types
+        assert "topic" in types
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_channel_filter_scopes_messages(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:3", "f5a_kw_a",
+                                     "редкоеслово_alpha важное", summary=None)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:4", "f5a_kw_b",
+                                     "редкоеслово_alpha другое", summary=None)
+        results = await emb_repo.keyword_search(
+            query="редкоеслово_alpha", limit=10, channel_ids=["f5a_kw_a"]
+        )
+        refs = {r.source_ref for r in results if r.entry_type == "message"}
+        assert "tg:f5a_kw:post:3" in refs
+        assert "tg:f5a_kw:post:4" not in refs
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_min_rank_cutoff(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:5", "f5a_kw",
+                                     "уникальное слово_beta встречается однажды", summary=None)
+        loose = await emb_repo.keyword_search(query="слово_beta", limit=10, min_rank=0.0)
+        assert any(r.source_ref == "tg:f5a_kw:post:5" for r in loose)
+        strict = await emb_repo.keyword_search(query="слово_beta", limit=10, min_rank=10.0)
+        assert all(r.source_ref != "tg:f5a_kw:post:5" for r in strict)
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_mixed_ru_en_corpus(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:6", "f5a_kw",
+                                     "Machine learning pipeline for anomaly detection",
+                                     summary="ML anomaly detection")
+        await self._insert_processed(test_db, "tg:f5a_kw:post:7", "f5a_kw",
+                                     "Обнаружение аномалий в данных с помощью машинного обучения",
+                                     summary="Аномалии в данных")
+        en = await emb_repo.keyword_search(query="anomaly detection", limit=10)
+        ru = await emb_repo.keyword_search(query="аномалий", limit=10)
+        en_refs = {r.source_ref for r in en}
+        ru_refs = {r.source_ref for r in ru}
+        assert "tg:f5a_kw:post:6" in en_refs
+        assert "tg:f5a_kw:post:7" in ru_refs
+        await self._cleanup(test_db)
+
+    async def test_keyword_search_entry_types_filter(self, test_db, emb_repo):
+        await self._cleanup(test_db)
+        await self._insert_processed(test_db, "tg:f5a_kw:post:8", "f5a_kw",
+                                     "редкое_gamma термин", summary=None)
+        await self._insert_topic(test_db, "f5a_kw_topic:t3",
+                                 title="редкое_gamma",
+                                 summary="про редкое_gamma", scope_in="[]")
+        only_msgs = await emb_repo.keyword_search(
+            query="редкое_gamma", limit=10, entry_types=["message"]
+        )
+        assert all(r.entry_type == "message" for r in only_msgs)
+        assert any(r.source_ref == "tg:f5a_kw:post:8" for r in only_msgs)
+        only_topics = await emb_repo.keyword_search(
+            query="редкое_gamma", limit=10, entry_types=["topic"]
+        )
+        assert all(r.entry_type == "topic" for r in only_topics)
+        await self._cleanup(test_db)
+
+
+# ---------------------------------------------------------------------------
+# 3. TestMigrationIdempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(_SKIP_PG, reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)")
+class TestMigrationIdempotency:
+    async def test_ensure_fts_columns_is_idempotent(self, test_db):
+        from tg_parser.storage.sqlalchemy.schemas.processing_storage import (
+            _ensure_fts_columns,
+            init_processing_storage_schema,
+        )
+
+        await init_processing_storage_schema(test_db.processing_storage_engine)
+        await _ensure_fts_columns(test_db.processing_storage_engine)
+        await _ensure_fts_columns(test_db.processing_storage_engine)
+        await _ensure_fts_columns(test_db.processing_storage_engine)
+
+    async def test_fts_gin_indexes_exist(self, test_db):
+        from sqlalchemy import text
+
+        from tg_parser.storage.sqlalchemy.schemas.processing_storage import (
+            init_processing_storage_schema,
+        )
+
+        await init_processing_storage_schema(test_db.processing_storage_engine)
+
+        async with test_db.processing_storage_engine.begin() as conn:
+            result = await conn.execute(text(
+                "SELECT indexname FROM pg_indexes "
+                "WHERE indexname IN ('idx_pd_search_vector', 'idx_tc_search_vector')"
+            ))
+            names = {row[0] for row in result.fetchall()}
+        assert "idx_pd_search_vector" in names
+        assert "idx_tc_search_vector" in names
+

--- a/tests/test_f5a_topic_rag.py
+++ b/tests/test_f5a_topic_rag.py
@@ -477,6 +477,7 @@ class TestHybridSearch:
 
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[msg_sim, topic_sim])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
 
         doc = ProcessedDocument(
             source_ref="tg:ch1:post:1",
@@ -523,6 +524,7 @@ class TestHybridSearch:
 
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
@@ -555,6 +557,7 @@ class TestHybridSearch:
         )
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[topic_sim])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
@@ -1171,6 +1174,7 @@ class TestHybridSearchEdge:
 
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[t1, t2])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
@@ -1209,6 +1213,7 @@ class TestHybridSearchEdge:
         ]
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=sims)
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(
             return_value={s.source_ref: Mock(channel_id="ch1") for s in sims}
@@ -1236,6 +1241,7 @@ class TestHybridSearchEdge:
 
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
 
@@ -1266,6 +1272,7 @@ class TestHybridSearchEdge:
         )
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[sim])
+        emb_repo.keyword_search = AsyncMock(return_value=[])
         proc_repo = AsyncMock()
         proc_repo.get_by_source_refs = AsyncMock(return_value={})
         topic_card_repo = AsyncMock()

--- a/tg_parser/api/routes/rag.py
+++ b/tg_parser/api/routes/rag.py
@@ -2,12 +2,16 @@
 RAG API routes (P5): search and Q&A endpoints.
 """
 
+from typing import Literal
+
 import structlog
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
 from tg_parser.api.auth import resolve_current_user
 from tg_parser.auth.models import CurrentUser
+
+SearchMode = Literal["semantic", "keyword", "hybrid"]
 
 router = APIRouter(prefix="/api/v1", tags=["RAG"])
 logger = structlog.get_logger(__name__)
@@ -17,14 +21,23 @@ logger = structlog.get_logger(__name__)
 
 
 class SearchRequest(BaseModel):
-    """Semantic search request."""
+    """Hybrid/semantic/keyword search request."""
 
     query: str = Field(description="Natural language search query")
     channel_id: str | None = Field(default=None, description="Optional channel filter")
     limit: int = Field(default=10, ge=1, le=100, description="Max results")
+    mode: SearchMode = Field(
+        default="hybrid",
+        description=(
+            "Retrieval mode: 'semantic' (pgvector cosine), 'keyword' (FTS ts_rank_cd), "
+            "or 'hybrid' (both via RRF)."
+        ),
+    )
 
     model_config = {
-        "json_schema_extra": {"examples": [{"query": "анализ крови норма", "limit": 5}]}
+        "json_schema_extra": {
+            "examples": [{"query": "анализ крови норма", "limit": 5, "mode": "hybrid"}]
+        }
     }
 
 
@@ -47,9 +60,17 @@ class AskRequest(BaseModel):
 
     question: str = Field(description="Question in natural language")
     channel_id: str | None = Field(default=None, description="Optional channel filter")
+    mode: SearchMode = Field(
+        default="hybrid",
+        description=(
+            "Retrieval mode forwarded to search: 'semantic', 'keyword', or 'hybrid'."
+        ),
+    )
 
     model_config = {
-        "json_schema_extra": {"examples": [{"question": "Когда назначают анализ СОЭ?"}]}
+        "json_schema_extra": {
+            "examples": [{"question": "Когда назначают анализ СОЭ?", "mode": "hybrid"}]
+        }
     }
 
 
@@ -69,13 +90,14 @@ async def search_documents(
     """Semantic search over embedded documents."""
     from tg_parser.services.retrieval_service import search
 
-    logger.info("rag_search", query=body.query[:80], channel_id=body.channel_id)
+    logger.info("rag_search", query=body.query[:80], channel_id=body.channel_id, mode=body.mode)
 
     results = await search(
         query=body.query,
         channel_id=body.channel_id,
         limit=body.limit,
         allowed_channel_ids=user.allowed_channel_ids,
+        mode=body.mode,
     )
 
     items = []
@@ -100,12 +122,13 @@ async def ask_question(
     """RAG Q&A: answer a question using retrieved context + LLM."""
     from tg_parser.services.retrieval_service import answer
 
-    logger.info("rag_ask", question=body.question[:80], channel_id=body.channel_id)
+    logger.info("rag_ask", question=body.question[:80], channel_id=body.channel_id, mode=body.mode)
 
     result = await answer(
         question=body.question,
         channel_id=body.channel_id,
         allowed_channel_ids=user.allowed_channel_ids,
+        mode=body.mode,
     )
 
     sources = [

--- a/tg_parser/api/routes/rag.py
+++ b/tg_parser/api/routes/rag.py
@@ -62,9 +62,7 @@ class AskRequest(BaseModel):
     channel_id: str | None = Field(default=None, description="Optional channel filter")
     mode: SearchMode = Field(
         default="hybrid",
-        description=(
-            "Retrieval mode forwarded to search: 'semantic', 'keyword', or 'hybrid'."
-        ),
+        description=("Retrieval mode forwarded to search: 'semantic', 'keyword', or 'hybrid'."),
     )
 
     model_config = {

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -470,6 +470,24 @@ class Settings(BaseSettings):
     )
 
     # ==========================================================================
+    # Hybrid Retrieval (F5-A Phase 1)
+    # ==========================================================================
+
+    hybrid_enabled: bool = Field(
+        default=True,
+        description="Enable hybrid (keyword FTS + semantic pgvector) retrieval",
+    )
+    hybrid_rrf_k: int = Field(
+        default=60,
+        description="Reciprocal Rank Fusion constant; higher values reduce discrimination between ranks",
+        ge=1,
+    )
+    fts_languages: str = Field(
+        default="russian,english",
+        description="Informational: FTS languages blended into the generated search_vector columns",
+    )
+
+    # ==========================================================================
     # Ollama Configuration
     # ==========================================================================
 

--- a/tg_parser/services/_ranking.py
+++ b/tg_parser/services/_ranking.py
@@ -1,0 +1,72 @@
+"""
+Ranking fusion utilities for hybrid retrieval (F5-A Phase 1).
+
+Reciprocal Rank Fusion (RRF) combines multiple ranked result lists
+(e.g. semantic pgvector + keyword FTS) into a single ranked list
+without requiring score normalization across heterogeneous metrics.
+
+Reference:
+    Cormack, G.V., Clarke, C.L.A., Buettcher, S.
+    "Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods"
+    SIGIR 2009.
+"""
+
+from collections.abc import Sequence
+
+from tg_parser.storage.ports import SimilarityResult
+
+
+def rrf_fuse(
+    *lists: Sequence[SimilarityResult],
+    k: int = 60,
+) -> list[SimilarityResult]:
+    """Fuse several ranked result lists via Reciprocal Rank Fusion.
+
+    For each list the rank is 1-indexed in the order received (lists are
+    assumed to be pre-sorted by their native relevance metric). Each
+    document contributes ``1 / (k + rank)`` to its RRF score; duplicates
+    across lists sum their contributions.
+
+    Args:
+        *lists: Variadic sequences of ``SimilarityResult``. Each list must
+            already be sorted (most relevant first). Empty lists are
+            tolerated and contribute nothing.
+        k: RRF constant. Larger k compresses the influence of high-rank
+            items; the canonical default is 60.
+
+    Returns:
+        Fused ``list[SimilarityResult]`` sorted by RRF score descending.
+        The ``score`` field is replaced with the RRF score (not the
+        original cosine / ts_rank). ``entry_type`` and ``topic_id`` come
+        from the first occurrence of each ``source_ref`` across input
+        lists (earlier lists win).
+    """
+    if k < 1:
+        raise ValueError("k must be >= 1")
+
+    accumulated: dict[str, float] = {}
+    first_seen: dict[str, SimilarityResult] = {}
+    insertion_order: dict[str, int] = {}
+
+    for result_list in lists:
+        for rank, item in enumerate(result_list, start=1):
+            contribution = 1.0 / (k + rank)
+            if item.source_ref in accumulated:
+                accumulated[item.source_ref] += contribution
+            else:
+                accumulated[item.source_ref] = contribution
+                first_seen[item.source_ref] = item
+                insertion_order[item.source_ref] = len(insertion_order)
+
+    fused = [
+        SimilarityResult(
+            source_ref=ref,
+            score=accumulated[ref],
+            entry_type=first_seen[ref].entry_type,
+            topic_id=first_seen[ref].topic_id,
+        )
+        for ref in insertion_order
+    ]
+
+    fused.sort(key=lambda r: (-r.score, insertion_order[r.source_ref]))
+    return fused

--- a/tg_parser/services/retrieval_service.py
+++ b/tg_parser/services/retrieval_service.py
@@ -6,17 +6,21 @@ Prompts are loaded from YAML via PromptLoader with fallback to built-in defaults
 LLM provider/model resolved via LLMConfigManager scope "rag".
 """
 
+import asyncio
 import contextlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import structlog
 
 from tg_parser.config import settings
 from tg_parser.domain.models import ProcessedDocument, TopicCard
+from tg_parser.services._ranking import rrf_fuse
 from tg_parser.services.db_context import embedding_repos, topic_embedding_repos
 from tg_parser.services.embedding_service import create_embedding_client
 from tg_parser.storage.ports import EmbeddingRepo, ProcessedDocumentRepo, TopicCardRepo
+
+SearchMode = Literal["semantic", "keyword", "hybrid"]
 
 if TYPE_CHECKING:
     from tg_parser.processing.ports import LLMClient
@@ -51,21 +55,27 @@ async def search(
     threshold: float = 0.0,
     include_topics: bool = True,
     allowed_channel_ids: list[str] | None = None,
+    mode: SearchMode = "hybrid",
     *,
     emb_repo: EmbeddingRepo | None = None,
     proc_repo: ProcessedDocumentRepo | None = None,
     topic_card_repo: TopicCardRepo | None = None,
 ) -> list[SearchResult]:
     """
-    Hybrid semantic search: embed query, find similar documents and topics via pgvector.
+    Hybrid retrieval over the processed corpus.
 
     Args:
         query: Natural language query
         channel_id: Optional single-channel filter
         limit: Max results to return
-        threshold: Minimum cosine similarity score
+        threshold: Minimum cosine similarity score (semantic path only)
         include_topics: Include topic embeddings in search (hybrid RAG)
         allowed_channel_ids: Tenant scoping — None=admin (all), []=no access, [ch1,...]=filter
+        mode: Retrieval strategy — ``"semantic"`` (pgvector cosine),
+            ``"keyword"`` (FTS ts_rank_cd), or ``"hybrid"`` (both via
+            Reciprocal Rank Fusion). Defaults to ``"hybrid"``. When the
+            global ``hybrid_enabled`` setting is False, ``"hybrid"`` is
+            silently downgraded to ``"semantic"``.
         emb_repo: Optional DI for EmbeddingRepo
         proc_repo: Optional DI for ProcessedDocumentRepo
         topic_card_repo: Optional DI for TopicCardRepo
@@ -90,14 +100,21 @@ async def search(
     else:
         effective_channel_ids = None
 
-    client = create_embedding_client()
-    try:
-        query_embeddings = await client.embed([query])
-        query_vec = query_embeddings[0]
-    finally:
-        await client.close()
+    effective_mode: SearchMode = mode
+    if effective_mode == "hybrid" and not settings.hybrid_enabled:
+        effective_mode = "semantic"
 
     entry_types = ["message", "topic"] if include_topics else ["message"]
+    fetch_limit = limit * 2 if channel_id else limit
+
+    query_vec: list[float] | None = None
+    if effective_mode in ("semantic", "hybrid"):
+        client = create_embedding_client()
+        try:
+            query_embeddings = await client.embed([query])
+            query_vec = query_embeddings[0]
+        finally:
+            await client.close()
 
     async with contextlib.AsyncExitStack() as stack:
         if emb_repo is None or proc_repo is None:
@@ -105,13 +122,37 @@ async def search(
         if topic_card_repo is None and include_topics:
             _emb2, topic_card_repo, _db2 = await stack.enter_async_context(topic_embedding_repos())
 
-        similar = await emb_repo.similarity_search(
-            query_vec,
-            limit=limit * 2 if channel_id else limit,
-            threshold=threshold,
-            entry_types=entry_types,
-            channel_ids=effective_channel_ids,
-        )
+        if effective_mode == "semantic":
+            similar = await emb_repo.similarity_search(
+                query_vec,
+                limit=fetch_limit,
+                threshold=threshold,
+                entry_types=entry_types,
+                channel_ids=effective_channel_ids,
+            )
+        elif effective_mode == "keyword":
+            similar = await emb_repo.keyword_search(
+                query,
+                limit=fetch_limit,
+                entry_types=entry_types,
+                channel_ids=effective_channel_ids,
+            )
+        else:
+            sem_task = emb_repo.similarity_search(
+                query_vec,
+                limit=fetch_limit,
+                threshold=threshold,
+                entry_types=entry_types,
+                channel_ids=effective_channel_ids,
+            )
+            kw_task = emb_repo.keyword_search(
+                query,
+                limit=fetch_limit,
+                entry_types=entry_types,
+                channel_ids=effective_channel_ids,
+            )
+            sem, kw = await asyncio.gather(sem_task, kw_task)
+            similar = rrf_fuse(sem, kw, k=settings.hybrid_rrf_k)[:fetch_limit]
 
         msg_refs = [s.source_ref for s in similar if s.entry_type == "message"]
         topic_ids = [s.topic_id for s in similar if s.entry_type == "topic" and s.topic_id]
@@ -205,6 +246,7 @@ async def answer(
     channel_id: str | None = None,
     limit: int = 5,
     allowed_channel_ids: list[str] | None = None,
+    mode: SearchMode = "hybrid",
     *,
     emb_repo: EmbeddingRepo | None = None,
     proc_repo: ProcessedDocumentRepo | None = None,
@@ -218,6 +260,7 @@ async def answer(
         channel_id: Optional channel filter
         limit: Number of context documents to retrieve
         allowed_channel_ids: Tenant scoping — None=admin (all)
+        mode: Retrieval strategy forwarded to ``search()``.
         emb_repo: Optional DI for EmbeddingRepo
         proc_repo: Optional DI for ProcessedDocumentRepo
         llm_client: Optional DI for LLMClient (if None, created via factory)
@@ -230,6 +273,7 @@ async def answer(
         channel_id=channel_id,
         limit=limit,
         allowed_channel_ids=allowed_channel_ids,
+        mode=mode,
         emb_repo=emb_repo,
         proc_repo=proc_repo,
     )

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -879,6 +879,38 @@ class EmbeddingRepo(ABC):
         pass
 
     @abstractmethod
+    async def keyword_search(
+        self,
+        query: str,
+        limit: int = 10,
+        entry_types: list[str] | None = None,
+        channel_ids: list[str] | None = None,
+        min_rank: float = 0.0,
+    ) -> list[SimilarityResult]:
+        """Full-text (FTS) search over processed_documents and topic_cards.
+
+        Implementation uses ``plainto_tsquery('simple', query)`` against the
+        STORED ``search_vector`` columns and ranks with ``ts_rank_cd``.
+        ``source_ref`` is the processed-document source ref for messages and
+        the topic id for topics (mirroring ``similarity_search``).
+
+        Args:
+            query: Natural-language query; tokenized via
+                ``plainto_tsquery('simple', ...)``.  Multi-language matching
+                is supported because the generated ``search_vector`` columns
+                blend simple + russian + english configurations.
+            limit: Max rows fetched from the UNION result.
+            entry_types: Post-fetch Python filter by ``entry_type`` (
+                ``"message"`` / ``"topic"``).  ``None`` means no filter.
+            channel_ids: SQL filter for ``processed_documents.channel_id``.
+                Topic-card channel filtering happens downstream in
+                ``retrieval_service`` via ``card.sources`` (Phase 1 does not
+                add a GIN index for ``topic_cards.channel_ids``).
+            min_rank: Python-side cutoff on the ``ts_rank_cd`` score.
+        """
+        pass
+
+    @abstractmethod
     async def count(self) -> int:
         """Return total number of stored embeddings."""
         pass

--- a/tg_parser/storage/sqlalchemy/embedding_repo.py
+++ b/tg_parser/storage/sqlalchemy/embedding_repo.py
@@ -172,6 +172,62 @@ class SAEmbeddingRepo(EmbeddingRepo):
             if float(r.score) >= threshold
         ]
 
+    async def keyword_search(
+        self,
+        query: str,
+        limit: int = 10,
+        entry_types: list[str] | None = None,
+        channel_ids: list[str] | None = None,
+        min_rank: float = 0.0,
+    ) -> list[SimilarityResult]:
+        """FTS search via ts_rank_cd over processed_documents + topic_cards."""
+        if not query or not query.strip():
+            return []
+
+        params: dict = {
+            "query": query,
+            "limit": limit,
+            "channel_ids": channel_ids,
+        }
+        sql = text("""
+            WITH q AS (SELECT plainto_tsquery('simple', :query) AS tsq)
+            SELECT source_ref,
+                   ts_rank_cd(search_vector, q.tsq) AS score,
+                   'message' AS entry_type,
+                   NULL::text AS topic_id
+            FROM processed_documents, q
+            WHERE search_vector @@ q.tsq
+              AND (
+                CAST(:channel_ids AS text[]) IS NULL
+                OR channel_id = ANY(CAST(:channel_ids AS text[]))
+              )
+            UNION ALL
+            SELECT id AS source_ref,
+                   ts_rank_cd(search_vector, q.tsq) AS score,
+                   'topic' AS entry_type,
+                   id AS topic_id
+            FROM topic_cards, q
+            WHERE search_vector @@ q.tsq
+            ORDER BY score DESC
+            LIMIT :limit
+        """)
+
+        result = await self.session.execute(sql, params)
+        rows = result.fetchall()
+
+        allowed_types = set(entry_types) if entry_types else None
+        return [
+            SimilarityResult(
+                source_ref=r.source_ref,
+                score=float(r.score),
+                entry_type=r.entry_type,
+                topic_id=r.topic_id,
+            )
+            for r in rows
+            if float(r.score) >= min_rank
+            and (allowed_types is None or r.entry_type in allowed_types)
+        ]
+
     async def count(self) -> int:
         result = await self.session.execute(text("SELECT count(*) FROM document_embeddings"))
         return result.scalar() or 0

--- a/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
+++ b/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
@@ -24,11 +24,17 @@ CREATE TABLE IF NOT EXISTS processed_documents (
   topics_json TEXT,
   entities_json TEXT,
   language TEXT,
-  metadata_json TEXT
+  metadata_json TEXT,
+  search_vector tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') ||
+    setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')
+  ) STORED
 );
 
 CREATE INDEX IF NOT EXISTS processed_documents_channel_idx ON processed_documents(channel_id);
 CREATE INDEX IF NOT EXISTS processed_documents_processed_at_idx ON processed_documents(processed_at);
+-- idx_pd_search_vector (GIN) is created by _ensure_fts_columns after ALTER for existing DBs
 
 -- Журнал неудачной обработки per-message (TR-47)
 CREATE TABLE IF NOT EXISTS processing_failures (
@@ -58,10 +64,16 @@ CREATE TABLE IF NOT EXISTS topic_cards (
   tags_json TEXT,
   related_topics_json TEXT,
   status TEXT,
-  metadata_json TEXT
+  metadata_json TEXT,
+  search_vector tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple',  coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')
+  ) STORED
 );
 
 CREATE INDEX IF NOT EXISTS topic_cards_updated_at_idx ON topic_cards(updated_at);
+-- idx_tc_search_vector (GIN) is created by _ensure_fts_columns after ALTER for existing DBs
 
 -- Таблица topic bundles (TR-43)
 CREATE TABLE IF NOT EXISTS topic_bundles (
@@ -322,6 +334,51 @@ async def _ensure_embedding_columns(engine: AsyncEngine) -> None:
         pass
 
 
+async def _ensure_fts_columns(engine: AsyncEngine) -> None:
+    """Add search_vector tsvector columns and GIN indexes for hybrid FTS.
+
+    Idempotent: safe to call on fresh DBs (columns already in CREATE TABLE),
+    on existing DBs that predate F5-A, and on repeat invocations.  Non-PG
+    engines (e.g. SQLite in legacy tests) are tolerated via exception
+    swallowing, matching the ``_ensure_embedding_columns`` pattern.
+    """
+    pd_ddl = (
+        "ALTER TABLE processed_documents ADD COLUMN IF NOT EXISTS search_vector "
+        "tsvector GENERATED ALWAYS AS ("
+        "setweight(to_tsvector('simple',  coalesce(summary, '')),    'A') || "
+        "setweight(to_tsvector('russian', coalesce(text_clean, '')), 'B') || "
+        "setweight(to_tsvector('english', coalesce(text_clean, '')), 'B')"
+        ") STORED"
+    )
+    tc_ddl = (
+        "ALTER TABLE topic_cards ADD COLUMN IF NOT EXISTS search_vector "
+        "tsvector GENERATED ALWAYS AS ("
+        "setweight(to_tsvector('simple',  coalesce(title, '')), 'A') || "
+        "setweight(to_tsvector('russian', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B') || "
+        "setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(scope_in_json, '')), 'B')"
+        ") STORED"
+    )
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(pd_ddl))
+            await conn.execute(text(tc_ddl))
+    except (ProgrammingError, OperationalError) as e:
+        logger.debug("FTS column creation skipped: %s", e)
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
+                "ON processed_documents USING GIN(search_vector)"
+            ))
+            await conn.execute(text(
+                "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
+                "ON topic_cards USING GIN(search_vector)"
+            ))
+    except (ProgrammingError, OperationalError) as e:
+        logger.debug("FTS index creation skipped: %s", e)
+
+
 async def init_processing_storage_schema(engine: AsyncEngine) -> None:
     """
     Создать таблицы для processing storage.
@@ -348,6 +405,8 @@ async def init_processing_storage_schema(engine: AsyncEngine) -> None:
             logger.debug("pgvector embedding DDL skipped: %s", e)
 
         await _ensure_embedding_columns(engine)
+
+    await _ensure_fts_columns(engine)
 
 
 async def init_embedding_index(engine: AsyncEngine) -> None:

--- a/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
+++ b/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
@@ -367,14 +367,18 @@ async def _ensure_fts_columns(engine: AsyncEngine) -> None:
 
     try:
         async with engine.begin() as conn:
-            await conn.execute(text(
-                "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
-                "ON processed_documents USING GIN(search_vector)"
-            ))
-            await conn.execute(text(
-                "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
-                "ON topic_cards USING GIN(search_vector)"
-            ))
+            await conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_pd_search_vector "
+                    "ON processed_documents USING GIN(search_vector)"
+                )
+            )
+            await conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_tc_search_vector "
+                    "ON topic_cards USING GIN(search_vector)"
+                )
+            )
     except (ProgrammingError, OperationalError) as e:
         logger.debug("FTS index creation skipped: %s", e)
 


### PR DESCRIPTION
## Summary

Implements **F5-A Phase 1: Hybrid Search** per `docs/plans/F5A_PERSISTENT_KB_PLAN.md` §3.

- **New retrieval mode `hybrid`** (now the default): runs keyword FTS and semantic pgvector search concurrently, then fuses via Reciprocal Rank Fusion (`k=60`).
- **Multilingual FTS** via one `search_vector tsvector GENERATED ALWAYS AS ... STORED` column per table (`processed_documents`, `topic_cards`), blending `simple`, `russian`, `english` analyzers with `setweight` boosting for titles/summaries. One GIN index per table.
- **API back-compat**: old callers get hybrid transparently; new optional `mode: "semantic" | "keyword" | "hybrid"` on `SearchRequest` / `AskRequest`. MCP pass-through deferred to Phase 2.
- **Kill-switch**: `HYBRID_ENABLED=false` silently downgrades `mode="hybrid"` to `"semantic"` at runtime.

## Changes by layer

- **Migrations** (`migrations/versions/processing/`): two idempotent Alembic revisions adding `search_vector` + GIN indexes.
- **Schema DDL** (`tg_parser/storage/sqlalchemy/schemas/processing_storage.py`): generated columns inlined into `CREATE TABLE` for fresh DBs; new idempotent `_ensure_fts_columns()` wired into `init_processing_storage_schema` so upgrades of existing DBs don't hit `UndefinedColumnError` on GIN creation (separate transactions for ALTER and CREATE INDEX).
- **Storage port + repo**: abstract `EmbeddingRepo.keyword_search()` (`tg_parser/storage/ports.py`) and concrete `SAEmbeddingRepo.keyword_search()` using `UNION ALL` of `processed_documents` and `topic_cards` with `ts_rank_cd` + `plainto_tsquery('simple', ...)`; Python-side filters for `entry_types` and `min_rank`.
- **Fusion module**: new `tg_parser/services/_ranking.py` with pure `rrf_fuse(*lists, k=60)` — aggregates duplicates, preserves first-seen `entry_type`/`topic_id`, stable ordering.
- **Service** (`tg_parser/services/retrieval_service.py`): `search()` and `answer()` accept `mode`; hybrid branch runs `asyncio.gather(similarity_search, keyword_search)` + `rrf_fuse`; embedding client is not instantiated in `keyword` mode (cost/perf win). All existing params (`channel_id`, `allowed_channel_ids`, `threshold`, `include_topics`, `limit`, `fetch_limit = 2·limit` with channel filter) preserved.
- **API** (`tg_parser/api/routes/rag.py`): `mode` field with Pydantic `Literal` validation; default `"hybrid"` on both endpoints.
- **Settings**: `HYBRID_ENABLED` (bool, default `true`), `HYBRID_RRF_K` (int ≥ 1, default `60`), `FTS_LANGUAGES` (informational).

## Testing

New file `tests/test_f5a_hybrid_search.py` (53 tests total):
- **`TestRRFFusion`** (13): empty inputs, 1-indexed ranks, duplicate aggregation, different `k`, invalid/negative `k`, input immutability, multi-list support, stable tie-breaking, preserved `entry_type`/`topic_id`.
- **`TestKeywordSearchRepo`** (8, pg-gated): FTS on processed_documents (RU), FTS on topic_cards, `UNION ALL` returns both entry types, `channel_ids` scoping, `min_rank` cutoff, mixed RU+EN corpus, `entry_types` filter, empty/whitespace query short-circuit.
- **`TestMigrationIdempotency`** (2, pg-gated): repeated `_ensure_fts_columns` is safe; GIN indexes exist after init.
- **`TestSearchModeSwitch`** (17): each mode calls only its repo(s); `hybrid_enabled=false` downgrades to semantic; default is hybrid; API rejects invalid mode and accepts all three; keyword mode skips embedding client creation; `include_topics=False` restricts `entry_types`; `channel_ids` / `threshold` / `fetch_limit` passthrough; hybrid score is RRF value (not original similarity); `answer()` forwards `mode`; `allowed_channel_ids=[]` short-circuits in all modes; `PermissionDenied` still raised in hybrid.
- **`TestHybridIntegration`** (4, pg-gated): dedup in fusion; rare-term-via-keyword dominance; empty corpus returns `[]`; results are `SimilarityResult` instances.
- **`TestSettings`** (3): defaults; env-var overrides; `HYBRID_RRF_K=0` rejected by validator.
- **Existing suites** patched defensively (`mock_emb_repo.keyword_search = AsyncMock(return_value=[])`) in `test_f4_scoped_access`, `test_f4_coverage_supplement`, `test_f4_vector_search_isolation`, `test_f5a_topic_rag`.

**Full suite** (`TEST_POSTGRES=1 pytest tests/ -q`): **1384 passed** (baseline on `main` was 1331 → +53), 1 deselected, exit 0, ~2:26.

## Documentation

- `docs/USER_GUIDE.md`: new "Hybrid Search" section — modes, multilingual FTS, env config, **explicit table-rewrite warning** for `ADD COLUMN GENERATED STORED` on large production DBs.
- `docs/MCP_AGENT_GUIDE.md`: notes that `search_knowledge_base` now uses hybrid by default; `mode` parameter pass-through through MCP is scoped for Phase 2.
- `ENV_VARIABLES_GUIDE.md`: entries for `HYBRID_ENABLED`, `HYBRID_RRF_K`, `FTS_LANGUAGES` + migration warning.
- `docs/plans/F5A_PERSISTENT_KB_PLAN.md`: Phase 1 acceptance criteria checked off; Phases 2/3 sketches untouched.

## Deployment notes

- The two Alembic revisions (`d4e5f6a7b8c9`, `e5f6a7b8c9d0`) use `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ... GENERATED ... STORED` + `CREATE INDEX IF NOT EXISTS`. **On large production tables this triggers a full rewrite** (documented in `USER_GUIDE.md` and `ENV_VARIABLES_GUIDE.md`). On small dev/staging DBs the migration is seconds.
- Rollback-safe: `DROP COLUMN search_vector` + `DROP INDEX idx_*_search_vector` would revert cleanly; old code paths still work as `semantic` when `HYBRID_ENABLED=false` (no FTS queries issued).
- No API contract break — existing clients keep working; they just start getting hybrid results by default.

## Test plan (reviewer)

- [ ] `TEST_POSTGRES=1 pytest tests/test_f5a_hybrid_search.py -v` — 53 pass.
- [ ] `TEST_POSTGRES=1 pytest tests/ -q` — full suite stays green (1384 pass).
- [ ] Apply Alembic migrations against a test DB; verify `search_vector` column + GIN indexes exist on both tables (`\d+ processed_documents`, `\d+ topic_cards`).
- [ ] Spot-check `POST /api/v1/search` with `{"query": "...", "mode": "keyword"}`, `"semantic"`, `"hybrid"` — all return results shaped consistently.
- [ ] Toggle `HYBRID_ENABLED=false` and confirm `mode="hybrid"` quietly downgrades to semantic (no FTS SQL in logs).

Made with [Cursor](https://cursor.com)