### PR TITLE
chore(lint): Stage 3 — final cleanup, ruff at 0 errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,9 @@ load_dotenv()
 _TEST_DB_NAME = os.environ.get("TEST_DB_NAME", "tg_parser_test")
 os.environ["DB_NAME"] = _TEST_DB_NAME
 
-from tg_parser.config.settings import Settings
-from tg_parser.domain.models import MessageType, RawTelegramMessage
-from tg_parser.storage.sqlalchemy import Database
+from tg_parser.config.settings import Settings  # noqa: E402  # must follow os.environ override
+from tg_parser.domain.models import MessageType, RawTelegramMessage  # noqa: E402
+from tg_parser.storage.sqlalchemy import Database  # noqa: E402
 
 # ============================================================================
 # Database Fixtures
@@ -184,7 +184,7 @@ def mock_telethon_client():
 async def cleanup_job_store():
     """
     Автоматически очищает JobStore и Database singleton после каждого теста.
-    
+
     Предотвращает зависание из-за незакрытых SQLite соединений
     и утечку состояния Database singleton между тестами.
     """
@@ -206,7 +206,7 @@ async def cleanup_job_store():
 def disable_metrics_for_tests():
     """
     Disable Prometheus metrics for tests to prevent registry conflicts.
-    
+
     Prometheus registry is global, and multiple app creations cause
     'Duplicated timeseries' errors.
     """

--- a/tests/test_agent_persistence.py
+++ b/tests/test_agent_persistence.py
@@ -3,7 +3,7 @@ Tests for Agent State Persistence (Phase 3B).
 
 Tests cover:
 - AgentStateRepo
-- TaskHistoryRepo  
+- TaskHistoryRepo
 - AgentStatsRepo
 - HandoffHistoryRepo
 - AgentPersistence integration

--- a/tests/test_agents_observability.py
+++ b/tests/test_agents_observability.py
@@ -578,7 +578,7 @@ class TestAgentsObservabilityE2E:
     async def test_full_cli_workflow(self, persistence_with_data, tmp_path):
         """
         Test full CLI workflow: list agents -> status -> history -> cleanup.
-        
+
         This E2E test verifies the complete CLI agent observability workflow
         with a real database.
         """
@@ -654,7 +654,7 @@ class TestAgentsObservabilityE2E:
     async def test_full_api_workflow(self, persistence_with_data):
         """
         Test full API workflow with TestClient.
-        
+
         This E2E test verifies the complete API workflow:
         - GET /api/v1/agents - list agents
         - GET /api/v1/agents/{name} - get specific agent

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from tg_parser.domain.models import (
     Anchor,
     BundleItem,

--- a/tests/test_cross_channel_topicization.py
+++ b/tests/test_cross_channel_topicization.py
@@ -16,7 +16,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from tg_parser.domain.models import (
     Anchor,
     IncrementalTopicizeResult,
@@ -277,7 +276,7 @@ class TestRunCrossChannelLinking:
         assert count >= 1
         topic_link_repo.upsert_batch.assert_called_once()
         saved_links = topic_link_repo.upsert_batch.call_args[0][0]
-        link_pairs = {(l.topic_id_a, l.topic_id_b) for l in saved_links}
+        link_pairs = {(link.topic_id_a, link.topic_id_b) for link in saved_links}
         assert ("t:own", "t:other") in link_pairs
 
     async def test_no_links_when_no_other_channels(self):
@@ -559,7 +558,7 @@ class TestRunIncrementalTopicizationOrchestration:
                 mock_settings.cross_channel_link_threshold = 0.3
                 mock_settings.topicization_batch_size = 50
 
-                result = await run_incremental_topicization(
+                await run_incremental_topicization(
                     channel_id="ch1",
                     new_doc_refs=doc_refs,
                     cross_channel=None,

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -1048,7 +1048,7 @@ async def test_run_command_error_handling(
 
     async def _failing_get_messages(*_args, **_kwargs):
         raise RuntimeError("Mock Telegram API error")
-        yield  # noqa: makes this an async generator for `async for`
+        yield  # noqa: B901  # makes this an async generator for `async for`
 
     mock_client.get_messages = _failing_get_messages
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -9,7 +9,6 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
-
 from tg_parser.domain.models import (
     Anchor,
     BundleItem,

--- a/tests/test_f4_scoped_access.py
+++ b/tests/test_f4_scoped_access.py
@@ -100,7 +100,7 @@ class TestAnswerScoping:
         mock_search.return_value = []
 
         from tg_parser.services.retrieval_service import answer
-        result = await answer(
+        await answer(
             question="test question",
             allowed_channel_ids=["ch1"],
         )

--- a/tests/test_f5a_topic_rag.py
+++ b/tests/test_f5a_topic_rag.py
@@ -634,7 +634,7 @@ class TestPipelineTopicEmbeddingHook:
             "embedded_count": 2, "skipped_count": 0, "total_count": 2,
         })) as mock_topic_emb:
             from tg_parser.services.pipeline_service import run_full_pipeline
-            stats = await run_full_pipeline(
+            await run_full_pipeline(
                 source_id="src1",
                 output_dir="/tmp/test",
             )

--- a/tests/test_incremental_topicization.py
+++ b/tests/test_incremental_topicization.py
@@ -887,7 +887,7 @@ class TestFullIncrementalFlowPhase1PlusPhase2:
             pipeline1.assign_documents_to_topics(docs, "labdiagnostica")
         )
 
-        phase1_assigned_refs = {a.source_ref for a in assignments}
+        {a.source_ref for a in assignments}
         assert len(assignments) >= 2  # at least 2 strong matches
 
         # Phase 2: mock LLM for unassigned
@@ -1280,7 +1280,7 @@ class TestCLIModeDispatch:
             from tg_parser.cli.app import app
 
             runner = CliRunner()
-            result = runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "full"])
+            runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "full"])
 
             mock_full.assert_called_once_with("test_ch", force=False, no_bundles=False)
             mock_incr.assert_not_called()
@@ -1299,7 +1299,7 @@ class TestCLIModeDispatch:
             from tg_parser.cli.app import app
 
             runner = CliRunner()
-            result = runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "incremental"])
+            runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "incremental"])
 
             mock_full.assert_not_called()
             mock_incr.assert_called_once_with("test_ch", cross_channel=None)
@@ -1318,7 +1318,7 @@ class TestCLIModeDispatch:
             from tg_parser.cli.app import app
 
             runner = CliRunner()
-            result = runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "assign-only"])
+            runner.invoke(app, ["topicize", "--channel", "test_ch", "--mode", "assign-only"])
 
             mock_full.assert_not_called()
             mock_incr.assert_not_called()
@@ -1336,7 +1336,7 @@ class TestCLIModeDispatch:
             from tg_parser.cli.app import app
 
             runner = CliRunner()
-            result = runner.invoke(app, ["topicize", "--channel", "test_ch", "--force"])
+            runner.invoke(app, ["topicize", "--channel", "test_ch", "--force"])
 
             mock_full.assert_called_once_with("test_ch", force=True, no_bundles=False)
             mock_incr.assert_not_called()

--- a/tests/test_job_storage.py
+++ b/tests/test_job_storage.py
@@ -224,7 +224,7 @@ class TestJobStore:
     async def test_list_jobs(self, job_store):
         """JobStore lists jobs."""
         # Create some jobs
-        for i in range(3):
+        for _ in range(3):
             job = Job(
                 job_id=f"test-list-{uuid.uuid4()}",
                 job_type=JobType.PROCESSING,

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -24,13 +24,13 @@ from tg_parser.mcp_server import BearerTokenVerifier, create_mcp_server
 
 def _make_test_server(*, auth: bool = False) -> FastMCP:
     """Create a minimal FastMCP for HTTP tests (no DB lifespan)."""
-    kwargs: dict = dict(
-        name="test-server",
-        host="127.0.0.1",
-        port=9999,
-        stateless_http=True,
-        json_response=True,
-    )
+    kwargs: dict = {
+        "name": "test-server",
+        "host": "127.0.0.1",
+        "port": 9999,
+        "stateless_http": True,
+        "json_response": True,
+    }
     if auth:
         kwargs["token_verifier"] = BearerTokenVerifier({"tok-valid": "test-client"})
         kwargs["auth"] = AuthSettings(

--- a/tests/test_mcp_management.py
+++ b/tests/test_mcp_management.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from tg_parser.auth.models import CurrentUser
 from tg_parser.mcp_server import (
     AddChannelResult,
@@ -593,7 +592,7 @@ class TestGetAllChannelStats:
         from tg_parser.services.channel_service import get_all_channel_stats
 
         sources = [_make_source(channel_id="ch")]
-        mock_ctx = _mock_stats_repos(sources=sources)
+        _mock_stats_repos(sources=sources)
 
         state_repo = AsyncMock()
         raw_repo = AsyncMock()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 from tg_parser.domain.models import (
     Anchor,
     BundleItem,
@@ -455,8 +454,8 @@ class TestGetDocumentTool:
 # S1: MCP logging configuration
 # ===========================================================================
 
-import io
-import sys
+import io  # noqa: E402  # section-local imports for TestMcpLogging
+import sys  # noqa: E402
 
 
 class TestMcpLogging:

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -829,7 +829,7 @@ class TestMultiAgentE2E:
     async def test_multi_agent_e2e_workflow(self, e2e_registry_with_persistence):
         """
         E2E test for multi-agent workflow with full pipeline:
-        
+
         1. Create and register agents
         2. Initialize orchestrator workflow
         3. Execute handoff between agents
@@ -943,8 +943,8 @@ class TestMultiAgentE2E:
     async def test_multi_agent_workflow_execution(self, e2e_registry_with_persistence):
         """
         E2E test for workflow execution through orchestrator.
-        
-        Tests the complete workflow: 
+
+        Tests the complete workflow:
         - Orchestrator routes to specialized agents
         - Each agent processes its step
         - Results are aggregated
@@ -1009,7 +1009,7 @@ class TestMultiAgentE2E:
     async def test_multi_agent_registry_persistence_sync(self, e2e_registry_with_persistence):
         """
         E2E test for registry-persistence synchronization.
-        
+
         Verifies that:
         - Agent registration triggers persistence save
         - Agent unregistration updates persistence

--- a/tests/test_phase3d_advanced.py
+++ b/tests/test_phase3d_advanced.py
@@ -115,7 +115,7 @@ class TestHealthChecks:
 
         with (
             patch("tg_parser.api.health_checks.settings") as mock_settings,
-            patch("tg_parser.storage.sqlalchemy.Database.get_instance", return_value=mock_db) as mock_db_cls,
+            patch("tg_parser.storage.sqlalchemy.Database.get_instance", return_value=mock_db),
         ):
             mock_settings.db_host = "nonexistent-host-12345"
             mock_settings.db_port = 5432

--- a/tests/test_postgres_concurrency.py
+++ b/tests/test_postgres_concurrency.py
@@ -166,7 +166,7 @@ class TestConcurrentWrites:
 
         try:
             # Initial pool status
-            initial_status = get_pool_status(engine)
+            get_pool_status(engine)
 
             # Run many concurrent queries
             workers = 20
@@ -232,7 +232,7 @@ class TestPoolStress:
                 conns.append(conn)
 
             # Try to get one more (should timeout or fail)
-            with pytest.raises(Exception):
+            with pytest.raises(Exception):  # noqa: B017  # backend-specific: TimeoutError or asyncpg.PoolError
                 async with engine.connect() as conn:
                     await conn.execute(text("SELECT 1"))
 

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -234,13 +234,15 @@ class TestPostgresSettings:
 
     def test_pool_size_validation(self):
         """Pool size should be validated."""
+        from pydantic import ValidationError
+
         settings = Settings(db_pool_size=10)
         assert settings.db_pool_size == 10
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             Settings(db_pool_size=0)
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             Settings(db_pool_size=100)
 
 

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -4,7 +4,6 @@
 
 from pathlib import Path
 
-
 from tg_parser.processing.prompt_loader import (
     PromptLoader,
     get_prompt_loader,

--- a/tests/test_rag_prompt_config.py
+++ b/tests/test_rag_prompt_config.py
@@ -1029,7 +1029,7 @@ class TestTopicizationPromptLoaderWiring:
             mock_loader.load.return_value = custom_config
             mock_get_loader.return_value = mock_loader
 
-            groups = await pipeline._merge_topics(topics, topics)
+            await pipeline._merge_topics(topics, topics)
 
         mock_loader.load.assert_called_with("merge")
         call_kwargs = mock_llm.generate_with_usage.call_args.kwargs
@@ -1066,7 +1066,7 @@ class TestTopicizationPromptLoaderWiring:
             mock_loader.load.return_value = config_no_template
             mock_get_loader.return_value = mock_loader
 
-            groups = await pipeline._merge_topics(topics, topics)
+            await pipeline._merge_topics(topics, topics)
 
         call_kwargs = mock_llm.generate_with_usage.call_args.kwargs
         assert "You have 2 topics" in call_kwargs["prompt"]
@@ -1243,7 +1243,7 @@ class TestGenerateTopicsBatchPromptLoader:
             mock_loader.load.return_value = config_with_model
             mock_get_loader.return_value = mock_loader
 
-            result = await pipeline._generate_topics_batch(candidates)
+            await pipeline._generate_topics_batch(candidates)
 
         call_kwargs = mock_llm.generate_with_usage.call_args.kwargs
         assert call_kwargs["temperature"] == 0.3

--- a/tests/test_retrieval_llm_refactor.py
+++ b/tests/test_retrieval_llm_refactor.py
@@ -6,7 +6,6 @@ Updated for RAG & Prompt Config: system/user split, PromptLoader, scope 'rag'.
 from unittest.mock import AsyncMock, patch
 
 
-
 class TestCallLlm:
     """_call_llm() uses LLMClient via DI or factory."""
 

--- a/tests/test_topic_linking_service.py
+++ b/tests/test_topic_linking_service.py
@@ -130,7 +130,7 @@ class TestLinkTopics:
 
         emb1 = _make_embedding("tg:ch1:post:1", [1.0, 0.0, 0.0])
         emb2 = _make_embedding("tg:ch2:post:1", [0.9, 0.1, 0.0])
-        emb3 = _make_embedding("tg:ch2:post:1", [0.0, 0.0, 1.0])
+        _make_embedding("tg:ch2:post:1", [0.0, 0.0, 1.0])
 
         topic_card_repo = AsyncMock()
         topic_card_repo.list_all.return_value = cards
@@ -172,7 +172,7 @@ class TestLinkTopics:
         topic_link_repo.upsert_batch.assert_called_once()
         saved_links = topic_link_repo.upsert_batch.call_args[0][0]
         assert len(saved_links) >= 1
-        assert all(isinstance(l, TopicLink) for l in saved_links)
+        assert all(isinstance(link, TopicLink) for link in saved_links)
 
     async def test_no_links_for_single_channel(self):
         cards = [

--- a/tests/test_topicization.py
+++ b/tests/test_topicization.py
@@ -8,7 +8,6 @@ import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
-
 from tg_parser.domain.models import (
     Anchor,
     BundleItemRole,

--- a/tg_parser/agents/archiver.py
+++ b/tg_parser/agents/archiver.py
@@ -38,7 +38,7 @@ def _record_to_dict(record: TaskRecord | HandoffRecord) -> dict[str, Any]:
 class AgentHistoryArchiver:
     """
     Archives expired agent history to compressed NDJSON files.
-    
+
     Features:
     - Archives task history records
     - Optionally archives handoff history
@@ -49,7 +49,7 @@ class AgentHistoryArchiver:
     def __init__(self, archive_path: Path):
         """
         Initialize archiver.
-        
+
         Args:
             archive_path: Base directory for archives
         """
@@ -67,10 +67,10 @@ class AgentHistoryArchiver:
     ) -> Path | None:
         """
         Archive task history records to NDJSON.gz file.
-        
+
         Args:
             records: List of TaskRecord to archive
-            
+
         Returns:
             Path to created archive file, or None if no records
         """
@@ -100,10 +100,10 @@ class AgentHistoryArchiver:
     ) -> Path | None:
         """
         Archive handoff history records to NDJSON.gz file.
-        
+
         Args:
             records: List of HandoffRecord to archive
-            
+
         Returns:
             Path to created archive file, or None if no records
         """
@@ -134,11 +134,11 @@ class AgentHistoryArchiver:
     ) -> dict[str, Path | None]:
         """
         Archive both task and handoff history.
-        
+
         Args:
             task_records: List of TaskRecord to archive
             handoff_records: Optional list of HandoffRecord to archive
-            
+
         Returns:
             Dictionary with paths to created files
         """
@@ -155,7 +155,7 @@ class AgentHistoryArchiver:
     def list_archives(self) -> list[dict[str, Any]]:
         """
         List all archive files.
-        
+
         Returns:
             List of archive info dictionaries
         """

--- a/tg_parser/agents/base.py
+++ b/tg_parser/agents/base.py
@@ -148,10 +148,10 @@ class AgentOutput(BaseModel):
 # ============================================================================
 
 
-class BaseAgent(ABC, Generic[InputT, OutputT]):
+class BaseAgent(ABC, Generic[InputT, OutputT]):  # noqa: UP046  # PEP 695 migration deferred — affects subclass hierarchy
     """
     Abstract base class for all agents in the system.
-    
+
     Defines the common interface that all agents must implement.
     Supports the A + C hybrid architecture pattern.
     """
@@ -159,7 +159,7 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     def __init__(self, metadata: AgentMetadata):
         """
         Initialize the agent with metadata.
-        
+
         Args:
             metadata: Agent metadata describing capabilities
         """
@@ -195,7 +195,7 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     async def initialize(self) -> None:
         """
         Initialize the agent.
-        
+
         Called once before the agent starts processing.
         Should set up any required resources.
         """
@@ -205,10 +205,10 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     async def process(self, input_data: InputT) -> OutputT:
         """
         Process input and produce output.
-        
+
         Args:
             input_data: Input data to process
-            
+
         Returns:
             Processed output
         """
@@ -218,7 +218,7 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     async def shutdown(self) -> None:
         """
         Shutdown the agent.
-        
+
         Called when the agent is being stopped.
         Should clean up any resources.
         """
@@ -227,7 +227,7 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     async def health_check(self) -> bool:
         """
         Check if the agent is healthy.
-        
+
         Returns:
             True if agent is ready to process, False otherwise
         """
@@ -236,13 +236,13 @@ class BaseAgent(ABC, Generic[InputT, OutputT]):
     async def handle_handoff(self, request: HandoffRequest) -> HandoffResponse:
         """
         Handle a handoff request from another agent.
-        
+
         Default implementation accepts and processes the handoff.
         Subclasses can override for custom behavior.
-        
+
         Args:
             request: Handoff request
-            
+
         Returns:
             Handoff response with result
         """

--- a/tg_parser/agents/orchestrator.py
+++ b/tg_parser/agents/orchestrator.py
@@ -46,7 +46,7 @@ class WorkflowStep:
     ):
         """
         Initialize a workflow step.
-        
+
         Args:
             name: Step name for identification
             agent_name: Specific agent to use (optional)
@@ -76,7 +76,7 @@ class Workflow:
     ):
         """
         Initialize a workflow.
-        
+
         Args:
             name: Workflow name
             steps: List of workflow steps in order
@@ -129,7 +129,7 @@ PROCESSING_WORKFLOW = Workflow(
 class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     """
     Orchestrator agent that coordinates multi-agent workflows.
-    
+
     Responsibilities:
     - Route tasks to appropriate specialized agents
     - Manage handoffs between agents
@@ -147,7 +147,7 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ):
         """
         Initialize the orchestrator.
-        
+
         Args:
             registry: Agent registry (uses global if not provided)
             model: LLM model for decision making
@@ -198,22 +198,22 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     async def process(self, input_data: AgentInput) -> AgentOutput:
         """
         Process an orchestration request.
-        
+
         Expected input format:
         {
             "workflow": "processing",  # Workflow name
             "data": {...},             # Initial data
         }
-        
+
         Or for direct routing:
         {
             "target_agent": "ProcessingAgent",  # Specific agent
             "data": {...},
         }
-        
+
         Args:
             input_data: Orchestration request
-            
+
         Returns:
             AgentOutput with aggregated results
         """
@@ -265,12 +265,12 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> AgentOutput:
         """
         Execute a named workflow.
-        
+
         Args:
             workflow_name: Name of workflow to execute
             input_data: Initial input data
             start_time: When processing started
-            
+
         Returns:
             AgentOutput with workflow results
         """
@@ -367,12 +367,12 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> AgentOutput:
         """
         Route directly to a specific agent.
-        
+
         Args:
             agent_name: Name of target agent
             input_data: Input data
             start_time: When processing started
-            
+
         Returns:
             AgentOutput from target agent
         """
@@ -423,10 +423,10 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     def _find_agent_for_step(self, step: WorkflowStep) -> BaseAgent | None:
         """
         Find an appropriate agent for a workflow step.
-        
+
         Args:
             step: Workflow step
-            
+
         Returns:
             Agent instance or None
         """
@@ -454,12 +454,12 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> AgentInput:
         """
         Prepare input for a workflow step.
-        
+
         Args:
             step: Workflow step
             context: Current workflow context
             task_id: Task identifier
-            
+
         Returns:
             AgentInput for the step
         """
@@ -488,12 +488,12 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Update workflow context with step output.
-        
+
         Args:
             step: Completed workflow step
             context: Current context
             output: Step output
-            
+
         Returns:
             Updated context
         """
@@ -519,12 +519,12 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> AgentOutput:
         """
         Execute a step with retry logic.
-        
+
         Args:
             agent: Agent to execute
             input_data: Step input
             step_name: Name of the step
-            
+
         Returns:
             AgentOutput from step execution
         """
@@ -566,7 +566,7 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     def register_workflow(self, workflow: Workflow) -> None:
         """
         Register a custom workflow.
-        
+
         Args:
             workflow: Workflow to register
         """
@@ -588,11 +588,11 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Convenience method to orchestrate a workflow.
-        
+
         Args:
             data: Input data
             workflow: Workflow name
-            
+
         Returns:
             Workflow results
         """
@@ -616,11 +616,11 @@ class OrchestratorAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Convenience method to send data directly to an agent.
-        
+
         Args:
             agent_name: Target agent name
             data: Data to send
-            
+
         Returns:
             Agent response
         """

--- a/tg_parser/agents/persistence.py
+++ b/tg_parser/agents/persistence.py
@@ -28,13 +28,13 @@ logger = structlog.get_logger(__name__)
 class AgentPersistence:
     """
     Persistence layer for agent state and history.
-    
+
     Provides a unified interface for:
     - Saving/restoring agent state
     - Recording task execution history
     - Tracking handoffs between agents
     - Aggregating statistics
-    
+
     Can be attached to AgentRegistry for automatic persistence.
     """
 
@@ -49,9 +49,9 @@ class AgentPersistence:
     ):
         """
         Initialize persistence layer.
-        
+
         All repositories are optional - only enabled features will work.
-        
+
         Args:
             agent_state_repo: Repository for agent state
             task_history_repo: Repository for task history
@@ -84,7 +84,7 @@ class AgentPersistence:
     async def save_agent_state(self, agent: BaseAgent) -> None:
         """
         Save agent state to persistent storage.
-        
+
         Called when agent is registered or updated.
         """
         if not self._agent_state_repo:
@@ -109,7 +109,7 @@ class AgentPersistence:
     async def load_agent_state(self, name: str) -> AgentState | None:
         """
         Load agent state from persistent storage.
-        
+
         Returns None if agent not found or persistence disabled.
         """
         if not self._agent_state_repo:
@@ -123,7 +123,7 @@ class AgentPersistence:
     ) -> dict[str, Any] | None:
         """
         Restore agent statistics from persistent storage.
-        
+
         Returns dict with restored stats or None if not found.
         """
         if not self._agent_state_repo:
@@ -187,9 +187,9 @@ class AgentPersistence:
     ) -> str | None:
         """
         Record a task execution.
-        
+
         Also updates agent statistics if enabled.
-        
+
         Returns: Task ID or None if persistence disabled
         """
         task_id = None

--- a/tg_parser/agents/processing_agent.py
+++ b/tg_parser/agents/processing_agent.py
@@ -61,12 +61,12 @@ class AgentProcessingOutput(BaseModel):
 def create_processing_agent() -> Agent:
     """
     Create TGProcessingAgent with text processing tools.
-    
+
     The agent uses three tools:
     - clean_text: Clean and normalize raw text
     - extract_topics: Extract topics and generate summary
     - extract_entities: Extract named entities
-    
+
     Returns:
         Configured Agent instance
     """
@@ -118,12 +118,12 @@ async def process_message_with_agent(
 ) -> ProcessedDocument:
     """
     Process a single message using the TGProcessingAgent.
-    
+
     Args:
         message: RawTelegramMessage to process
         agent: Optional agent instance (uses global if not provided)
         context: Optional AgentContext for LLM-enhanced tools
-        
+
     Returns:
         ProcessedDocument with extracted information
     """
@@ -183,7 +183,7 @@ Use all three tools (clean_text, extract_topics, extract_entities) to extract st
 def _extract_processing_data(result: Any) -> dict:
     """
     Extract structured data from agent run result.
-    
+
     Combines tool outputs into a single processing result.
     Handles both basic tools and LLM-enhanced DeepAnalysisResult.
     """
@@ -326,13 +326,13 @@ async def process_batch_with_agent(
 ) -> list[ProcessedDocument]:
     """
     Process multiple messages using the agent.
-    
+
     Args:
         messages: List of messages to process
         concurrency: Max concurrent processing tasks
         agent: Optional agent instance
         context: Optional AgentContext for LLM-enhanced tools
-        
+
     Returns:
         List of ProcessedDocuments
     """
@@ -377,7 +377,7 @@ async def process_batch_with_agent(
 class TGProcessingAgent:
     """
     Wrapper class for TGProcessingAgent functionality.
-    
+
     Provides object-oriented interface for agent-based processing.
     Supports both basic and LLM-enhanced tools.
     Phase 2E: Supports hybrid mode with v1.2 pipeline as a tool.
@@ -394,7 +394,7 @@ class TGProcessingAgent:
     ):
         """
         Initialize the processing agent.
-        
+
         Args:
             model: Model to use (e.g., "gpt-4o-mini")
             provider: LLM provider ("openai", "anthropic", "gemini", "ollama")

--- a/tg_parser/agents/registry.py
+++ b/tg_parser/agents/registry.py
@@ -55,7 +55,7 @@ class AgentRegistration:
 class AgentRegistry:
     """
     Central registry for managing agents.
-    
+
     Provides:
     - Agent registration and unregistration
     - Lookup by name, type, or capability
@@ -67,7 +67,7 @@ class AgentRegistry:
     def __init__(self, persistence: AgentPersistence | None = None):
         """
         Initialize empty registry.
-        
+
         Args:
             persistence: Optional persistence layer for state recovery
         """
@@ -84,10 +84,10 @@ class AgentRegistry:
     def register(self, agent: BaseAgent) -> None:
         """
         Register an agent with the registry.
-        
+
         Args:
             agent: Agent instance to register
-            
+
         Raises:
             ValueError: If agent with same name already registered
         """
@@ -127,9 +127,9 @@ class AgentRegistry:
     async def register_with_persistence(self, agent: BaseAgent) -> None:
         """
         Register an agent and save to persistent storage.
-        
+
         Also restores statistics if available.
-        
+
         Args:
             agent: Agent instance to register
         """
@@ -155,10 +155,10 @@ class AgentRegistry:
     def unregister(self, name: str) -> bool:
         """
         Unregister an agent from the registry.
-        
+
         Args:
             name: Name of agent to unregister
-            
+
         Returns:
             True if agent was unregistered, False if not found
         """
@@ -189,10 +189,10 @@ class AgentRegistry:
     async def unregister_with_persistence(self, name: str) -> bool:
         """
         Unregister an agent and mark as inactive in storage.
-        
+
         Args:
             name: Name of agent to unregister
-            
+
         Returns:
             True if agent was unregistered, False if not found
         """
@@ -210,10 +210,10 @@ class AgentRegistry:
     def get(self, name: str) -> BaseAgent | None:
         """
         Get agent by name.
-        
+
         Args:
             name: Agent name
-            
+
         Returns:
             Agent instance or None if not found
         """
@@ -223,10 +223,10 @@ class AgentRegistry:
     def get_registration(self, name: str) -> AgentRegistration | None:
         """
         Get full registration entry by name.
-        
+
         Args:
             name: Agent name
-            
+
         Returns:
             Registration entry or None if not found
         """
@@ -235,10 +235,10 @@ class AgentRegistry:
     def get_by_type(self, agent_type: AgentType) -> list[BaseAgent]:
         """
         Get all agents of a specific type.
-        
+
         Args:
             agent_type: Type of agents to find
-            
+
         Returns:
             List of matching agents
         """
@@ -248,10 +248,10 @@ class AgentRegistry:
     def get_by_capability(self, capability: AgentCapability) -> list[BaseAgent]:
         """
         Get all agents with a specific capability.
-        
+
         Args:
             capability: Capability to search for
-            
+
         Returns:
             List of agents with that capability
         """
@@ -261,7 +261,7 @@ class AgentRegistry:
     def get_active(self) -> list[BaseAgent]:
         """
         Get all active agents.
-        
+
         Returns:
             List of active agents
         """
@@ -277,16 +277,16 @@ class AgentRegistry:
     ) -> BaseAgent | None:
         """
         Find the best agent for a specific capability.
-        
+
         Uses heuristics to select:
         1. Prefer specified agent type if provided
         2. Prefer agents with fewer errors
         3. Prefer agents with lower average processing time
-        
+
         Args:
             capability: Required capability
             prefer_type: Preferred agent type (optional)
-            
+
         Returns:
             Best matching agent or None
         """
@@ -334,7 +334,7 @@ class AgentRegistry:
     ) -> None:
         """
         Record task completion statistics for an agent.
-        
+
         Args:
             name: Agent name
             processing_time_ms: Time taken to process
@@ -369,9 +369,9 @@ class AgentRegistry:
     ) -> str | None:
         """
         Record task completion with full persistence.
-        
+
         Updates in-memory stats and persists to storage.
-        
+
         Args:
             name: Agent name
             task_type: Type of task executed
@@ -382,7 +382,7 @@ class AgentRegistry:
             error: Error message if failed
             source_ref: Source reference
             channel_id: Channel ID
-            
+
         Returns:
             Task ID if persistence enabled, None otherwise
         """
@@ -408,7 +408,7 @@ class AgentRegistry:
     def get_statistics(self) -> dict[str, Any]:
         """
         Get registry statistics.
-        
+
         Returns:
             Dictionary with statistics
         """
@@ -442,7 +442,7 @@ class AgentRegistry:
     async def health_check_all(self) -> dict[str, bool]:
         """
         Run health check on all registered agents.
-        
+
         Returns:
             Dictionary mapping agent name to health status
         """
@@ -461,7 +461,7 @@ class AgentRegistry:
     async def initialize_all(self) -> dict[str, bool]:
         """
         Initialize all registered agents.
-        
+
         Returns:
             Dictionary mapping agent name to initialization status
         """
@@ -481,7 +481,7 @@ class AgentRegistry:
     async def shutdown_all(self) -> dict[str, bool]:
         """
         Shutdown all registered agents.
-        
+
         Returns:
             Dictionary mapping agent name to shutdown status
         """
@@ -527,12 +527,12 @@ _global_registry: AgentRegistry | None = None
 def get_registry(persistence: AgentPersistence | None = None) -> AgentRegistry:
     """
     Get the global agent registry.
-    
+
     Creates a new registry if one doesn't exist.
-    
+
     Args:
         persistence: Optional persistence layer (only used when creating new registry)
-    
+
     Returns:
         Global AgentRegistry instance
     """
@@ -545,7 +545,7 @@ def get_registry(persistence: AgentPersistence | None = None) -> AgentRegistry:
 def reset_registry() -> None:
     """
     Reset the global registry.
-    
+
     Used primarily for testing.
     """
     global _global_registry
@@ -555,7 +555,7 @@ def reset_registry() -> None:
 def set_registry_persistence(persistence: AgentPersistence) -> None:
     """
     Set persistence layer for the global registry.
-    
+
     Args:
         persistence: Persistence layer to use
     """

--- a/tg_parser/agents/specialized/export.py
+++ b/tg_parser/agents/specialized/export.py
@@ -34,7 +34,7 @@ class ExportFormat:
 class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     """
     Specialized agent for data export.
-    
+
     Handles conversion of processed documents to various output formats
     suitable for RAG systems and knowledge bases.
     """
@@ -46,7 +46,7 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     ):
         """
         Initialize the export agent.
-        
+
         Args:
             output_dir: Directory for output files
             default_format: Default export format
@@ -83,17 +83,17 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     async def process(self, input_data: AgentInput) -> AgentOutput:
         """
         Process export request.
-        
+
         Expected input format:
         {
             "documents": [...],  # Documents to export
             "format": "ndjson",  # Export format
             "filename": "...",   # Optional filename
         }
-        
+
         Args:
             input_data: Input containing documents and export options
-            
+
         Returns:
             AgentOutput with export results
         """
@@ -162,11 +162,11 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Export documents as NDJSON (one JSON object per line).
-        
+
         Args:
             documents: Documents to export
             filename: Optional filename
-            
+
         Returns:
             Export result with content or file path
         """
@@ -201,11 +201,11 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Export documents as JSON array.
-        
+
         Args:
             documents: Documents to export
             filename: Optional filename
-            
+
         Returns:
             Export result with content or file path
         """
@@ -235,11 +235,11 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Export topic clusters.
-        
+
         Args:
             topics: Topic clusters to export
             filename: Optional filename
-            
+
         Returns:
             Export result with content or file path
         """
@@ -264,10 +264,10 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     def _to_kb_entry(self, doc: dict[str, Any]) -> dict[str, Any]:
         """
         Convert document to knowledge base entry format.
-        
+
         Args:
             doc: Document dict
-            
+
         Returns:
             KB entry dict
         """
@@ -294,12 +294,12 @@ class ExportAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> dict[str, Any]:
         """
         Convenience method to export documents.
-        
+
         Args:
             documents: Documents to export (dicts or ProcessedDocument)
             format: Export format
             filename: Optional filename
-            
+
         Returns:
             Export results
         """

--- a/tg_parser/agents/specialized/processing.py
+++ b/tg_parser/agents/specialized/processing.py
@@ -55,11 +55,11 @@ class ProcessingMode:
 class ProcessingAgent(BaseAgent[AgentInput, AgentOutput]):
     """
     Specialized agent for message processing.
-    
+
     Implements the A + C hybrid pattern:
     - A: Specialized agent for processing stage
     - C: Internal routing between simple and deep processing
-    
+
     Features:
     - Simple mode: Fast pattern-based processing (no LLM calls)
     - Deep mode: LLM-enhanced analysis for complex content
@@ -76,7 +76,7 @@ class ProcessingAgent(BaseAgent[AgentInput, AgentOutput]):
     ):
         """
         Initialize the processing agent.
-        
+
         Args:
             model: LLM model to use for deep processing
             provider: LLM provider
@@ -117,7 +117,7 @@ class ProcessingAgent(BaseAgent[AgentInput, AgentOutput]):
         self._simple_agent = Agent(
             name="SimpleProcessor",
             instructions="""You are a fast text processor for Telegram messages.
-            
+
 Use the provided tools to:
 1. clean_text - Clean and normalize the raw text
 2. extract_topics - Find topics and generate summary
@@ -170,10 +170,10 @@ Provide thorough and accurate results.""",
     async def process(self, input_data: AgentInput) -> AgentOutput:
         """
         Process input data.
-        
+
         Args:
             input_data: Input containing text to process
-            
+
         Returns:
             AgentOutput with processing results
         """
@@ -233,14 +233,14 @@ Provide thorough and accurate results.""",
     def _select_mode(self, text: str) -> str:
         """
         Automatically select processing mode based on text complexity.
-        
+
         Simple heuristics:
         - Short texts (< threshold) → simple mode
         - Long or complex texts → deep mode
-        
+
         Args:
             text: Text to analyze
-            
+
         Returns:
             Processing mode
         """
@@ -263,12 +263,12 @@ Provide thorough and accurate results.""",
     async def _process_simple(self, text: str) -> dict[str, Any]:
         """
         Process text using simple (fast) mode.
-        
+
         Uses pattern-based tools without LLM calls.
-        
+
         Args:
             text: Text to process
-            
+
         Returns:
             Processing results
         """
@@ -286,12 +286,12 @@ Provide thorough and accurate results.""",
     async def _process_deep(self, text: str) -> dict[str, Any]:
         """
         Process text using deep (LLM-enhanced) mode.
-        
+
         Uses LLM for semantic analysis.
-        
+
         Args:
             text: Text to process
-            
+
         Returns:
             Processing results
         """
@@ -310,10 +310,10 @@ Provide thorough and accurate results.""",
     def _extract_results(self, result: Any) -> dict[str, Any]:
         """
         Extract structured results from agent run result.
-        
+
         Args:
             result: Result from Runner.run()
-            
+
         Returns:
             Structured dictionary with results
         """
@@ -370,11 +370,11 @@ Provide thorough and accurate results.""",
     ) -> dict[str, Any]:
         """
         Convenience method to process text directly.
-        
+
         Args:
             text: Text to process
             mode: Processing mode (optional, uses default if not provided)
-            
+
         Returns:
             Processing results
         """

--- a/tg_parser/agents/specialized/topicization.py
+++ b/tg_parser/agents/specialized/topicization.py
@@ -24,7 +24,7 @@ logger = structlog.get_logger(__name__)
 class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
     """
     Specialized agent for topicization (semantic clustering).
-    
+
     Takes processed documents and groups them into semantic topics.
     Integrates with existing topicization pipeline.
     """
@@ -38,7 +38,7 @@ class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
     ):
         """
         Initialize the topicization agent.
-        
+
         Args:
             model: LLM model for semantic analysis
             provider: LLM provider
@@ -87,7 +87,7 @@ class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
     async def process(self, input_data: AgentInput) -> AgentOutput:
         """
         Process input data for topicization.
-        
+
         Expected input format:
         {
             "documents": [
@@ -95,10 +95,10 @@ class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
                 ...
             ]
         }
-        
+
         Args:
             input_data: Input containing documents to cluster
-            
+
         Returns:
             AgentOutput with topic clusters
         """
@@ -156,13 +156,13 @@ class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> list[dict[str, Any]]:
         """
         Cluster documents into semantic topics.
-        
+
         Basic implementation using topic overlap.
         For production, integrates with full topicization pipeline.
-        
+
         Args:
             documents: List of processed documents
-            
+
         Returns:
             List of topic clusters
         """
@@ -202,10 +202,10 @@ class TopicizationAgent(BaseAgent[AgentInput, AgentOutput]):
     ) -> list[dict[str, Any]]:
         """
         Convenience method to cluster ProcessedDocument objects.
-        
+
         Args:
             documents: List of ProcessedDocument instances
-            
+
         Returns:
             List of topic clusters
         """

--- a/tg_parser/agents/tools/pipeline_tool.py
+++ b/tg_parser/agents/tools/pipeline_tool.py
@@ -38,7 +38,7 @@ class PipelineResult(BaseModel):
 async def _create_pipeline_on_demand(context: AgentContext) -> "ProcessingPipelineImpl | None":
     """
     Create a pipeline instance on demand when not provided in context.
-    
+
     This is a fallback for when the pipeline isn't pre-configured.
     Returns None if creation fails.
     """
@@ -101,18 +101,18 @@ async def process_with_pipeline(
 ) -> PipelineResult:
     """
     Process text using the proven v1.2 LLM pipeline.
-    
+
     Use this tool when:
     - Text requires deep semantic analysis
     - You need reliable entity/topic extraction
     - Basic tools are insufficient for the message complexity
     - Text is long or contains technical/domain-specific content
-    
+
     This tool uses the full LLM pipeline with:
     - Configurable prompts (YAML-based)
     - Retry mechanism (3 attempts with exponential backoff)
     - Multi-LLM support (OpenAI, Anthropic, Gemini, Ollama)
-    
+
     Returns structured processing result with cleaned text, summary,
     topics, entities, and language detection.
     """
@@ -195,7 +195,7 @@ async def process_with_pipeline(
 def _fallback_basic_processing(text: str) -> PipelineResult:
     """
     Fallback processing when pipeline is unavailable.
-    
+
     Uses basic pattern matching similar to agent tools.
     """
     import re
@@ -255,7 +255,7 @@ def _fallback_basic_processing(text: str) -> PipelineResult:
 class InMemoryProcessedDocumentRepo:
     """
     Simple in-memory repository for on-demand pipeline processing.
-    
+
     Used when pipeline is created on-the-fly without database access.
     """
 

--- a/tg_parser/agents/tools/text_tools.py
+++ b/tg_parser/agents/tools/text_tools.py
@@ -28,7 +28,7 @@ logger = structlog.get_logger(__name__)
 class AgentContext:
     """
     Context for agent tools.
-    
+
     Provides access to LLM client and configuration for enhanced tools.
     Phase 2E: Added pipeline field for hybrid mode.
     """
@@ -80,13 +80,13 @@ def clean_text(
 ) -> CleanTextResult:
     """
     Clean and normalize raw text from a Telegram message.
-    
+
     This tool performs:
     - Remove noise (excessive whitespace, special characters)
     - Fix formatting issues
     - Normalize unicode
     - Detect language
-    
+
     Returns cleaned text and detected language.
     """
     if not text or not text.strip():
@@ -136,10 +136,10 @@ def extract_topics(
 ) -> TopicsResult:
     """
     Extract main topics and themes from text.
-    
+
     Identifies key topics, categories, and themes present in the text.
     Also generates a brief summary if the text is meaningful.
-    
+
     Returns list of topics and optional summary.
     """
     if not text or not text.strip():
@@ -196,7 +196,7 @@ def extract_entities(
 ) -> EntitiesResult:
     """
     Extract named entities from text.
-    
+
     Identifies and extracts:
     - Persons (names of people)
     - Organizations (companies, institutions)
@@ -204,7 +204,7 @@ def extract_entities(
     - Products (product names, brands)
     - Dates (date mentions)
     - Other relevant entities
-    
+
     Returns list of entities with types and confidence scores.
     """
     if not text or not text.strip():
@@ -336,10 +336,10 @@ async def analyze_text_deep(
 ) -> DeepAnalysisResult:
     """
     Perform deep analysis of text using LLM.
-    
+
     This tool uses the LLM for semantic analysis when available.
     Falls back to basic pattern matching if LLM is not configured.
-    
+
     Extracts:
     - Clean text
     - Language
@@ -414,7 +414,7 @@ async def extract_topics_llm(
 ) -> TopicsResult:
     """
     Extract topics using LLM for semantic understanding.
-    
+
     Unlike keyword-based extraction, this tool understands context
     and can identify topics that aren't explicitly mentioned.
     """
@@ -466,7 +466,7 @@ async def extract_entities_llm(
 ) -> EntitiesResult:
     """
     Extract named entities using LLM for better accuracy.
-    
+
     Can identify entities that pattern matching would miss,
     and correctly classify ambiguous entities.
     """

--- a/tg_parser/api/health_checks.py
+++ b/tg_parser/api/health_checks.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger(__name__)
 async def check_database() -> dict[str, Any]:
     """
     Check database connectivity and health.
-    
+
     Returns:
         Dictionary with database health status
     """
@@ -82,7 +82,7 @@ async def check_database() -> dict[str, Any]:
 async def check_llm_provider() -> dict[str, Any]:
     """
     Check LLM provider connectivity.
-    
+
     Returns:
         Dictionary with LLM provider health status
     """
@@ -196,7 +196,7 @@ async def _check_ollama() -> None:
 async def check_agent_registry() -> dict[str, Any]:
     """
     Check agent registry status.
-    
+
     Returns:
         Dictionary with agent registry health status
     """
@@ -218,7 +218,7 @@ async def check_agent_registry() -> dict[str, Any]:
         result["status"] = "ok"
         result["details"]["total_agents"] = len(agents)
         result["details"]["active_agents"] = active_count
-        result["details"]["agent_types"] = list(set(a.agent_type for a in agents))
+        result["details"]["agent_types"] = list({a.agent_type for a in agents})
 
     except (SQLAlchemyError, RuntimeError) as e:
         result["status"] = "error"
@@ -231,7 +231,7 @@ async def check_agent_registry() -> dict[str, Any]:
 async def check_scheduler() -> dict[str, Any]:
     """
     Check background scheduler status.
-    
+
     Returns:
         Dictionary with scheduler health status
     """
@@ -266,7 +266,7 @@ async def check_scheduler() -> dict[str, Any]:
 async def check_all_components() -> dict[str, str]:
     """
     Check all system components.
-    
+
     Returns:
         Dictionary mapping component name to status
     """
@@ -294,7 +294,7 @@ async def check_all_components() -> dict[str, str]:
 async def get_detailed_health() -> dict[str, Any]:
     """
     Get detailed health information for all components.
-    
+
     Returns:
         Dictionary with detailed health info
     """

--- a/tg_parser/api/job_store.py
+++ b/tg_parser/api/job_store.py
@@ -21,7 +21,7 @@ logger = structlog.get_logger(__name__)
 class JobStore:
     """
     Singleton job storage manager.
-    
+
     Manages database connection and provides job repository.
     """
 
@@ -95,7 +95,7 @@ class JobStore:
           webhook_url TEXT,
           webhook_secret TEXT
         );
-        
+
         CREATE INDEX IF NOT EXISTS api_jobs_status_idx ON api_jobs(status);
         CREATE INDEX IF NOT EXISTS api_jobs_created_at_idx ON api_jobs(created_at DESC);
         CREATE INDEX IF NOT EXISTS api_jobs_job_type_idx ON api_jobs(job_type);
@@ -162,7 +162,7 @@ def get_job_store() -> JobStore:
 async def ensure_job_store_initialized() -> JobStore:
     """
     Ensure job store is initialized and return it.
-    
+
     Automatically initializes if not already done.
     Thread-safe for async context.
     """

--- a/tg_parser/api/main.py
+++ b/tg_parser/api/main.py
@@ -4,10 +4,10 @@ FastAPI application for TG_parser HTTP API.
 Usage:
     # Development
     uvicorn tg_parser.api.main:app --reload
-    
+
     # Production
     uvicorn tg_parser.api.main:app --host 0.0.0.0 --port 8000
-    
+
     # Or use the CLI command
     tg-parser api --port 8000
 """
@@ -133,7 +133,7 @@ API_VERSION = "2.0.0"
 async def lifespan(app: FastAPI):
     """
     Application lifespan handler.
-    
+
     Handles startup and shutdown events.
     """
     from tg_parser.storage.sqlalchemy import Database
@@ -186,7 +186,7 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     """
     Create and configure FastAPI application.
-    
+
     Returns:
         Configured FastAPI application
     """

--- a/tg_parser/api/metrics.py
+++ b/tg_parser/api/metrics.py
@@ -105,7 +105,7 @@ SCHEDULER_TASKS_TOTAL = Counter(
 def agent_metrics() -> Callable[[Info], None]:
     """
     Custom metric function for agent-related metrics.
-    
+
     This is called per-request by the instrumentator.
     """
     def instrumentation(info: Info) -> None:
@@ -128,9 +128,9 @@ _instrumented_apps: set[int] = set()  # Track which apps have been instrumented
 def create_instrumentator() -> Instrumentator:
     """
     Create and configure Prometheus instrumentator.
-    
+
     Returns singleton Instrumentator instance to avoid duplicate metric registration.
-    
+
     Returns:
         Configured Instrumentator instance
     """
@@ -205,7 +205,7 @@ def record_agent_task(
 ) -> None:
     """
     Record an agent task execution.
-    
+
     Args:
         agent_name: Name of the agent
         task_type: Type of task
@@ -228,7 +228,7 @@ def record_agent_task(
 def record_message_processed(channel_id: str, success: bool) -> None:
     """
     Record a message processing event.
-    
+
     Args:
         channel_id: Channel identifier
         success: Whether processing succeeded
@@ -243,7 +243,7 @@ def record_message_processed(channel_id: str, success: bool) -> None:
 def record_topic_created(channel_id: str) -> None:
     """
     Record a topic creation event.
-    
+
     Args:
         channel_id: Channel identifier
     """
@@ -260,7 +260,7 @@ def record_llm_request(
 ) -> None:
     """
     Record an LLM request.
-    
+
     Args:
         provider: LLM provider name
         model: Model name
@@ -299,7 +299,7 @@ def record_llm_request(
 def update_active_agents(agent_type: str, count: int) -> None:
     """
     Update the count of active agents.
-    
+
     Args:
         agent_type: Type of agent
         count: Number of active agents
@@ -310,7 +310,7 @@ def update_active_agents(agent_type: str, count: int) -> None:
 def record_job_status(status: str) -> None:
     """
     Record a job status change.
-    
+
     Args:
         status: Job status (pending, running, completed, failed)
     """
@@ -320,7 +320,7 @@ def record_job_status(status: str) -> None:
 def update_active_jobs(count: int) -> None:
     """
     Update the count of active jobs.
-    
+
     Args:
         count: Number of active jobs
     """
@@ -330,7 +330,7 @@ def update_active_jobs(count: int) -> None:
 def record_scheduler_task(task_name: str, success: bool) -> None:
     """
     Record a scheduler task execution.
-    
+
     Args:
         task_name: Name of the scheduled task
         success: Whether task succeeded

--- a/tg_parser/api/middleware/logging.py
+++ b/tg_parser/api/middleware/logging.py
@@ -26,7 +26,7 @@ request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     """
     Middleware for request logging and X-Request-ID propagation.
-    
+
     Features:
     - Generates X-Request-ID if not provided
     - Logs request start/completion with timing
@@ -105,7 +105,7 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 def get_request_id() -> str:
     """
     Get current request ID from context.
-    
+
     Returns empty string if called outside of request context.
     """
     return request_id_var.get()

--- a/tg_parser/api/middleware/rate_limit.py
+++ b/tg_parser/api/middleware/rate_limit.py
@@ -22,7 +22,7 @@ logger = structlog.get_logger(__name__)
 def _get_rate_limit_key(request: Request) -> str:
     """
     Get rate limit key combining IP and API key (if present).
-    
+
     This ensures rate limits apply per-client even through proxies
     when API keys are used.
     """
@@ -38,7 +38,7 @@ def _get_rate_limit_key(request: Request) -> str:
 def get_limiter() -> Limiter:
     """
     Create and configure rate limiter.
-    
+
     Returns disabled limiter if rate_limit_enabled is False.
     """
     if not settings.rate_limit_enabled:

--- a/tg_parser/api/routes/agents.py
+++ b/tg_parser/api/routes/agents.py
@@ -136,7 +136,7 @@ async def list_agents(
 ) -> AgentListResponse:
     """
     List all registered agents.
-    
+
     Returns agent metadata and basic statistics.
     """
     assert_admin(user)
@@ -209,7 +209,7 @@ async def get_agent_stats(
 ) -> AgentStatsResponse:
     """
     Get statistics for an agent.
-    
+
     Returns aggregated statistics over the specified period.
     """
     assert_admin(user)

--- a/tg_parser/api/routes/export.py
+++ b/tg_parser/api/routes/export.py
@@ -45,7 +45,7 @@ def _job_status_to_api(status: JobStatus) -> APIJobStatus:
 async def _run_export_job(job_id: str, request: ExportRequest) -> None:
     """
     Background task to run export.
-    
+
     Sends webhook notification on completion if configured.
     """
     job_store = await ensure_job_store_initialized()
@@ -161,10 +161,10 @@ async def start_export(
 ) -> ExportResponse:
     """
     Start async export of processed data.
-    
+
     Creates a background job and returns immediately with job_id.
     When complete, download_url will be available.
-    
+
     **Authentication**: Required if API_KEY_REQUIRED=true
     **Rate Limit**: 20 requests per minute
     """

--- a/tg_parser/api/routes/health.py
+++ b/tg_parser/api/routes/health.py
@@ -12,12 +12,11 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.exc import SQLAlchemyError
 
 from tg_parser.api.auth import verify_api_key
-
-logger = structlog.get_logger(__name__)
-
 from tg_parser.api.health_checks import check_all_components, get_detailed_health
 from tg_parser.api.schemas import HealthResponse, StatusResponse
 from tg_parser.config import settings
+
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["Health"])
 
@@ -26,7 +25,7 @@ router = APIRouter(tags=["Health"])
 async def health_check() -> HealthResponse:
     """
     Basic health check endpoint.
-    
+
     Returns simple health status for load balancers and monitoring.
     Performs a fast DB ping (SELECT 1) to detect database outages.
     Always returns HTTP 200 — use ``status`` field to distinguish ok/degraded.
@@ -65,7 +64,7 @@ async def _check_db_ping() -> str:
 async def status() -> StatusResponse:
     """
     Detailed status endpoint.
-    
+
     Returns component health and statistics.
     This performs actual health checks on all components.
     """
@@ -97,7 +96,7 @@ async def status() -> StatusResponse:
 async def detailed_status(_client: str | None = Depends(verify_api_key)) -> dict[str, Any]:
     """
     Detailed status with component-level health information.
-    
+
     Returns comprehensive health information including:
     - Database connectivity and latency
     - LLM provider status
@@ -127,7 +126,7 @@ async def detailed_status(_client: str | None = Depends(verify_api_key)) -> dict
 async def scheduler_status(_client: str | None = Depends(verify_api_key)) -> dict[str, Any]:
     """
     Get background scheduler status and scheduled tasks.
-    
+
     Returns:
         Scheduler status and list of scheduled tasks
     """
@@ -145,7 +144,7 @@ async def scheduler_status(_client: str | None = Depends(verify_api_key)) -> dic
 async def _get_basic_stats() -> dict[str, int]:
     """
     Get basic statistics from database.
-    
+
     Returns:
         Dictionary with basic stats
     """

--- a/tg_parser/api/routes/process.py
+++ b/tg_parser/api/routes/process.py
@@ -12,7 +12,10 @@ import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from sqlalchemy.exc import SQLAlchemyError
 
-from tg_parser.api.auth import resolve_current_user, verify_api_key  # noqa: F401  # verify_api_key is patched by tests/test_api_security.py via mock.patch path
+from tg_parser.api.auth import (  # noqa: F401  # verify_api_key is patched by tests/test_api_security.py via mock.patch path
+    resolve_current_user,
+    verify_api_key,
+)
 from tg_parser.api.job_store import ensure_job_store_initialized
 from tg_parser.api.middleware import limiter
 from tg_parser.api.schemas import (
@@ -43,7 +46,7 @@ def _job_status_to_api(status: JobStatus) -> APIJobStatus:
 async def _run_processing_job(job_id: str, request: ProcessRequest) -> None:
     """
     Background task to run processing.
-    
+
     Updates job status as processing progresses.
     Sends webhook notification on completion if configured.
     """
@@ -156,10 +159,10 @@ async def start_processing(
 ) -> ProcessResponse:
     """
     Start async processing of messages from a channel.
-    
+
     Creates a background job and returns immediately with job_id.
     Use GET /api/v1/status/{job_id} to check progress.
-    
+
     **Authentication**: Required if API_KEY_REQUIRED=true
     **Rate Limit**: 10 requests per minute
     """
@@ -212,7 +215,7 @@ async def start_processing(
 async def get_job_status(job_id: str, _user: CurrentUser = Depends(resolve_current_user)) -> JobStatusResponse:
     """
     Get status of a processing job.
-    
+
     Returns current status, progress, and result when completed.
     """
     job_store = await ensure_job_store_initialized()
@@ -248,7 +251,7 @@ async def list_jobs(
 ) -> list[JobStatusResponse]:
     """
     List processing jobs.
-    
+
     Optionally filter by status. Returns most recent first.
     """
     job_store = await ensure_job_store_initialized()

--- a/tg_parser/api/webhooks.py
+++ b/tg_parser/api/webhooks.py
@@ -29,14 +29,14 @@ async def send_webhook(
 ) -> bool:
     """
     Send webhook notification with optional HMAC signature.
-    
+
     Args:
         url: Webhook URL to call
         payload: JSON payload to send
         secret: Optional HMAC secret for signature (X-Webhook-Signature)
         max_retries: Max retry attempts (default from settings)
         timeout: HTTP timeout in seconds (default from settings)
-        
+
     Returns:
         True if webhook was delivered successfully, False otherwise
     """
@@ -146,14 +146,14 @@ def create_job_completion_payload(
 ) -> dict[str, Any]:
     """
     Create standard webhook payload for job completion.
-    
+
     Args:
         job_id: Unique job identifier
         job_type: "processing" or "export"
         status: Final job status ("completed" or "failed")
         result: Optional result data
         error: Optional error message
-        
+
     Returns:
         Standardized webhook payload
     """
@@ -183,14 +183,14 @@ def verify_webhook_signature(
 ) -> bool:
     """
     Verify incoming webhook signature.
-    
+
     Useful for webhook receivers to validate authenticity.
-    
+
     Args:
         body: Raw request body
         signature: X-Webhook-Signature header value
         secret: HMAC secret
-        
+
     Returns:
         True if signature is valid
     """

--- a/tg_parser/cli/agents_cmd.py
+++ b/tg_parser/cli/agents_cmd.py
@@ -35,7 +35,7 @@ def list_agents(
 ):
     """
     List all registered agents.
-    
+
     Shows agent name, type, capabilities, and basic statistics.
     """
     async def _list():
@@ -236,7 +236,7 @@ def cleanup_history(
 ):
     """
     Clean up expired task history records.
-    
+
     By default, deletes expired records. Use --archive to save them first.
     Use --include-handoffs with --archive to also archive handoff records.
     """
@@ -300,7 +300,7 @@ def cleanup_history(
                 async with session_factory() as session:
                     result = await session.execute(
                         text("""
-                            SELECT * FROM handoff_history 
+                            SELECT * FROM handoff_history
                             WHERE status IN ('completed', 'failed')
                             ORDER BY created_at DESC
                             LIMIT 10000

--- a/tg_parser/cli/api_cmd.py
+++ b/tg_parser/cli/api_cmd.py
@@ -17,7 +17,7 @@ def run_api_server(
 ) -> None:
     """
     Run the HTTP API server.
-    
+
     Args:
         host: Host to bind to
         port: Port to bind to
@@ -27,9 +27,9 @@ def run_api_server(
     """
     try:
         import uvicorn
-    except ImportError:
+    except ImportError as err:
         logger.error("uvicorn not installed. Run: pip install uvicorn[standard]")
-        raise SystemExit(1)
+        raise SystemExit(1) from err
 
     logger.info("Starting TG_parser API server on %s:%s", host, port)
 

--- a/tg_parser/cli/app.py
+++ b/tg_parser/cli/app.py
@@ -65,13 +65,13 @@ def auth(
         asyncio.run(_auth())
         typer.echo("\n✅ Авторизация успешна! Session сохранена.")
         typer.echo(f"   Файл: {session_path}")
-    except EOFError:
+    except EOFError as err:
         typer.echo(
             "\n❌ Невозможно прочитать код подтверждения (stdin закрыт).\n"
             "   Используйте: docker compose run --rm tg_parser auth",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from err
     except Exception as e:
         typer.echo(f"\n❌ Ошибка авторизации: {e}", err=True)
         raise typer.Exit(code=1) from e
@@ -199,7 +199,7 @@ def process(
     Обрабатывает raw → ProcessedDocument.
 
     С флагом --retry-failed обрабатывает только сообщения с прошлыми ошибками.
-    
+
     v1.2: Multi-LLM поддержка через --provider и --model флаги.
     v1.2: Параллельная обработка через --concurrency флаг (рекомендуется 3-5).
     v2.0: Agent-based processing через --agent флаг.
@@ -736,9 +736,9 @@ def api(
 ):
     """
     Start HTTP API server (v2.0).
-    
+
     Runs FastAPI server for HTTP-based processing.
-    
+
     Examples:
         tg-parser api --port 8000
         tg-parser api --reload  # Development mode

--- a/tg_parser/cli/db_cmd.py
+++ b/tg_parser/cli/db_cmd.py
@@ -24,11 +24,11 @@ def get_project_root() -> Path:
 def run_alembic_command(args: list[str], db_name: str = "ingestion") -> int:
     """
     Запустить команду alembic.
-    
+
     Args:
         args: Аргументы для alembic
         db_name: Имя базы данных (ingestion/raw/processing)
-    
+
     Returns:
         Exit code
     """
@@ -77,7 +77,7 @@ def upgrade(
 ):
     """
     Применить миграции (upgrade).
-    
+
     Примеры:
         tg-parser db upgrade                 # Все базы до head
         tg-parser db upgrade --db ingestion  # Только ingestion
@@ -121,9 +121,9 @@ def downgrade(
 ):
     """
     Откатить миграции (downgrade).
-    
+
     ⚠️  Внимание: downgrade может привести к потере данных!
-    
+
     Примеры:
         tg-parser db downgrade --db ingestion      # Откат на 1 ревизию назад
         tg-parser db downgrade --db raw base       # Откат до base (удалит все таблицы)
@@ -162,7 +162,7 @@ def current(
 ):
     """
     Показать текущую версию схемы.
-    
+
     Примеры:
         tg-parser db current                 # Все базы
         tg-parser db current --db ingestion  # Только ingestion
@@ -192,7 +192,7 @@ def history(
 ):
     """
     Показать историю миграций.
-    
+
     Примеры:
         tg-parser db history --db ingestion    # История ingestion
         tg-parser db history --db raw -v       # История raw с деталями
@@ -221,9 +221,9 @@ def stamp(
 ):
     """
     Пометить текущее состояние БД определенной ревизией (без изменений схемы).
-    
+
     Используется для синхронизации существующей БД с миграциями.
-    
+
     Примеры:
         tg-parser db stamp --db ingestion head  # Пометить как head
         tg-parser db stamp --db raw 0001        # Пометить как 0001
@@ -312,9 +312,9 @@ def backup(
         size_mb = backup_path.stat().st_size / (1024 * 1024)
         typer.echo(f"\n✅ Бэкап создан: {backup_path} ({size_mb:.1f} MB)")
 
-    except FileNotFoundError:
+    except FileNotFoundError as err:
         typer.echo("❌ pg_dump не найден", err=True)
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from err
     except Exception as e:
         typer.echo(f"❌ Ошибка: {e}", err=True)
         raise typer.Exit(code=1) from e

--- a/tg_parser/cli/init_db.py
+++ b/tg_parser/cli/init_db.py
@@ -17,11 +17,11 @@ from tg_parser.config import settings
 def run_alembic_upgrade(db_name: str, project_root: Path) -> bool:
     """
     Запустить alembic upgrade для конкретной базы.
-    
+
     Args:
         db_name: Имя базы (ingestion/raw/processing)
         project_root: Корень проекта
-    
+
     Returns:
         True если успешно
     """
@@ -99,7 +99,7 @@ async def init_databases_fallback() -> None:
 def init_databases_sync() -> None:
     """
     Синхронная обёртка для CLI команды.
-    
+
     Session 22: Использует Alembic миграции вместо прямого DDL.
     """
     import asyncio

--- a/tg_parser/config/logging.py
+++ b/tg_parser/config/logging.py
@@ -20,7 +20,7 @@ from tg_parser.config.settings import Settings
 def configure_logging(settings: Settings | None = None) -> None:
     """
     Configure structured logging for the application.
-    
+
     Args:
         settings: Application settings (default: load from env)
     """
@@ -93,10 +93,10 @@ def configure_logging(settings: Settings | None = None) -> None:
 def get_logger(name: str | None = None) -> Any:
     """
     Get a structured logger instance.
-    
+
     Args:
         name: Logger name (default: calling module)
-    
+
     Returns:
         Structured logger with bound context
     """
@@ -106,9 +106,9 @@ def get_logger(name: str | None = None) -> Any:
 def bind_contextvars(**kwargs: Any) -> None:
     """
     Bind key-value pairs to context vars for all subsequent logs.
-    
+
     Useful for propagating request_id, user_id, etc.
-    
+
     Example:
         bind_contextvars(request_id="abc-123", user_id=42)
     """
@@ -124,7 +124,7 @@ def clear_contextvars() -> None:
 def unbind_contextvars(*keys: str) -> None:
     """
     Remove specific keys from context vars.
-    
+
     Example:
         unbind_contextvars("request_id", "user_id")
     """

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -559,7 +559,7 @@ class Settings(BaseSettings):
 class RetrySettings(BaseSettings):
     """
     Настройки retry для LLM и других операций (Session 22).
-    
+
     Позволяет конфигурировать параметры retry через ENV переменные.
     """
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -130,16 +130,16 @@ def create_mcp_server() -> FastMCP:
     """Build FastMCP instance from application settings."""
     from tg_parser.config import settings
 
-    kwargs: dict[str, Any] = dict(
-        name="TG_parser Knowledge Base",
-        instructions=_MCP_INSTRUCTIONS,
-        host=settings.mcp_host,
-        port=settings.mcp_port,
-        streamable_http_path=settings.mcp_path,
-        stateless_http=True,
-        json_response=True,
-        lifespan=_mcp_lifespan,
-    )
+    kwargs: dict[str, Any] = {
+        "name": "TG_parser Knowledge Base",
+        "instructions": _MCP_INSTRUCTIONS,
+        "host": settings.mcp_host,
+        "port": settings.mcp_port,
+        "streamable_http_path": settings.mcp_path,
+        "stateless_http": True,
+        "json_response": True,
+        "lifespan": _mcp_lifespan,
+    }
 
     if settings.mcp_auth_enabled and settings.mcp_auth_tokens:
         kwargs["token_verifier"] = BearerTokenVerifier(settings.mcp_auth_tokens)

--- a/tg_parser/processing/llm/factory.py
+++ b/tg_parser/processing/llm/factory.py
@@ -4,11 +4,14 @@ LLM Client Factory.
 Создаёт LLM клиент по провайдеру.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from tg_parser.processing.ports import LLMClient
+
+if TYPE_CHECKING:
+    from .rate_limiter import LLMRateLimiter
 
 logger = structlog.get_logger(__name__)
 
@@ -56,7 +59,7 @@ def create_llm_client(
 ) -> LLMClient:
     """
     Create an LLM client for the given provider.
-    
+
     Args:
         provider: "openai" | "anthropic" | "gemini" | "ollama"
         api_key: Provider API key (not required for Ollama)
@@ -65,10 +68,10 @@ def create_llm_client(
         settings: Optional Settings for provider-specific config. Falls back to global singleton.
         instrument: Wrap with InstrumentedLLMClient for Prometheus metrics (default True)
         **kwargs: Additional client parameters
-        
+
     Returns:
         LLMClient instance
-        
+
     Raises:
         ValueError: Unknown provider or missing API key
     """
@@ -155,10 +158,10 @@ def create_llm_client(
 def get_model_id_from_client(client: LLMClient) -> str:
     """
     Извлечь model_id из LLM клиента.
-    
+
     Args:
         client: LLM клиент instance
-        
+
     Returns:
         Model ID строка
     """
@@ -175,10 +178,10 @@ def get_model_id_from_client(client: LLMClient) -> str:
 def get_provider_from_client(client: LLMClient) -> str:
     """
     Определить провайдера по типу клиента.
-    
+
     Args:
         client: LLM клиент instance
-        
+
     Returns:
         Provider name
     """

--- a/tg_parser/processing/llm/gemini_client.py
+++ b/tg_parser/processing/llm/gemini_client.py
@@ -24,7 +24,7 @@ _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 529}
 class GeminiClient(LLMClient):
     """
     Google Gemini клиент через REST API.
-    
+
     Поддерживаемые модели:
     - gemini-2.0-flash-exp
     - gemini-1.5-flash
@@ -212,11 +212,11 @@ class GeminiClient(LLMClient):
     ) -> str:
         """
         Вычислить prompt_id для детерминизма.
-        
+
         Args:
             system_prompt: System prompt
             user_prompt_template: User prompt template
-            
+
         Returns:
             prompt_id в формате "sha256:<hash>"
         """

--- a/tg_parser/processing/llm/ollama_client.py
+++ b/tg_parser/processing/llm/ollama_client.py
@@ -25,13 +25,13 @@ _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 529}
 class OllamaClient(LLMClient):
     """
     Ollama локальный клиент через OpenAI-compatible API.
-    
+
     Поддерживаемые модели (примеры):
     - llama3.2
     - mistral
     - qwen2.5
     - phi3
-    
+
     Требует запущенный Ollama server (default: http://localhost:11434)
     """
 
@@ -182,11 +182,11 @@ class OllamaClient(LLMClient):
     ) -> str:
         """
         Вычислить prompt_id для детерминизма.
-        
+
         Args:
             system_prompt: System prompt
             user_prompt_template: User prompt template
-            
+
         Returns:
             prompt_id в формате "sha256:<hash>"
         """

--- a/tg_parser/processing/pipeline.py
+++ b/tg_parser/processing/pipeline.py
@@ -40,14 +40,14 @@ logger = structlog.get_logger(__name__)
 def extract_json_from_response(response_text: str) -> str:
     """
     Извлекает JSON из ответа LLM.
-    
+
     Некоторые модели (например, Claude) возвращают JSON обёрнутый
     в markdown code block (```json ... ```). Эта функция извлекает
     чистый JSON из таких ответов.
-    
+
     Args:
         response_text: Сырой текст ответа от LLM
-        
+
     Returns:
         Чистый JSON строка
     """
@@ -704,7 +704,7 @@ class ProcessingPipelineImpl(ProcessingPipeline):
 
         LLM calls run fully parallel (semaphore-bounded).
         DB writes are batched in a single transaction after all LLM calls complete.
-        
+
         TR-47: ошибка на одном сообщении не должна ронять весь батч.
         """
         t0 = time.perf_counter()
@@ -771,7 +771,7 @@ class ProcessingPipelineImpl(ProcessingPipeline):
 
         new_docs = [r for r in completed_results if r is not None]
         failed_refs = [
-            m.source_ref for m, r in zip(to_process, completed_results) if r is None
+            m.source_ref for m, r in zip(to_process, completed_results, strict=False) if r is None
         ]
 
         # Phase 3: batch DB write

--- a/tg_parser/processing/topicization.py
+++ b/tg_parser/processing/topicization.py
@@ -712,9 +712,9 @@ class TopicizationPipelineImpl(TopicizationPipeline):
         Session 33: lowered from 4 to 2 (configurable) to capture short medical
         abbreviations like СОЭ, ТТГ, ПЦР, IgE, IgG, ЛДГ, АЛТ, ДНК, РНК.
         """
-        return {w for w in re.findall(
+        return set(re.findall(
             rf"[a-zA-Zа-яА-ЯёЁ]{{{MIN_TOKEN_LENGTH},}}", text.lower(),
-        )}
+        ))
 
     @classmethod
     def _tokenize_topic_card(cls, topic_card: TopicCard) -> set[str]:

--- a/tg_parser/services/analytics_service.py
+++ b/tg_parser/services/analytics_service.py
@@ -93,7 +93,7 @@ async def get_cross_channel_analytics(
             allowed_set = set(allowed_channel_ids)
             all_cards = [c for c in all_cards if any(s in allowed_set for s in c.sources)]
 
-        source_map = {s.channel_id: s for s in sources}
+        {s.channel_id: s for s in sources}
 
         channel_stats: dict[str, ChannelStats] = {}
 

--- a/tg_parser/services/background_scheduler.py
+++ b/tg_parser/services/background_scheduler.py
@@ -19,7 +19,7 @@ logger = structlog.get_logger(__name__)
 class BackgroundScheduler:
     """
     Background task scheduler using APScheduler.
-    
+
     Manages periodic tasks like:
     - Expired records cleanup
     - Health checks
@@ -55,7 +55,7 @@ class BackgroundScheduler:
     ) -> None:
         """
         Add a periodic task.
-        
+
         Args:
             task_id: Unique task identifier
             func: Async function to execute
@@ -101,10 +101,10 @@ class BackgroundScheduler:
     def remove_task(self, task_id: str) -> bool:
         """
         Remove a task.
-        
+
         Args:
             task_id: Task identifier
-            
+
         Returns:
             True if task was removed, False if not found
         """
@@ -123,7 +123,7 @@ class BackgroundScheduler:
     def get_tasks(self) -> list[dict[str, Any]]:
         """
         Get list of scheduled tasks.
-        
+
         Returns:
             List of task info dictionaries
         """
@@ -154,7 +154,7 @@ class BackgroundScheduler:
     def shutdown(self, wait: bool = True) -> None:
         """
         Shutdown the scheduler.
-        
+
         Args:
             wait: Whether to wait for running tasks to complete
         """
@@ -187,11 +187,11 @@ async def cleanup_expired_records(
 ) -> dict[str, int]:
     """
     Cleanup expired task history and handoff records.
-    
+
     Args:
         retention_days: Number of days to retain records
         archive_path: Optional path to archive expired records
-        
+
     Returns:
         Dictionary with cleanup statistics
     """
@@ -237,9 +237,9 @@ async def cleanup_expired_records(
 async def health_check_task() -> dict[str, str]:
     """
     Periodic health check task.
-    
+
     Checks all components and logs warnings for unhealthy ones.
-    
+
     Returns:
         Dictionary with component health status
     """
@@ -266,7 +266,7 @@ def setup_default_tasks(
 ) -> None:
     """
     Setup default background tasks.
-    
+
     Args:
         scheduler: Scheduler instance
         cleanup_interval_hours: Interval for cleanup task in hours

--- a/tg_parser/services/channel_service.py
+++ b/tg_parser/services/channel_service.py
@@ -114,7 +114,7 @@ async def get_all_channel_stats(
                 )
 
                 missing_refs = await emb_repo.list_missing(cid)
-                missing_embeddings = len(missing_refs)
+                len(missing_refs)
 
                 results.append({
                     "channel_id": cid,

--- a/tg_parser/services/embedding_service.py
+++ b/tg_parser/services/embedding_service.py
@@ -150,7 +150,7 @@ async def run_embedding(
                 total_api_time += time.perf_counter() - api_t0
 
                 items = []
-                for ref, emb in zip(batch_refs, embeddings):
+                for ref, emb in zip(batch_refs, embeddings, strict=False):
                     items.append((ref, emb, model, None))
 
                 db_t0 = time.perf_counter()
@@ -233,7 +233,7 @@ async def run_incremental_embedding(
 
                 items = [
                     (d.source_ref, emb, model, None)
-                    for d, emb in zip(batch, embeddings)
+                    for d, emb in zip(batch, embeddings, strict=False)
                 ]
                 saved = await emb_repo.save_batch(items)
                 embedded_count += saved
@@ -312,7 +312,7 @@ async def run_topic_embedding(
 
                 embeddings = await client.embed(texts)
 
-                for card, emb in zip(batch, embeddings):
+                for card, emb in zip(batch, embeddings, strict=False):
                     await emb_repo.save(
                         source_ref=card.id,
                         embedding=emb,

--- a/tg_parser/services/topic_linking_service.py
+++ b/tg_parser/services/topic_linking_service.py
@@ -50,7 +50,7 @@ def _cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
     """Compute cosine similarity between two embedding vectors."""
     if not vec_a or not vec_b or len(vec_a) != len(vec_b):
         return 0.0
-    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    dot = sum(a * b for a, b in zip(vec_a, vec_b, strict=False))
     norm_a = math.sqrt(sum(a * a for a in vec_a))
     norm_b = math.sqrt(sum(b * b for b in vec_b))
     if norm_a == 0 or norm_b == 0:

--- a/tg_parser/storage/engine_factory.py
+++ b/tg_parser/storage/engine_factory.py
@@ -17,7 +17,7 @@ logger = structlog.get_logger(__name__)
 class EngineConfig:
     """
     Конфигурация для создания SQLAlchemy engine.
-    
+
     Attributes:
         url: SQLAlchemy connection URL
         pool_size: Base number of connections in pool
@@ -56,7 +56,7 @@ def _build_postgres_url(
 ) -> str:
     """
     Построить PostgreSQL connection URL.
-    
+
     Returns:
         SQLAlchemy URL for PostgreSQL with asyncpg driver
     """
@@ -78,7 +78,7 @@ def create_postgres_engine_config(
 ) -> EngineConfig:
     """
     Создать конфигурацию engine для PostgreSQL.
-    
+
     PostgreSQL использует QueuePool для эффективного переиспользования connections.
     """
     url = _build_postgres_url(host, port, database, user, password)
@@ -144,15 +144,15 @@ def create_engine_from_settings(
 ) -> AsyncEngine:
     """
     Создать AsyncEngine из Settings для указанной БД.
-    
+
     Args:
         settings: Application settings
         db_name: Which database: 'ingestion', 'raw', or 'processing'
         echo: Enable SQL query logging (for debugging)
-        
+
     Returns:
         Configured AsyncEngine
-        
+
     Raises:
         ValueError: If db_name is invalid
     """

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -43,7 +43,7 @@ class JobStatus(str, Enum):
 class Job:
     """
     API Job model for persistent storage.
-    
+
     Stores state of async processing/export jobs.
     """
     job_id: str
@@ -629,7 +629,7 @@ class TopicLinkRepo(ABC):
 class JobRepo(ABC):
     """
     Repository for API jobs (Phase 2F - Persistent Job Storage).
-    
+
     Stores processing and export job state persistently.
     """
 
@@ -657,7 +657,7 @@ class JobRepo(ABC):
     ) -> list[Job]:
         """
         List jobs with optional filters.
-        
+
         Returns most recent first.
         """
         pass
@@ -666,7 +666,7 @@ class JobRepo(ABC):
     async def delete_old_jobs(self, older_than: datetime) -> int:
         """
         Delete jobs older than specified date.
-        
+
         Returns number of deleted jobs.
         """
         pass
@@ -686,7 +686,7 @@ class JobRepo(ABC):
 class AgentState:
     """
     Persistent state of an agent.
-    
+
     Stores metadata and accumulated statistics for recovery after restart.
     """
     name: str
@@ -714,7 +714,7 @@ class AgentState:
 class TaskRecord:
     """
     Record of a task execution.
-    
+
     Stores full input/output with TTL for archival.
     """
     id: str
@@ -735,7 +735,7 @@ class TaskRecord:
 class AgentDailyStats:
     """
     Aggregated daily statistics for an agent.
-    
+
     Persists even after task history cleanup.
     """
     agent_name: str
@@ -872,7 +872,7 @@ class EmbeddingRepo(ABC):
 class AgentStateRepo(ABC):
     """
     Repository for agent state persistence (Phase 3B).
-    
+
     Stores agent metadata and statistics for recovery after restart.
     """
 
@@ -905,7 +905,7 @@ class AgentStateRepo(ABC):
     ) -> None:
         """
         Update agent statistics after task completion.
-        
+
         Updates: total_tasks_processed, total_errors, avg_processing_time_ms, last_used_at
         """
         pass
@@ -914,7 +914,7 @@ class AgentStateRepo(ABC):
 class TaskHistoryRepo(ABC):
     """
     Repository for task execution history (Phase 3B).
-    
+
     Stores full input/output with TTL for archival.
     """
 
@@ -934,7 +934,7 @@ class TaskHistoryRepo(ABC):
     ) -> str:
         """
         Record a task execution.
-        
+
         Returns: Task ID
         """
         pass
@@ -975,7 +975,7 @@ class TaskHistoryRepo(ABC):
     async def cleanup_expired(self) -> int:
         """
         Delete expired records.
-        
+
         Returns: Number of deleted records
         """
         pass
@@ -992,7 +992,7 @@ class TaskHistoryRepo(ABC):
 class AgentStatsRepo(ABC):
     """
     Repository for aggregated agent statistics (Phase 3B).
-    
+
     Daily statistics persist even after task history cleanup.
     """
 
@@ -1035,7 +1035,7 @@ class AgentStatsRepo(ABC):
     ) -> dict[str, Any]:
         """
         Get summary statistics for an agent.
-        
+
         Returns aggregated stats over the specified number of days.
         """
         pass

--- a/tg_parser/storage/sqlalchemy/agent_state_repo.py
+++ b/tg_parser/storage/sqlalchemy/agent_state_repo.py
@@ -18,14 +18,14 @@ logger = structlog.get_logger(__name__)
 class SAAgentStateRepo(AgentStateRepo):
     """
     SQLAlchemy implementation of agent state storage.
-    
+
     Uses PostgreSQL (agent_states table).
     """
 
     def __init__(self, session_factory):
         """
         Initialize with session factory.
-        
+
         Args:
             session_factory: Callable that returns AsyncSession
         """
@@ -165,14 +165,14 @@ class SAAgentStateRepo(AgentStateRepo):
     ) -> None:
         """
         Update agent statistics after task completion.
-        
+
         Uses incremental update for rolling average.
         """
         async with self._session_factory() as session:
             # First, get current stats
             result = await session.execute(
                 text("""
-                    SELECT total_tasks_processed, total_errors, avg_processing_time_ms 
+                    SELECT total_tasks_processed, total_errors, avg_processing_time_ms
                     FROM agent_states WHERE name = :name
                 """),
                 {"name": name},

--- a/tg_parser/storage/sqlalchemy/agent_stats_repo.py
+++ b/tg_parser/storage/sqlalchemy/agent_stats_repo.py
@@ -18,7 +18,7 @@ logger = structlog.get_logger(__name__)
 class SAAgentStatsRepo(AgentStatsRepo):
     """
     SQLAlchemy implementation of agent statistics storage.
-    
+
     Uses PostgreSQL (agent_stats table).
     Stores aggregated daily statistics that persist even after task history cleanup.
     """
@@ -26,7 +26,7 @@ class SAAgentStatsRepo(AgentStatsRepo):
     def __init__(self, session_factory):
         """
         Initialize with session factory.
-        
+
         Args:
             session_factory: Callable that returns AsyncSession
         """
@@ -62,7 +62,7 @@ class SAAgentStatsRepo(AgentStatsRepo):
                 text("""
                     SELECT total_tasks, successful_tasks, failed_tasks,
                            total_processing_time_ms, min_processing_time_ms, max_processing_time_ms
-                    FROM agent_stats 
+                    FROM agent_stats
                     WHERE agent_name = :agent_name AND date = :date AND task_type = :task_type
                 """),
                 {"agent_name": agent_name, "date": today, "task_type": task_type},
@@ -186,7 +186,7 @@ class SAAgentStatsRepo(AgentStatsRepo):
     ) -> dict[str, Any]:
         """
         Get summary statistics for an agent.
-        
+
         Returns aggregated stats over the specified number of days.
         """
         from_date = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
@@ -194,7 +194,7 @@ class SAAgentStatsRepo(AgentStatsRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    SELECT 
+                    SELECT
                         SUM(total_tasks) as total_tasks,
                         SUM(successful_tasks) as successful_tasks,
                         SUM(failed_tasks) as failed_tasks,
@@ -203,7 +203,7 @@ class SAAgentStatsRepo(AgentStatsRepo):
                         MAX(max_processing_time_ms) as max_time,
                         COUNT(DISTINCT date) as active_days,
                         COUNT(DISTINCT task_type) as task_types
-                    FROM agent_stats 
+                    FROM agent_stats
                     WHERE agent_name = :agent_name AND date >= :from_date
                 """),
                 {"agent_name": agent_name, "from_date": from_date},

--- a/tg_parser/storage/sqlalchemy/handoff_history_repo.py
+++ b/tg_parser/storage/sqlalchemy/handoff_history_repo.py
@@ -19,14 +19,14 @@ logger = structlog.get_logger(__name__)
 class SAHandoffHistoryRepo(HandoffHistoryRepo):
     """
     SQLAlchemy implementation of handoff history storage.
-    
+
     Uses PostgreSQL (handoff_history table).
     """
 
     def __init__(self, session_factory):
         """
         Initialize with session factory.
-        
+
         Args:
             session_factory: Callable that returns AsyncSession
         """
@@ -185,7 +185,7 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
     ) -> dict[str, Any]:
         """Get handoff statistics."""
         query = """
-            SELECT 
+            SELECT
                 COUNT(*) as total_handoffs,
                 SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
                 SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
@@ -194,7 +194,7 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
                 AVG(processing_time_ms) as avg_processing_time_ms,
                 MIN(processing_time_ms) as min_processing_time_ms,
                 MAX(processing_time_ms) as max_processing_time_ms
-            FROM handoff_history 
+            FROM handoff_history
             WHERE 1=1
         """
         params: dict = {}
@@ -266,11 +266,11 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
     ) -> list[HandoffRecord]:
         """
         Get expired handoff records for archiving before deletion.
-        
+
         Args:
             retention_days: Records older than this are considered expired
             limit: Maximum number of records to return
-            
+
         Returns:
             List of expired HandoffRecord objects
         """
@@ -281,7 +281,7 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    SELECT * FROM handoff_history 
+                    SELECT * FROM handoff_history
                     WHERE created_at < :cutoff
                     ORDER BY created_at ASC
                     LIMIT :limit
@@ -298,10 +298,10 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
     ) -> int:
         """
         Delete expired handoff records.
-        
+
         Args:
             retention_days: Records older than this will be deleted
-            
+
         Returns:
             Number of deleted records
         """
@@ -312,7 +312,7 @@ class SAHandoffHistoryRepo(HandoffHistoryRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    DELETE FROM handoff_history 
+                    DELETE FROM handoff_history
                     WHERE created_at < :cutoff
                 """),
                 {"cutoff": cutoff},

--- a/tg_parser/storage/sqlalchemy/job_repo.py
+++ b/tg_parser/storage/sqlalchemy/job_repo.py
@@ -18,14 +18,14 @@ logger = structlog.get_logger(__name__)
 class SAJobRepo(JobRepo):
     """
     SQLAlchemy implementation of job storage.
-    
+
     Uses PostgreSQL (api_jobs table).
     """
 
     def __init__(self, session_factory):
         """
         Initialize with session factory.
-        
+
         Args:
             session_factory: Callable that returns AsyncSession
         """
@@ -169,7 +169,7 @@ class SAJobRepo(JobRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    DELETE FROM api_jobs 
+                    DELETE FROM api_jobs
                     WHERE created_at < :older_than
                     AND status IN ('completed', 'failed')
                 """),

--- a/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
+++ b/tg_parser/storage/sqlalchemy/schemas/processing_storage.py
@@ -124,13 +124,13 @@ CREATE TABLE IF NOT EXISTS agent_states (
   provider TEXT,
   is_active INTEGER NOT NULL DEFAULT 1,
   metadata_json TEXT,
-  
+
   -- Statistics (restored on startup)
   total_tasks_processed INTEGER NOT NULL DEFAULT 0,
   total_errors INTEGER NOT NULL DEFAULT 0,
   avg_processing_time_ms REAL NOT NULL DEFAULT 0.0,
   last_used_at TEXT,
-  
+
   -- Timestamps
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
@@ -144,24 +144,24 @@ CREATE TABLE IF NOT EXISTS task_history (
   id TEXT PRIMARY KEY,
   agent_name TEXT NOT NULL,
   task_type TEXT NOT NULL,
-  
+
   -- Context
   source_ref TEXT,
   channel_id TEXT,
-  
+
   -- Full data (JSON)
   input_json TEXT NOT NULL,
   output_json TEXT,
-  
+
   -- Result
   success INTEGER NOT NULL DEFAULT 1,
   error TEXT,
   processing_time_ms INTEGER,
-  
+
   -- Timestamps and retention
   created_at TEXT NOT NULL,
   expires_at TEXT,
-  
+
   FOREIGN KEY (agent_name) REFERENCES agent_states(name)
 );
 
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS agent_stats (
   agent_name TEXT NOT NULL,
   date TEXT NOT NULL,
   task_type TEXT NOT NULL,
-  
+
   -- Daily aggregates
   total_tasks INTEGER NOT NULL DEFAULT 0,
   successful_tasks INTEGER NOT NULL DEFAULT 0,
@@ -184,7 +184,7 @@ CREATE TABLE IF NOT EXISTS agent_stats (
   total_processing_time_ms INTEGER NOT NULL DEFAULT 0,
   min_processing_time_ms INTEGER,
   max_processing_time_ms INTEGER,
-  
+
   PRIMARY KEY (agent_name, date, task_type)
 );
 
@@ -198,16 +198,16 @@ CREATE TABLE IF NOT EXISTS handoff_history (
   target_agent TEXT NOT NULL,
   task_type TEXT NOT NULL,
   priority INTEGER NOT NULL DEFAULT 5,
-  
+
   -- Status tracking
   status TEXT NOT NULL CHECK(status IN ('pending', 'accepted', 'in_progress', 'completed', 'failed', 'rejected')),
-  
+
   -- Data (JSON)
   payload_json TEXT,
   context_json TEXT,
   result_json TEXT,
   error TEXT,
-  
+
   -- Timing
   processing_time_ms INTEGER,
   created_at TEXT NOT NULL,

--- a/tg_parser/storage/sqlalchemy/task_history_repo.py
+++ b/tg_parser/storage/sqlalchemy/task_history_repo.py
@@ -19,14 +19,14 @@ logger = structlog.get_logger(__name__)
 class SATaskHistoryRepo(TaskHistoryRepo):
     """
     SQLAlchemy implementation of task history storage.
-    
+
     Uses PostgreSQL (task_history table).
     """
 
     def __init__(self, session_factory, default_retention_days: int = 14):
         """
         Initialize with session factory.
-        
+
         Args:
             session_factory: Callable that returns AsyncSession
             default_retention_days: Default retention period for task records
@@ -83,7 +83,7 @@ class SATaskHistoryRepo(TaskHistoryRepo):
     ) -> str:
         """
         Record a task execution.
-        
+
         Returns: Task ID
         """
         task_id = f"task_{uuid.uuid4().hex[:12]}"
@@ -210,7 +210,7 @@ class SATaskHistoryRepo(TaskHistoryRepo):
     async def cleanup_expired(self) -> int:
         """
         Delete expired records.
-        
+
         Returns: Number of deleted records
         """
         now = datetime.now(UTC).isoformat()
@@ -218,7 +218,7 @@ class SATaskHistoryRepo(TaskHistoryRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    DELETE FROM task_history 
+                    DELETE FROM task_history
                     WHERE expires_at IS NOT NULL AND expires_at < :now
                 """),
                 {"now": now},
@@ -244,7 +244,7 @@ class SATaskHistoryRepo(TaskHistoryRepo):
         async with self._session_factory() as session:
             result = await session.execute(
                 text("""
-                    SELECT * FROM task_history 
+                    SELECT * FROM task_history
                     WHERE expires_at IS NOT NULL AND expires_at < :now
                     ORDER BY expires_at ASC
                     LIMIT :limit


### PR DESCRIPTION
## Summary

Final stage of the 3-PR lint-debt cleanup. After this merges, `ruff check tg_parser/ tests/` returns **All checks passed!** and CI lint job will be green for all subsequent PRs (including F5-A Phase 1 #2).

### Auto-fixes (`--unsafe-fixes`, semantically safe)

| Code | Count | Description |
|---|---|---|
| W293/W291 | 333 | Trailing whitespace in docstrings |
| F841 | 17 | Unused-variable (call expressions preserved as bare statements) |
| B905 | 5 | `zip()` → `zip(strict=False)` (preserves silent-truncate behavior) |
| C401/C408/C416 | 4 | Collection-call simplifications |

### Manual fixes (~14)

- **F821** `tg_parser/processing/llm/factory.py` — added `TYPE_CHECKING` import for `LLMRateLimiter` forward-reference (kept lazy runtime import in function body)
- **B904** ×3 `cli/*` — `raise X from err` inside except clauses
- **E741** ×2 — renamed `l` → `link` in test set comprehensions
- **B007** ×1 — renamed unused `i` → `_` in range loop
- **B017** `tests/test_postgres_integration.py` — `pytest.raises(Exception)` → `pytest.raises(ValidationError)` for Settings validation
- **E402** `tg_parser/api/routes/health.py` — moved 3 imports above `logger =`
- **UP046** `tg_parser/agents/base.py` — `# noqa` (PEP 695 migration deferred, affects BaseAgent subclass hierarchy)

### Targeted suppressions with rationale

- `tests/conftest.py` 3× E402 — must follow `os.environ["DB_NAME"]` override
- `tests/test_mcp_server.py` 2× E402 — section-local imports for late-defined test class
- `tests/test_postgres_concurrency.py` 1× B017 — backend-specific pool exhaustion error
- `tests/test_e2e_pipeline.py` — fixed invalid `# noqa` (added missing code `B901`)

## Test plan

- [x] `ruff check tg_parser/ tests/` → All checks passed (0 errors)
- [x] `pytest tests/ -x -q` → 1273 passed, 58 skipped, 0 failed
- [x] No behavior changes (semantically equivalent transformations only)

## Stages roadmap

- ✅ **Stage 1 (PR #4):** Safe auto-fix — 2078 cosmetic fixes
- ✅ **Stage 2 (PR #5):** F401 unused-imports — 89 fixes
- ✅ **Stage 3 (this PR):** Manual + unsafe-safe fixes — 359 fixes → **0 lint errors**

After merge: rebase F5-A Phase 1 PR #2 onto green main and merge.

Made with [Cursor](https://cursor.com)