### PR TITLE
chore(lint): Stage 2 — remove F401 unused imports (89 fixes)

### DIFF
--- a/tests/test_agent_persistence.py
+++ b/tests/test_agent_persistence.py
@@ -11,7 +11,7 @@ Tests cover:
 """
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -39,7 +39,6 @@ from tg_parser.storage.ports import (
     TaskRecord,
 )
 from tg_parser.storage.sqlalchemy.agent_state_repo import SAAgentStateRepo
-from tg_parser.storage.sqlalchemy.agent_stats_repo import SAAgentStatsRepo
 from tg_parser.storage.sqlalchemy.handoff_history_repo import SAHandoffHistoryRepo
 from tg_parser.storage.sqlalchemy.task_history_repo import SATaskHistoryRepo
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -6,7 +6,7 @@ Session 14 Phase 2C: LLM-enhanced tools and provider support tests.
 """
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,10 +23,6 @@ from tg_parser.agents.tools.text_tools import (
     _basic_clean_text,
     _basic_extract_entities,
     _basic_extract_topics,
-    # Basic tools
-    clean_text,
-    extract_entities,
-    extract_topics,
 )
 from tg_parser.domain.models import RawTelegramMessage
 
@@ -383,7 +379,6 @@ def _call_clean_text(text: str) -> CleanTextResult:
     # But for testing, we'll call the logic directly
     import re
 
-    from tg_parser.agents.tools import text_tools
 
     if not text or not text.strip():
         return CleanTextResult(text_clean="", language="unknown")

--- a/tests/test_agents_observability.py
+++ b/tests/test_agents_observability.py
@@ -10,9 +10,7 @@ Tests cover:
 import gzip
 import json
 from datetime import UTC, datetime, timedelta
-from io import StringIO
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/test_agents_phase2e.py
+++ b/tests/test_agents_phase2e.py
@@ -5,7 +5,7 @@ Tests for pipeline tool, hybrid agent configuration, and CLI flags.
 """
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,7 +15,7 @@ from tg_parser.agents.tools.pipeline_tool import (
     _fallback_basic_processing,
     process_with_pipeline,
 )
-from tg_parser.agents.tools.text_tools import AgentContext, EntityItem
+from tg_parser.agents.tools.text_tools import AgentContext
 from tg_parser.domain.models import MessageType, RawTelegramMessage
 
 # ============================================================================

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from tg_parser.domain.models import (
     Anchor,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,13 +9,12 @@ Tests cover:
 """
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from tg_parser.api.main import create_app
-from tg_parser.api.schemas import JobStatus
 
 # ============================================================================
 # Fixtures

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -10,8 +10,6 @@ Tests cover:
 
 import hashlib
 import hmac
-import json
-from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/test_cross_channel_topicization.py
+++ b/tests/test_cross_channel_topicization.py
@@ -16,7 +16,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from tg_parser.domain.models import (
     Anchor,
@@ -25,7 +24,6 @@ from tg_parser.domain.models import (
     ProcessedDocument,
     TopicAssignment,
     TopicCard,
-    TopicLink,
     TopicType,
 )
 from tg_parser.processing.topicization_prompts import build_incremental_discover_prompt

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -8,7 +8,7 @@ Covers:
 """
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -9,7 +9,6 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
 
 from tg_parser.domain.models import (
     Anchor,

--- a/tests/test_f4_auth_resolution.py
+++ b/tests/test_f4_auth_resolution.py
@@ -75,7 +75,6 @@ class TestResolveUserByAuth:
         clear_cache()
 
     async def test_resolve_returns_none_when_not_found(self):
-        from tg_parser.storage.ports import User
 
         mock_repo = AsyncMock()
         mock_repo.resolve_auth = AsyncMock(return_value=None)
@@ -592,7 +591,6 @@ class TestResolveMcpUser:
 
     async def test_unknown_client_id_returns_admin(self):
         from tg_parser.mcp_server import resolve_mcp_user
-        from tg_parser.storage.ports import User
 
         mock_repo = AsyncMock()
         mock_repo.get_by_id = AsyncMock(return_value=None)

--- a/tests/test_f4_coverage_supplement.py
+++ b/tests/test_f4_coverage_supplement.py
@@ -375,9 +375,8 @@ class TestAPIPermissionDeniedHandler:
 
     def test_permission_denied_returns_403(self, client):
         """PermissionDenied raised inside a route → 403 with detail message."""
-        from fastapi import APIRouter, Depends
+        from fastapi import APIRouter
 
-        from tg_parser.api.auth import resolve_current_user
         from tg_parser.api.main import app
         from tg_parser.auth.ownership import PermissionDenied as PD
 

--- a/tests/test_f4_scoped_access.py
+++ b/tests/test_f4_scoped_access.py
@@ -4,7 +4,6 @@ Tests for F4 Multi-Tenancy Phase 4: Scoped Data Access.
 Unit tests (mock DB) for service-level and tool-level scoping.
 """
 
-from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_f4_vector_search_isolation.py
+++ b/tests/test_f4_vector_search_isolation.py
@@ -5,7 +5,6 @@ Tests SQL-level channel_ids filtering and IVFFlat probes behavior.
 Requires TEST_POSTGRES=1 for integration tests.
 """
 
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -184,7 +183,7 @@ class TestCrossChannelTopicEmbedding:
         from datetime import UTC, datetime
 
         from tg_parser.domain.models import Anchor, MessageType, TopicCard, TopicType
-        from tg_parser.services.retrieval_service import SearchResult, search
+        from tg_parser.services.retrieval_service import search
         from tg_parser.storage.ports import SimilarityResult
 
         mock_emb_repo = AsyncMock()

--- a/tests/test_f5a_topic_rag.py
+++ b/tests/test_f5a_topic_rag.py
@@ -10,9 +10,8 @@ Tests for F5-A: Persistent KB + Topic RAG.
 7. Edge cases
 """
 
-import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -476,7 +475,6 @@ class TestHybridSearch:
 
     async def test_search_messages_only(self):
         from tg_parser.services.retrieval_service import search
-        from tg_parser.storage.ports import SimilarityResult
 
         emb_repo = AsyncMock()
         emb_repo.similarity_search = AsyncMock(return_value=[])

--- a/tests/test_f8a_hardening.py
+++ b/tests/test_f8a_hardening.py
@@ -387,7 +387,7 @@ class TestGeminiRetry:
 
 class TestIngestionRateLimit:
     def _make_orchestrator(self, source=None):
-        from tg_parser.ingestion.orchestrator import IngestionOrchestrator, RetryableError
+        from tg_parser.ingestion.orchestrator import IngestionOrchestrator
 
         mock_settings = MagicMock()
         mock_settings.ingestion_max_attempts_per_run = 3
@@ -518,7 +518,6 @@ class TestIngestionRateLimit:
 class TestDBPoolMetrics:
     def test_register_pool_metrics_attaches_listeners(self):
         """_register_pool_metrics attaches checkout/checkin listeners to each pool."""
-        from unittest.mock import call
 
         from tg_parser.storage.sqlalchemy.database import Database
 

--- a/tests/test_gpt5_responses_api.py
+++ b/tests/test_gpt5_responses_api.py
@@ -8,10 +8,8 @@ Tests:
 - Response parsing from Responses API
 """
 
-import json
 from unittest.mock import AsyncMock, Mock, patch
 
-import httpx
 import pytest
 
 from tg_parser.processing.llm.openai_client import OpenAIClient

--- a/tests/test_incremental_topicization.py
+++ b/tests/test_incremental_topicization.py
@@ -1226,7 +1226,6 @@ class TestUncoveredDocsResolution:
     @pytest.mark.asyncio
     async def test_finds_correct_uncovered_docs(self):
         """Given 20 docs and 10 covered, uncovered_refs should have exactly 10."""
-        from tg_parser.domain.models import IncrementalTopicizeResult
 
         all_docs = [
             _make_doc(f"tg:labdiagnostica:post:{i}") for i in range(20)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -5,7 +5,7 @@ Covers stable_json_dumps, stable_json_loads, parse_iso_datetime,
 and the custom _json_default serializer.
 """
 
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,7 +8,6 @@ Tests:
 - Context vars binding
 """
 
-import json
 import logging
 from io import StringIO
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -10,7 +10,6 @@ Covers:
 
 from unittest.mock import patch
 
-import pytest
 from httpx import ASGITransport, AsyncClient
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP

--- a/tests/test_mcp_management.py
+++ b/tests/test_mcp_management.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from tg_parser.auth.models import CurrentUser
 from tg_parser.mcp_server import (

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from tg_parser.domain.models import (
     Anchor,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -6,7 +6,6 @@ Verifies that init_*_schema() functions create the expected tables
 on a live PostgreSQL test database.
 """
 
-import pytest
 from sqlalchemy import text
 
 from tg_parser.storage.sqlalchemy.schemas.ingestion_state import init_ingestion_state_schema

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -10,9 +10,6 @@ Tests for:
 - Workflow execution
 """
 
-from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4
 
 import pytest
 
@@ -25,7 +22,6 @@ from tg_parser.agents import (
     # Registry
     AgentRegistry,
     AgentType,
-    BaseAgent,
     ExportAgent,
     HandoffRequest,
     HandoffResponse,

--- a/tests/test_phase3d_advanced.py
+++ b/tests/test_phase3d_advanced.py
@@ -7,7 +7,6 @@ Tests for:
 - Background scheduler
 """
 
-from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,8 +35,6 @@ class TestPrometheusMetrics:
     def test_record_agent_task(self):
         """Test recording agent task metrics."""
         from tg_parser.api.metrics import (
-            AGENT_TASK_DURATION_SECONDS,
-            AGENT_TASKS_TOTAL,
             record_agent_task,
         )
 

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -13,7 +13,6 @@ from sqlalchemy import text
 
 from tg_parser.config.settings import Settings
 from tg_parser.storage.engine_factory import (
-    create_engine_from_config,
     create_engine_from_settings,
     create_postgres_engine_config,
     get_pool_status,

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -4,7 +4,6 @@
 
 from pathlib import Path
 
-import pytest
 
 from tg_parser.processing.prompt_loader import (
     PromptLoader,

--- a/tests/test_rag_prompt_config.py
+++ b/tests/test_rag_prompt_config.py
@@ -10,7 +10,6 @@ Tests for RAG & Prompt Config (Wave 1.5):
 
 import json
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -903,7 +902,7 @@ class TestGeminiAgentPromptLoading:
 
     def test_agent_reload_updates_prompt_from_loader(self):
         """After reloading the loader with a different value, agent picks it up."""
-        from tg_parser.bot.agent import GeminiAgent, _load_bot_system_prompt
+        from tg_parser.bot.agent import GeminiAgent
 
         agent = GeminiAgent(api_key="test-key")
         original = agent._system_prompt

--- a/tests/test_retrieval_llm_refactor.py
+++ b/tests/test_retrieval_llm_refactor.py
@@ -5,7 +5,6 @@ Updated for RAG & Prompt Config: system/user split, PromptLoader, scope 'rag'.
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
 
 
 class TestCallLlm:

--- a/tests/test_retry_settings.py
+++ b/tests/test_retry_settings.py
@@ -7,7 +7,6 @@ Tests:
 - Integration with pipeline retry logic
 """
 
-import os
 
 import pytest
 from pydantic import ValidationError
@@ -117,7 +116,7 @@ def test_retry_settings_jitter_validation():
 @pytest.mark.asyncio
 async def test_retry_settings_integration_with_pipeline():
     """Test that pipeline uses retry_settings for retry logic."""
-    from unittest.mock import AsyncMock, Mock, patch
+    from unittest.mock import AsyncMock, Mock
 
     from tg_parser.config import retry_settings
     from tg_parser.domain.models import RawTelegramMessage

--- a/tests/test_topicization.py
+++ b/tests/test_topicization.py
@@ -8,7 +8,6 @@ import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 
 from tg_parser.domain.models import (
     Anchor,

--- a/tg_parser/agents/orchestrator.py
+++ b/tg_parser/agents/orchestrator.py
@@ -19,7 +19,6 @@ from tg_parser.agents.base import (
     AgentType,
     BaseAgent,
     HandoffRequest,
-    HandoffResponse,
     HandoffStatus,
 )
 from tg_parser.agents.registry import AgentRegistry, get_registry

--- a/tg_parser/agents/persistence.py
+++ b/tg_parser/agents/persistence.py
@@ -20,7 +20,7 @@ from tg_parser.storage.ports import (
     TaskRecord,
 )
 
-from .base import AgentMetadata, BaseAgent, HandoffRequest, HandoffResponse
+from .base import BaseAgent, HandoffRequest, HandoffResponse
 
 logger = structlog.get_logger(__name__)
 

--- a/tg_parser/agents/processing_agent.py
+++ b/tg_parser/agents/processing_agent.py
@@ -12,10 +12,9 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from agents import Agent, Runner, function_tool, set_tracing_disabled
+from agents import Agent, Runner, set_tracing_disabled
 from pydantic import BaseModel, Field
 
-from tg_parser.config import settings
 from tg_parser.domain.ids import make_processed_document_id
 from tg_parser.domain.models import Entity, ProcessedDocument, RawTelegramMessage
 
@@ -25,17 +24,13 @@ from .tools.text_tools import (
     CleanTextResult,
     DeepAnalysisResult,
     EntitiesResult,
-    EntityItem,
-    ProcessingResult,
     TopicsResult,
     # LLM-enhanced tools
     analyze_text_deep,
     # Basic tools
     clean_text,
     extract_entities,
-    extract_entities_llm,
     extract_topics,
-    extract_topics_llm,
 )
 
 logger = structlog.get_logger(__name__)

--- a/tg_parser/api/routes/export.py
+++ b/tg_parser/api/routes/export.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse
 from sqlalchemy.exc import SQLAlchemyError
 
-from tg_parser.api.auth import resolve_current_user, verify_api_key
+from tg_parser.api.auth import resolve_current_user
 from tg_parser.api.job_store import ensure_job_store_initialized
 from tg_parser.api.middleware import limiter
 from tg_parser.api.schemas import (

--- a/tg_parser/api/routes/process.py
+++ b/tg_parser/api/routes/process.py
@@ -12,7 +12,7 @@ import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy.exc import SQLAlchemyError
 
-from tg_parser.api.auth import resolve_current_user, verify_api_key
+from tg_parser.api.auth import resolve_current_user, verify_api_key  # noqa: F401  # verify_api_key is patched by tests/test_api_security.py via mock.patch path
 from tg_parser.api.job_store import ensure_job_store_initialized
 from tg_parser.api.middleware import limiter
 from tg_parser.api.schemas import (

--- a/tg_parser/api/routes/users.py
+++ b/tg_parser/api/routes/users.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from tg_parser.api.auth import resolve_current_user
 from tg_parser.auth.models import CurrentUser
-from tg_parser.auth.ownership import PermissionDenied, assert_admin
+from tg_parser.auth.ownership import assert_admin
 
 router = APIRouter(prefix="/api/v1/users", tags=["Users"])
 logger = structlog.get_logger(__name__)

--- a/tg_parser/cli/agents_cmd.py
+++ b/tg_parser/cli/agents_cmd.py
@@ -6,7 +6,6 @@ Phase 3C: Agent monitoring and cleanup commands.
 
 import asyncio
 from datetime import UTC, datetime
-from typing import Optional
 
 import structlog
 import typer

--- a/tg_parser/cli/api_cmd.py
+++ b/tg_parser/cli/api_cmd.py
@@ -2,7 +2,6 @@
 CLI command to run the HTTP API server.
 """
 
-from typing import Optional
 
 import structlog
 

--- a/tg_parser/cli/app.py
+++ b/tg_parser/cli/app.py
@@ -332,7 +332,6 @@ def topicize(
       --no-cross-channel Disable cross-channel features (per-channel only).
       (omit)             Use CROSS_CHANNEL_TOPICIZATION setting (default: True).
     """
-    import asyncio
 
     if mode not in ("auto", "full", "incremental", "assign-only"):
         typer.echo(

--- a/tg_parser/services/retrieval_service.py
+++ b/tg_parser/services/retrieval_service.py
@@ -7,7 +7,7 @@ LLM provider/model resolved via LLMConfigManager scope "rag".
 """
 
 import contextlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import structlog

--- a/tg_parser/services/topic_linking_service.py
+++ b/tg_parser/services/topic_linking_service.py
@@ -20,7 +20,6 @@ import structlog
 from tg_parser.domain.models import TopicCard, TopicLink
 from tg_parser.services.analytics_service import _extract_keywords
 from tg_parser.services.db_context import topic_linking_repos
-from tg_parser.storage.ports import TopicLinkRepo
 
 logger = structlog.get_logger(__name__)
 

--- a/tg_parser/services/topicization_service.py
+++ b/tg_parser/services/topicization_service.py
@@ -10,7 +10,6 @@ Session 48: Phase 2 Enhancement + Phase 3 — cross-channel topicization.
 """
 
 import contextlib
-import math
 from collections import defaultdict
 from datetime import UTC, datetime
 

--- a/tg_parser/storage/engine_factory.py
+++ b/tg_parser/storage/engine_factory.py
@@ -8,7 +8,6 @@ from typing import Literal
 
 import structlog
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.pool import QueuePool
 
 from tg_parser.config.settings import Settings
 

--- a/tg_parser/storage/sqlalchemy/agent_state_repo.py
+++ b/tg_parser/storage/sqlalchemy/agent_state_repo.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_parser.storage.ports import AgentState, AgentStateRepo
 

--- a/tg_parser/storage/sqlalchemy/agent_stats_repo.py
+++ b/tg_parser/storage/sqlalchemy/agent_stats_repo.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_parser.storage.ports import AgentDailyStats, AgentStatsRepo
 

--- a/tg_parser/storage/sqlalchemy/handoff_history_repo.py
+++ b/tg_parser/storage/sqlalchemy/handoff_history_repo.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_parser.storage.ports import HandoffHistoryRepo, HandoffRecord
 

--- a/tg_parser/storage/sqlalchemy/job_repo.py
+++ b/tg_parser/storage/sqlalchemy/job_repo.py
@@ -5,11 +5,10 @@ Phase 2F: Persistent Job Storage.
 """
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_parser.storage.ports import Job, JobRepo, JobStatus, JobType
 

--- a/tg_parser/storage/sqlalchemy/task_history_repo.py
+++ b/tg_parser/storage/sqlalchemy/task_history_repo.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from tg_parser.storage.ports import TaskHistoryRepo, TaskRecord
 

--- a/tg_parser/storage/sqlalchemy/user_repo.py
+++ b/tg_parser/storage/sqlalchemy/user_repo.py
@@ -2,7 +2,6 @@
 SQLAlchemy implementation of UserRepo (F4 Multi-Tenancy).
 """
 
-from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import text


### PR DESCRIPTION
## Summary

Stage 2 of 3 in lint-debt cleanup before F5-A Phase 1 merge.

Removes **89 of 90** unused imports via `ruff --select F401 --fix` across 51 files.

### Excluded import (1)

- `tg_parser/api/routes/process.py:verify_api_key` — kept with `# noqa: F401`.
  Reason: `tests/test_api_security.py` patches it via `mock.patch("tg_parser.api.routes.process.verify_api_key")`. Removing the import would break the dynamic patch path even though the symbol has no static reference.

### Audit performed

Searched the codebase for dynamic patterns that could reference removed imports:
- `mock.patch("tg_parser...")` — only `verify_api_key` flagged (handled above).
- `getattr(...)` with target symbols — no matches.

## Test plan

- [x] `pytest tests/ -x -q` → 1273 passed, 58 skipped, 0 failed
- [x] No regressions introduced
- [ ] CI may still fail due to remaining ~245 errors (W293/W291 leftovers + F841/F821/B-series); Stage 3 will address

## Stages roadmap

- ✅ **Stage 1 (PR #4):** Safe auto-fix — 2078 cosmetic fixes (merged)
- ✅ **Stage 2 (this PR):** F401 unused-imports — 89 fixes
- 🟡 **Stage 3:** F841/F821/E402/B-series — manual cleanup (~70)

Made with [Cursor](https://cursor.com)