### PR TITLE
feat(f5a-phase2): Relevance tuning — type quotas, FTS min_rank, structured RAG context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,16 @@ DB_MAX_OVERFLOW=10
 
 
 # =============================================================================
+# RAG Relevance Tuning (F5-A Phase 2)
+# =============================================================================
+# Fine-tune keyword search cutoffs and RAG type-quota behaviour in answer().
+#
+# FTS_MIN_RANK=0.0                        # ts_rank_cd cutoff (0.0 = no cutoff); typical useful range 0.001-0.05
+# RAG_TOPIC_QUOTA=2                       # Reserve N topic cards in answer() context; remainder goes to messages
+# RAG_SEARCH_OVERFETCH_FACTOR=2           # answer() fetches limit * factor before quota split (headroom)
+
+
+# =============================================================================
 # Topicization Tuning
 # =============================================================================
 # TOPICIZATION_BATCH_SIZE=50           # Max docs per LLM call in discover_new_topics

--- a/ENV_VARIABLES_GUIDE.md
+++ b/ENV_VARIABLES_GUIDE.md
@@ -129,6 +129,14 @@ LLM_VERBOSITY=low
 # FTS_LANGUAGES=russian,english
 
 # =============================================================================
+# RAG Relevance Tuning (F5-A Phase 2)
+# =============================================================================
+
+# FTS_MIN_RANK=0.0
+# RAG_TOPIC_QUOTA=2
+# RAG_SEARCH_OVERFETCH_FACTOR=2
+
+# =============================================================================
 # Multi-Tenancy (F4)
 # =============================================================================
 
@@ -560,6 +568,42 @@ override per-request (`"semantic" | "keyword" | "hybrid"`).
 `e5f6a7b8c9d0` (`topic_cards.search_vector`). WARNING: `ADD COLUMN ...
 GENERATED ... STORED` triggers a full table rewrite in PostgreSQL. Apply
 during a maintenance window for production databases > 1M rows.
+
+---
+
+### RAG Relevance Tuning (F5-A Phase 2)
+
+Fine-tune keyword cutoffs and topic/message quotas in the RAG pipeline. All
+three settings are consumed inside `retrieval_service`: `fts_min_rank` is
+forwarded to `emb_repo.keyword_search` on keyword/hybrid paths; `rag_topic_quota`
+and `rag_search_overfetch_factor` drive `answer()` behaviour
+(`_apply_type_quotas` + overfetch). Callers can override per-request via
+`search(fts_min_rank=...)` / `answer(topic_quota=...)`.
+
+#### `FTS_MIN_RANK`
+- **Type**: float (>= 0.0)
+- **Default**: `0.0`
+- **Description**: Default `ts_rank_cd` cutoff for keyword search. `0.0`
+  disables the cutoff (all hits are returned). Typical useful range for
+  noisy corpora is `0.001`–`0.05`: raise this to drop marginal FTS matches
+  from the keyword branch. The semantic branch is unaffected (it uses
+  `threshold` for pgvector cosine cutoffs).
+
+#### `RAG_TOPIC_QUOTA`
+- **Type**: integer (0..20)
+- **Default**: `2`
+- **Description**: Number of topic cards reserved in the RAG context before
+  filling the remainder with messages. `0` → topics disabled for RAG.
+  Raise to `3–4` for overview-style questions; keep `2` for factual
+  queries. Clamped to `limit` inside `answer()`.
+
+#### `RAG_SEARCH_OVERFETCH_FACTOR`
+- **Type**: integer (1..10)
+- **Default**: `2`
+- **Description**: `answer()` fetches `limit * factor` candidates from
+  `search()` to give `_apply_type_quotas` headroom for the underflow
+  fallback. Increasing this helps when the corpus skews toward one type
+  (e.g. many messages, few topics) but doubles/triples retrieval work.
 
 ---
 

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -97,6 +97,7 @@ Parameters:
   query: str                    # Search query (natural language)
   channel_id: str | null        # Filter by channel (optional)
   limit: int = 10               # Max results
+  mode: str = "hybrid"          # "semantic" | "keyword" | "hybrid"
 
 Returns: list[SearchResultItem]
   source_ref: str
@@ -106,11 +107,10 @@ Returns: list[SearchResultItem]
   channel_id: str | null
 ```
 
-**Retrieval mode (F5-A Phase 1):** `search_knowledge_base` uses hybrid retrieval
-by default (keyword FTS + semantic pgvector fused via Reciprocal Rank Fusion).
-The `mode` parameter (`"semantic" | "keyword" | "hybrid"`) is exposed on the
-REST `/api/v1/search` endpoint; MCP pass-through of `mode` is planned for
-Phase 2.
+**Retrieval mode:** Since F5-A Phase 2, `mode` is forwarded through the MCP
+wrapper into the retrieval service. Values: `semantic` (pgvector cosine
+only), `keyword` (PostgreSQL FTS `ts_rank_cd` only), `hybrid` (both via
+Reciprocal Rank Fusion; default). Invalid values raise `ValueError`.
 
 ### `ask_question`
 
@@ -118,12 +118,22 @@ Phase 2.
 Parameters:
   question: str                 # Natural language question
   channel_id: str | null        # Filter by channel (optional)
+  mode: str = "hybrid"          # "semantic" | "keyword" | "hybrid"
 
 Returns: AnswerResultItem
   answer: str
   sources: list[SearchResultItem]
   model: str | null
 ```
+
+**Context structure (F5-A Phase 2):** The underlying RAG pipeline now
+assembles the LLM context from two optional sections — `## Related Topics`
+(topic cards, prefixed `[T1]`, `[T2]`, …) and `## Source Messages`
+(individual posts, prefixed `[M1]`, `[M2]`, …). The bracket indices are
+visual labels; the LLM is instructed to cite via the `ref` value (e.g.
+`[tg:channel:post:123]`). Topic-weighted quotas (`RAG_TOPIC_QUOTA`) and
+overfetch (`RAG_SEARCH_OVERFETCH_FACTOR`) are configurable via env vars —
+see `USER_GUIDE.md` → “RAG Context Structure & Type Quotas”.
 
 ### `list_topics`
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -390,7 +390,7 @@ TOPICIZATION_LLM_MODEL=claude-sonnet-4-20250514
 | `keyword` | Только FTS (`plainto_tsquery` + `ts_rank_cd`) | Точные термины, имена, аббревиатуры |
 | `hybrid` (default) | `semantic` + `keyword` через RRF | Общий случай — безопасный дефолт |
 
-`POST /api/v1/search` и `/api/v1/ask` принимают поле `mode` в теле запроса; MCP-инструмент `search_knowledge_base` также использует `hybrid` по умолчанию (в Phase 1 `mode` ещё не пробрасывается через MCP-wrapper — ожидается в Phase 2).
+`POST /api/v1/search` и `/api/v1/ask` принимают поле `mode` в теле запроса. Начиная с Phase 2 MCP-инструменты `search_knowledge_base` и `ask_question` также принимают параметр `mode` (значения те же: `semantic` | `keyword` | `hybrid`, дефолт `hybrid`).
 
 ### Multilingual FTS
 
@@ -415,6 +415,43 @@ python -m tg_parser.cli migrate --target head
 # Проверить текущий head
 python -m tg_parser.cli migrate --show-current
 ```
+
+---
+
+## RAG Context Structure & Type Quotas (F5-A Phase 2)
+
+Начиная с Phase 2 RAG Q&A (`ask_question` / `POST /api/v1/ask`) собирает контекст для LLM из **двух отдельных секций**:
+
+- `## Related Topics` — блоки с префиксом `[T1]`, `[T2]`, …, содержат `title`, `summary`, `scope`, `tags` и список каналов-источников. Используются LLM для тематического обрамления ответа.
+- `## Source Messages` — блоки с префиксом `[M1]`, `[M2]`, …, содержат `channel`, `ref`, текст (truncated до `context_char_limit`) и темы. Используются для конкретных фактов.
+
+Префиксы `[T1]` / `[M1]` — **только визуальные метки** внутри контекста. Для цитирования LLM просят использовать `ref`-значение (например, `[tg:channel:post:123]` или `[topic:…]`), а не индекс. Версия промпта — `prompts/rag.yaml` v1.2.0.
+
+### Квотирование тем и сообщений
+
+`answer()` теперь:
+
+1. Делает `search(limit=limit * RAG_SEARCH_OVERFETCH_FACTOR)` для «headroom».
+2. Применяет `_apply_type_quotas`: берёт до `RAG_TOPIC_QUOTA` карточек тем, остальное — сообщениями.
+3. При недоборе в одну сторону backfill-ит за счёт другой (если тем меньше квоты — добирает сообщениями; если сообщений нет — добирает темами).
+4. Возвращает `≤ limit` источников (overfetch — внутренняя оптимизация; бот/CLI получают ровно то число, что просили).
+
+### Настройка релевантности
+
+```env
+# FTS score cutoff для keyword-ветки (0.0 = без cutoff). Типично 0.001–0.05.
+FTS_MIN_RANK=0.0
+# Сколько тем резервировать в контексте RAG перед заполнением сообщениями.
+RAG_TOPIC_QUOTA=2
+# Множитель overfetch для headroom против недобора после квотирования.
+RAG_SEARCH_OVERFETCH_FACTOR=2
+```
+
+Явный вызов `search(fts_min_rank=…)` / `answer(topic_quota=…)` переопределяет дефолты на один запрос. Semantic-ветка использует отдельный `threshold` (pgvector cosine) и `FTS_MIN_RANK` игнорирует.
+
+> 💡 **Когда повышать `FTS_MIN_RANK`:** если в корпусе много коротких сообщений с шумной лексикой и keyword-mode возвращает слабо-релевантный хвост. Диапазон 0.001–0.05 обычно отсекает «случайные» совпадения без потери полезных.
+>
+> 💡 **Когда менять `RAG_TOPIC_QUOTA`:** поднимайте до 3–4 для обзорных вопросов «что было на тему X?», оставляйте `2` для фактических запросов. `0` — если темы не нужны совсем.
 
 ---
 

--- a/docs/plans/F5A_PERSISTENT_KB_PLAN.md
+++ b/docs/plans/F5A_PERSISTENT_KB_PLAN.md
@@ -207,14 +207,27 @@ fts_languages: str = "russian,english"  # информационная
 
 ---
 
-## 4. Фаза 2 — Relevance tuning & Topic-weighted RAG (набросок)
+## 4. Фаза 2 — Relevance tuning & Topic-weighted RAG (DONE)
 
-> Детализация — в отдельном prompt перед Session 2.
+**Phase 2 DONE** — ветка `feat/f5a-phase2-relevance-tuning`, коммиты:
+- `feat(f5a-phase2): add RAG type quotas and FTS min_rank pipeline`
+- `feat(f5a-phase2): structured topic-weighted RAG context + MCP mode passthrough`
 
-- **`min_score` cutoff** в `similarity_search` и в hybrid fusion (пороги — в settings).
-- **Квоты по типам**: `topic_quota=2`, `message_quota=N-2` вместо общего pool — в `retrieval_service.answer()`.
-- **Структурированный RAG context**: `_build_context` выдаёт два раздела — `## Related Topics` (сжатые topic cards) и `## Source Messages` (chunks). Обновляем `prompts/rag.yaml`.
-- **A/B-проверка**: опционально пробрасываем `include_topic_cards` как параметр MCP-tool для сравнения.
+**Что добавлено:**
+
+- **`FTS_MIN_RANK` cutoff** для keyword-ветки через `retrieval_service.search(fts_min_rank=...)` → `emb_repo.keyword_search(min_rank=...)`. Semantic-ветка продолжает использовать `threshold` для pgvector cosine.
+- **Квоты по типам** через новую pure-function `_apply_type_quotas(results, limit, topic_quota)`: up to `RAG_TOPIC_QUOTA` топиков, остальное — сообщениями, с underflow fallback в обе стороны. `answer()` делает overfetch `limit * RAG_SEARCH_OVERFETCH_FACTOR` перед квотированием.
+- **Структурированный RAG context**: `_build_context` теперь выдаёт два раздела — `## Related Topics` (префикс `[T1]`/`[T2]`/…) и `## Source Messages` (`[M1]`/`[M2]`/…). Пустые секции опускаются. Score выводится с 3 знаками после запятой.
+- **`prompts/rag.yaml` v1.2.0** — system prompt описывает обе секции и правила цитирования через `ref`, а не через bracket-индекс.
+- **MCP `mode` passthrough** — `search_knowledge_base` и `ask_question` принимают `mode: str = "hybrid"`; невалидное значение → `ValueError`. `_MCP_INSTRUCTIONS` обновлён.
+
+**Что отложено в Phase 3 / вне scope F5-A:**
+
+- Deduplication (content hash, near-duplicate) — §5 ниже.
+- Cross-encoder / LLM re-ranking, linear fusion как альтернатива RRF.
+- `mode` в bot/CLI `search`/`answer` (дефолт `hybrid` достаточен).
+- GIN по `topic_cards.channel_ids`, автодетекция языка FTS.
+- Adaptive quotas.
 
 ---
 

--- a/docs/plans/F5A_PHASE2_IMPLEMENTATION_PLAN.md
+++ b/docs/plans/F5A_PHASE2_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,483 @@
+# F5-A Phase 2 — Implementation Plan (Relevance tuning & Topic-weighted RAG)
+
+**Версия проекта:** 4.5.0+ (после мёрджа Phase 1 — `feat/f5a-phase1-hybrid-search`, PR #2)
+**Scope:** Тонкая настройка relevance (min_score cutoffs + topic/message квоты) и структурированный RAG-контекст с разделами `## Related Topics` и `## Source Messages`. Проброс `mode` в MCP-tools.
+**Предыдущие фазы:** Wave 1.5 → F8-A ✅ → F5-A Phase 1 (Hybrid Search) ✅. Следующие: F5-A Phase 3 (dedup).
+**Design-doc:** [`F5A_PERSISTENT_KB_PLAN.md`](F5A_PERSISTENT_KB_PLAN.md) §4.
+**Starter prompt:** [`../prompts/F5A_PHASE2_IMPLEMENTATION_PROMPT.md`](../prompts/F5A_PHASE2_IMPLEMENTATION_PROMPT.md)
+
+---
+
+## Контекст (что уже есть после Phase 1)
+
+- `retrieval_service.search(mode="semantic"|"keyword"|"hybrid")` — [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) строка 49. Дефолт `hybrid`. Параметр `threshold` применяется только к semantic ветке (pgvector cosine cutoff).
+- `retrieval_service.answer(mode=...)` — строка 239. Вызывает `search(limit=5)`, затем строит `_build_context` (строка 208) без разделения по типам: все блоки в одном пуле с префиксом `[TOPIC]` или `[1] channel:`.
+- `emb_repo.keyword_search(min_rank=0.0)` — [`tg_parser/storage/sqlalchemy/embedding_repo.py`](../../tg_parser/storage/sqlalchemy/embedding_repo.py) строка 177. Python-side cutoff на `ts_rank_cd`. Сервис сейчас передаёт дефолт `0.0`.
+- `rrf_fuse` — [`tg_parser/services/_ranking.py`](../../tg_parser/services/_ranking.py). RRF score не нормализован и не сопоставим с cosine/ts_rank → **post-fusion cutoff не применяем**.
+- Settings — [`tg_parser/config/settings.py`](../../tg_parser/config/settings.py) строки 476–488: `hybrid_enabled`, `hybrid_rrf_k`, `fts_languages`.
+- MCP tools `search_knowledge_base` (строка 436) и `ask_question` (строка 477) — [`tg_parser/mcp_server.py`](../../tg_parser/mcp_server.py). Оба БЕЗ параметра `mode`, hybrid используется неявно по дефолту.
+- Прочие потребители `search`/`answer`: [`tg_parser/api/routes/rag.py`](../../tg_parser/api/routes/rag.py) (уже имеет `mode`), [`tg_parser/bot/tools.py`](../../tg_parser/bot/tools.py), [`tg_parser/cli/app.py`](../../tg_parser/cli/app.py).
+- Существующие тесты `_build_context`: `tests/test_f5a_topic_rag.py` (9 методов: строки 540, 556, 570, 593, 605, 611, 1108, 1121, 1134) и `tests/test_rag_prompt_config.py` (8 методов: строки 286, 305, 320, 338, 342, 356, 377, 1401) — суммарно ~17 тестов, ~50 ассертов. **Ломаются при изменении формата**; включаем в scope обновления (Commit 2).
+- Существующий `rag.yaml` v1.1.0 — [`prompts/rag.yaml`](../../prompts/rag.yaml). Будет обновлён до v1.2.0 с описанием двух разделов.
+
+---
+
+## Архитектура
+
+```mermaid
+flowchart LR
+  Q[Question] --> A["answer mode, limit"]
+  A --> S["search limit*2 headroom"]
+  S --> Pool["mixed SearchResults"]
+  Pool --> Split["split by entry_type"]
+  Split --> TQ["topic_quota topics"]
+  Split --> MQ["message_quota messages"]
+  TQ --> Build["_build_context structured"]
+  MQ --> Build
+  Build --> Ctx1["## Related Topics"]
+  Build --> Ctx2["## Source Messages"]
+  Ctx1 --> Prompt
+  Ctx2 --> Prompt
+  Prompt --> LLM
+```
+
+---
+
+## Коммит 1 — Relevance tuning (min_score + type quotas)
+
+### 1.1 Settings
+
+В [`tg_parser/config/settings.py`](../../tg_parser/config/settings.py) после `fts_languages` (~488):
+
+```python
+# ==========================================================================
+# RAG Relevance Tuning (F5-A Phase 2)
+# ==========================================================================
+
+fts_min_rank: float = Field(
+    default=0.0,
+    description="Default ts_rank_cd cutoff for keyword search (0.0 = no cutoff)",
+    ge=0.0,
+)
+rag_topic_quota: int = Field(
+    default=2,
+    description="Number of topic cards reserved in answer() context before filling with messages",
+    ge=0,
+    le=20,
+)
+rag_search_overfetch_factor: int = Field(
+    default=2,
+    description="answer() fetches limit * factor before applying quotas for headroom",
+    ge=1,
+    le=10,
+)
+```
+
+Обновить `.env.example`:
+
+```bash
+# --- F5-A Phase 2: RAG Relevance Tuning ---
+# FTS score cutoff (0.0 = no cutoff). Typical useful range 0.001–0.05.
+FTS_MIN_RANK=0.0
+# Reserve N topic cards in answer() context; remainder goes to messages.
+RAG_TOPIC_QUOTA=2
+# answer() fetches limit * factor before quota split (headroom against under-fill).
+RAG_SEARCH_OVERFETCH_FACTOR=2
+```
+
+### 1.2 Service: pipe `fts_min_rank` через service layer
+
+В [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py):
+
+- Добавить параметр `fts_min_rank: float | None = None` в `search()` (после `threshold`).
+- В веточках `keyword` и `hybrid` передавать `min_rank=fts_min_rank if fts_min_rank is not None else settings.fts_min_rank` в `emb_repo.keyword_search(...)`.
+- Semantic путь продолжает использовать `threshold` как есть.
+
+### 1.3 Service: type quotas в `answer()`
+
+Текущий `answer()` (строка 239) вызывает `search(limit=limit)` и сразу строит context. Phase 2:
+
+```python
+async def answer(
+    question: str,
+    channel_id: str | None = None,
+    limit: int = 5,
+    allowed_channel_ids: list[str] | None = None,
+    mode: SearchMode = "hybrid",
+    topic_quota: int | None = None,
+    *,
+    emb_repo: EmbeddingRepo | None = None,
+    proc_repo: ProcessedDocumentRepo | None = None,
+    llm_client: "LLMClient | None" = None,
+) -> AnswerResult:
+    effective_topic_quota = topic_quota if topic_quota is not None else settings.rag_topic_quota
+    effective_topic_quota = min(effective_topic_quota, limit)
+
+    overfetch = max(1, settings.rag_search_overfetch_factor)
+    raw = await search(
+        question,
+        channel_id=channel_id,
+        limit=limit * overfetch,
+        allowed_channel_ids=allowed_channel_ids,
+        mode=mode,
+        emb_repo=emb_repo,
+        proc_repo=proc_repo,
+    )
+
+    sources = _apply_type_quotas(raw, limit=limit, topic_quota=effective_topic_quota)
+
+    # ... далее как сейчас (no-results branch, prompt build, _call_llm)
+```
+
+**Новая pure-function `_apply_type_quotas`** (в том же модуле, приватная):
+
+```python
+def _apply_type_quotas(
+    results: list[SearchResult],
+    limit: int,
+    topic_quota: int,
+) -> list[SearchResult]:
+    """Split results by entry_type, apply quotas with underflow fallback.
+
+    Rules:
+    - Take up to ``topic_quota`` topics (preserving score order).
+    - Fill remaining slots with messages (preserving score order).
+    - If topics < topic_quota, backfill shortfall with extra messages.
+    - If messages < available slots, backfill shortfall with extra topics.
+    - Return topics first, then messages (stable section-ordering for
+      downstream _build_context).
+    """
+    topics = [r for r in results if r.entry_type == "topic"]
+    messages = [r for r in results if r.entry_type == "message"]
+
+    picked_topics = topics[:topic_quota]
+    remaining = limit - len(picked_topics)
+    picked_messages = messages[:remaining]
+
+    # Underflow: messages < remaining → backfill with extra topics
+    shortfall = limit - len(picked_topics) - len(picked_messages)
+    if shortfall > 0 and len(topics) > len(picked_topics):
+        extra_topics = topics[len(picked_topics) : len(picked_topics) + shortfall]
+        picked_topics.extend(extra_topics)
+
+    return picked_topics + picked_messages
+```
+
+**Важно:**
+- `search()` не меняем в части квот — квотирование только в RAG path (`answer()`).
+- Order within each type preserved (score-descending from `search()`).
+- `topics` блок всегда первым в результате → `_build_context` (Commit 2) делает это явно через секции.
+
+### 1.4 Тесты Коммита 1
+
+Новый файл `tests/test_f5a_phase2_tuning.py`:
+
+- **`TestApplyTypeQuotas`** (~8 unit-тестов, no DB):
+  - `test_empty_results_returns_empty`
+  - `test_topics_within_quota_fill_exact`
+  - `test_messages_fill_remainder`
+  - `test_topic_underflow_backfills_with_messages`
+  - `test_message_underflow_backfills_with_topics`
+  - `test_both_types_sparse_returns_all_available`
+  - `test_topic_quota_zero_returns_only_messages`
+  - `test_topic_quota_equals_limit_returns_only_topics`
+  - `test_order_within_type_preserved`
+
+- **`TestAnswerQuotas`** (~5 integration-style, mocked search):
+  - `test_answer_default_topic_quota_2` — patch `search`, verify `_apply_type_quotas` called with `topic_quota=2`.
+  - `test_answer_topic_quota_override` — explicit `topic_quota=3` overrides settings default.
+  - `test_answer_overfetches_for_quota_headroom` — asserts `search(limit=limit * factor)`.
+  - `test_answer_returns_at_most_limit_sources_after_quotas` — `len(result.sources) <= limit` even after overfetch.
+  - `test_answer_empty_results_returns_no_results_message`.
+
+- **`TestFtsMinRankPipeline`** (~3):
+  - `test_search_passes_settings_default_min_rank` — `keyword_search` called with `min_rank=settings.fts_min_rank`.
+  - `test_search_explicit_min_rank_overrides` — `search(fts_min_rank=0.05)` wins over settings.
+  - `test_semantic_mode_unaffected_by_fts_min_rank` — semantic branch still uses `threshold`.
+
+- **`TestSettingsPhase2`** (~3):
+  - `test_defaults` (`fts_min_rank=0.0`, `rag_topic_quota=2`, `rag_search_overfetch_factor=2`).
+  - `test_env_overrides`.
+  - `test_rag_topic_quota_validator` (reject negative).
+
+### 1.5 Commit 1 message
+
+```
+feat(f5a-phase2): add RAG type quotas and FTS min_rank pipeline
+```
+
+---
+
+## Коммит 2 — Structured topic-weighted context + MCP mode passthrough
+
+### 2.1 Structured `_build_context`
+
+В [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) заменить `_build_context` (строка 208):
+
+```python
+def _build_context(results: list[SearchResult], char_limit: int) -> str:
+    """Build structured RAG context with separate topic and message sections.
+
+    Output format (both sections optional; empty when no matches of that type):
+
+        ## Related Topics
+        [T1] ref: <topic_id> | channels: <csv> | score: <float>
+        Title: <card.title>
+        Summary: <card.summary>
+        Scope: <csv>            (when scope_in non-empty)
+        Tags: <csv>             (when tags non-empty)
+
+        ---
+
+        [T2] ...
+
+        ## Source Messages
+        [M1] channel: <id> | ref: <source_ref> | score: <float>
+        Title: <summary or text[:80]>
+        Text: <text_clean[:char_limit]>
+        Topics: <csv>           (when topics non-empty)
+
+        ---
+
+        [M2] ...
+    """
+    topics = [r for r in results if r.entry_type == "topic" and r.topic_card is not None]
+    messages = [r for r in results if r.entry_type != "topic" and r.document is not None]
+
+    sections: list[str] = []
+
+    if topics:
+        parts = []
+        for i, r in enumerate(topics, 1):
+            card = r.topic_card
+            channels = ", ".join(card.sources) if card.sources else "unknown"
+            header = f"[T{i}] ref: {r.source_ref} | channels: {channels} | score: {r.score:.3f}"
+            body_lines = [f"Title: {card.title}", f"Summary: {card.summary}"]
+            if card.scope_in:
+                body_lines.append(f"Scope: {', '.join(card.scope_in)}")
+            if card.tags:
+                body_lines.append(f"Tags: {', '.join(card.tags)}")
+            parts.append(header + "\n" + "\n".join(body_lines))
+        sections.append("## Related Topics\n\n" + "\n\n---\n\n".join(parts))
+
+    if messages:
+        parts = []
+        for i, r in enumerate(messages, 1):
+            doc = r.document
+            title = doc.summary or doc.text_clean[:80]
+            header = f"[M{i}] channel: {doc.channel_id} | ref: {r.source_ref} | score: {r.score:.3f}"
+            body_lines = [f"Title: {title}", f"Text: {doc.text_clean[:char_limit]}"]
+            if doc.topics:
+                body_lines.append(f"Topics: {', '.join(doc.topics)}")
+            parts.append(header + "\n" + "\n".join(body_lines))
+        sections.append("## Source Messages\n\n" + "\n\n---\n\n".join(parts))
+
+    return "\n\n".join(sections)
+```
+
+Ключевые отличия от v1:
+- Префиксы `[T1]`/`[M1]` (было `[1] [TOPIC]` и `[1] channel:`).
+- Два раздела через `## Related Topics` / `## Source Messages` (markdown H2).
+- Score отображается с 3 знаками (было 2) — даёт лучший signal на hybrid.
+- Порядок: сначала топики, потом сообщения (quota-split уже обеспечен в `answer()`).
+
+### 2.2 Обновить `prompts/rag.yaml` до v1.2.0
+
+```yaml
+metadata:
+  version: "1.2.0"
+  description: "RAG Q&A prompt for answering questions; topic-weighted context (F5-A Phase 2)"
+
+system:
+  prompt: |
+    You are a knowledge base assistant that answers questions using content from Telegram channels.
+
+    Context structure:
+    - The context contains two optional sections: "## Related Topics" and "## Source Messages".
+    - Topic blocks (prefixed "[T1]", "[T2]", ...) describe thematic groupings with a title, summary, scope and source channels.
+    - Message blocks (prefixed "[M1]", "[M2]", ...) are individual posts with a channel id, source ref and text.
+
+    Instructions:
+    - Answer ONLY based on the provided context. Do not use prior knowledge.
+    - If the context does not contain enough information, say so explicitly.
+    - Use the "## Related Topics" section for high-level thematic reasoning; use the "## Source Messages" section for concrete evidence.
+    - Cite sources using their ref value, NOT the bracket index. Prefer message citations [tg:channel:post:123] for factual claims and topic citations for thematic framing.
+    - Structure your answer: direct answer first, then supporting details with citations.
+    - Respond in the SAME LANGUAGE as the user's question.
+    - Do NOT wrap your response in markdown code blocks unless showing code.
+```
+
+Остальное (`user.template`, `no_results`, `model`) — без изменений.
+
+### 2.3 MCP tools `mode` passthrough
+
+В [`tg_parser/mcp_server.py`](../../tg_parser/mcp_server.py):
+
+- `search_knowledge_base` (строка 436):
+  ```python
+  from typing import get_args
+  from tg_parser.services.retrieval_service import SearchMode
+
+  _VALID_MODES = set(get_args(SearchMode))
+
+  async def search_knowledge_base(
+      query: str,
+      channel_id: str | None = None,
+      limit: int = 10,
+      mode: str = "hybrid",  # NEW
+      ctx: Context | None = None,
+  ) -> list[SearchResultItem]:
+      """... Args: ... mode: Retrieval strategy — 'semantic' | 'keyword' | 'hybrid' (default). ..."""
+      if mode not in _VALID_MODES:
+          raise ValueError(f"invalid mode: {mode!r}; expected one of {sorted(_VALID_MODES)}")
+      # ...
+      results = await search(
+          query=query, channel_id=channel_id, limit=limit,
+          allowed_channel_ids=user.allowed_channel_ids,
+          mode=mode,
+      )
+  ```
+
+- `ask_question` (строка 477): аналогично, параметр `mode: str = "hybrid"` + validation + проброс.
+
+- Обновить блок Search & Q&A в `_MCP_INSTRUCTIONS` в `mcp_server.py` (строки 50–51): "search_knowledge_base for semantic search" → "search_knowledge_base for hybrid search (mode=semantic|keyword|hybrid; default hybrid)". Аналогично — упомянуть `mode` у `ask_question`.
+
+**Bot/CLI** — в Phase 2 **не трогаем** (неявный дефолт hybrid). Пометить в плане как "Phase 3 candidate".
+
+### 2.4 Обновить существующие тесты под новый формат контекста
+
+Затронутые файлы:
+
+- [`tests/test_f5a_topic_rag.py`](../../tests/test_f5a_topic_rag.py) — 9 методов с `_build_context` (строки 540, 556, 570, 593, 605, 611, 1108, 1121, 1134). Нужно:
+  - Изменить ассерты `"[1] channel: ch1"` → `"[M1] channel: ch1"` + `"## Source Messages"`.
+  - `"[TOPIC]"` → `"[T1]"` + `"## Related Topics"`.
+  - `"[1] channel:", "[2] [TOPIC]"` (mixed) → проверять обе секции и presence маркеров `[M1]`/`[T1]`.
+
+- [`tests/test_rag_prompt_config.py`](../../tests/test_rag_prompt_config.py) — 8 методов (строки 286, 305, 320, 338, 342, 356, 377, 1401). Аналогичные правки.
+
+**Стратегия:** заменяем хрупкие строчные ассерты на структурные (содержит ли `## Related Topics`; есть ли `[M1]`; нет ли утечки текста).
+
+### 2.5 Тесты Коммита 2
+
+В `tests/test_f5a_phase2_tuning.py` добавить:
+
+- **`TestStructuredContext`** (~8):
+  - `test_empty_results_returns_empty_string`
+  - `test_topics_only_emits_topics_section_only`
+  - `test_messages_only_emits_messages_section_only`
+  - `test_mixed_emits_both_sections_topics_first`
+  - `test_topic_marker_format_is_T_prefixed` (regex: `\[T\d+\]`)
+  - `test_message_marker_format_is_M_prefixed` (regex: `\[M\d+\]`)
+  - `test_section_separator_triple_dash_between_blocks`
+  - `test_char_limit_truncates_message_text_only`
+
+- **`TestMcpModePassthrough`** (~5):
+  - `test_search_knowledge_base_default_mode_hybrid` — patch `search`, assert `mode="hybrid"`.
+  - `test_search_knowledge_base_explicit_keyword` — `mode="keyword"` forwarded.
+  - `test_search_knowledge_base_rejects_invalid_mode` — ValueError.
+  - `test_ask_question_default_mode_hybrid`.
+  - `test_ask_question_mode_forwarded`.
+
+- **`TestRagPromptV12`** (~2):
+  - `test_rag_prompt_loads_v1_2_0` — version string.
+  - `test_system_prompt_mentions_sections` — contains `"## Related Topics"` и `"## Source Messages"`.
+
+### 2.6 Документация
+
+- [`docs/USER_GUIDE.md`](../../docs/USER_GUIDE.md) — расширить раздел "Hybrid Search" (добавленный в Phase 1) новой подсекцией "RAG context structure & type quotas":
+  - Структура контекста `## Related Topics` / `## Source Messages`.
+  - Как менять квоту тем через `RAG_TOPIC_QUOTA`.
+  - `FTS_MIN_RANK` — когда полезно (шумные короткие сообщения).
+
+- [`docs/MCP_AGENT_GUIDE.md`](../../docs/MCP_AGENT_GUIDE.md) — обновить:
+  - `search_knowledge_base` и `ask_question` теперь принимают `mode`.
+  - Формат контекста в `ask_question` теперь structured.
+
+- [`ENV_VARIABLES_GUIDE.md`](../../ENV_VARIABLES_GUIDE.md) — добавить:
+  - `FTS_MIN_RANK`, `RAG_TOPIC_QUOTA`, `RAG_SEARCH_OVERFETCH_FACTOR`.
+
+- [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](F5A_PERSISTENT_KB_PLAN.md) — отметить Phase 2 DONE.
+
+- [`docs/LLM_PROMPTS.md`](../../docs/LLM_PROMPTS.md) — если упоминает `rag.yaml` версию, обновить до 1.2.0.
+
+### 2.7 Commit 2 message
+
+```
+feat(f5a-phase2): structured topic-weighted RAG context + MCP mode passthrough
+```
+
+---
+
+## Порядок работы
+
+1. **Ветка** `feat/f5a-phase2-relevance-tuning` от актуального `main` (после мёрджа PR #2 с Phase 1).
+2. **Коммит 1**:
+   - Settings → `.env.example` → tests `TestSettingsPhase2` (TDD).
+   - `_apply_type_quotas` pure function → unit-тесты.
+   - `answer(topic_quota=..., overfetch)` wiring → mocked tests.
+   - `fts_min_rank` pipeline → mocked tests.
+   - `.venv/bin/pytest tests/test_f5a_phase2_tuning.py::TestApplyTypeQuotas tests/test_f5a_phase2_tuning.py::TestFtsMinRankPipeline tests/test_f5a_phase2_tuning.py::TestSettingsPhase2 tests/test_f5a_phase2_tuning.py::TestAnswerQuotas -x -q`
+3. **Коммит 2**:
+   - Новый `_build_context` → `TestStructuredContext` (TDD).
+   - Обновить все существующие `_build_context` ассерты (`test_f5a_topic_rag.py`, `test_rag_prompt_config.py`).
+   - `rag.yaml` v1.2.0 → `TestRagPromptV12`.
+   - MCP tools `mode` → `TestMcpModePassthrough` (с моком `search`/`answer` как в `tests/test_mcp_server.py`).
+   - Docs.
+4. **Финальный regression:** `TEST_POSTGRES=1 .venv/bin/pytest tests/ -x -q`. Ожидаемо 1384 → ~1410 тестов (+25–30).
+5. **PR** против `main`. После мёрджа — Phase 3 (dedup).
+
+---
+
+## Критерии готовности
+
+1. `settings.fts_min_rank`, `rag_topic_quota`, `rag_search_overfetch_factor` читаются из env; проходят валидаторы.
+2. `retrieval_service.search(fts_min_rank=...)` пробрасывает в `keyword_search.min_rank`; дефолт берётся из settings.
+3. `retrieval_service.answer(topic_quota=..., ...)` применяет `_apply_type_quotas` с overfetch; fallback при underflow работает для обоих типов.
+4. `_apply_type_quotas` — pure function; ≥8 unit-тестов.
+5. `_build_context` выдаёт `## Related Topics` и `## Source Messages`; форматы `[T1]` / `[M1]`.
+6. `prompts/rag.yaml` — v1.2.0; system prompt описывает две секции и правила цитирования.
+7. MCP tools `search_knowledge_base` и `ask_question` принимают `mode: str = "hybrid"`; валидируют значение; пробрасывают в сервис.
+8. Существующие тесты `_build_context` (`test_f5a_topic_rag.py`, `test_rag_prompt_config.py`) обновлены под новый формат и проходят.
+9. Новый файл `tests/test_f5a_phase2_tuning.py` содержит ~25 тестов (`TestApplyTypeQuotas`, `TestAnswerQuotas`, `TestFtsMinRankPipeline`, `TestSettingsPhase2`, `TestStructuredContext`, `TestMcpModePassthrough`, `TestRagPromptV12`), все проходят.
+10. Полный regression проходит (`TEST_POSTGRES=1 pytest tests/ -x -q` → ≥1410 passed).
+11. Документация обновлена (USER_GUIDE, MCP_AGENT_GUIDE, ENV_VARIABLES_GUIDE, LLM_PROMPTS, F5A_PERSISTENT_KB_PLAN → Phase 2 DONE).
+12. Два коммита с указанными messages.
+
+---
+
+## Что НЕ входит в scope Phase 2
+
+- Deduplication (content hash, near-duplicate) — Phase 3.
+- Cross-encoder / LLM re-ranking — вне F5-A.
+- Linear fusion как альтернатива RRF — отложено.
+- `mode` в bot tools и CLI `search`/`answer` — отдельный минорный коммит после Phase 2 (или в рамках Phase 3, по ситуации).
+- GIN по `topic_cards.channel_ids` для SQL-level tenancy — отложено.
+- Автодетекция языка запроса для FTS.
+- A/B telemetry (track какой режим выбран, какая квота сработала) — опционально, в рамках F9 observability.
+- Динамическое квотирование (adaptive) — отложено; дефолт 2 темы + остальное сообщения достаточен для MVP.
+- Изменение формата `SearchResultItem` в API/MCP (`text_preview` и т.п.) — остаётся v1.
+
+---
+
+## Риски и митигация
+
+| Риск | Митигация |
+|---|---|
+| Обновление формата контекста ломает кастомные `rag.yaml` у пользователей | Backward-compatible prompts fallback; версия 1.2.0 явно; в USER_GUIDE пример миграции |
+| Квотирование даёт пустой context если `topic_quota >= limit` и сообщений нет | `_apply_type_quotas` fallback backfill; тест `test_topic_underflow_backfills_with_messages` |
+| Новый prompt на малых LLM (локальный Ollama) хуже работает со структурированным контекстом | Оставляем `rag.yaml` override механизм; документируем совет "use flat context for small models" |
+| `overfetch_factor=2` удваивает стоимость embedding в semantic/hybrid ветках | Применяется только в `answer()`, не в raw `search()`; пользователь контролирует через env |
+| Ломаются ~50 существующих ассертов `_build_context` (~17 тест-методов) | Явно в scope; централизованная правка; структурные ассерты вместо строчных |
+| MCP клиенты с closed schema падают на новом параметре `mode` | MCP tools optional args — клиенты без параметра получают дефолт; документируем в MCP_AGENT_GUIDE |
+| Bot/CLI потребители видят меньше sources (квота-фильтрация в `answer()`) | Намеренно — они и до Phase 2 ожидали `limit` записей; overfetch — внутренняя оптимизация; добавить unit-тест `test_answer_returns_at_most_limit_sources_after_quotas` |
+| `_apply_type_quotas` подставляет topic перед message — может перевзвесить ответы LLM | Структура контекста явно отделяет секции; system prompt в `rag.yaml` v1.2.0 говорит "use topics for thematic framing, messages for facts" |
+
+---
+
+## Связанные документы
+
+- [`F5A_PHASE1_IMPLEMENTATION_PLAN.md`](F5A_PHASE1_IMPLEMENTATION_PLAN.md) — завершённая Phase 1.
+- [`F5A_PERSISTENT_KB_PLAN.md`](F5A_PERSISTENT_KB_PLAN.md) §4 — исходный набросок Phase 2.
+- [`../prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md`](../prompts/F5A_PHASE1_IMPLEMENTATION_PROMPT.md) — образец стартового промпта.
+- [`../../docs/LLM_PROMPTS.md`](../../docs/LLM_PROMPTS.md) — документация prompts-loader.
+- PR #2 ([`feat/f5a-phase1-hybrid-search`](https://github.com/AlexEfimov/TG_parser/pull/2)) — prerequisite.

--- a/docs/prompts/F5A_PHASE2_IMPLEMENTATION_PROMPT.md
+++ b/docs/prompts/F5A_PHASE2_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,333 @@
+# F5-A Phase 2 Implementation — Стартовый промпт
+
+**Версия проекта:** 4.5.0+ (после мёрджа Phase 1 в `main` — PR #2, ветка `feat/f5a-phase1-hybrid-search`)
+**Ветка:** `feat/f5a-phase2-relevance-tuning` (создать от обновлённого `main`)
+**План реализации:** [`docs/plans/F5A_PHASE2_IMPLEMENTATION_PLAN.md`](../plans/F5A_PHASE2_IMPLEMENTATION_PLAN.md) — **читать первым**
+**Design-doc:** [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](../plans/F5A_PERSISTENT_KB_PLAN.md) §4
+
+---
+
+## Цель
+
+Добавить **relevance tuning** и **topic-weighted RAG context**:
+
+1. Settings `fts_min_rank`, `rag_topic_quota`, `rag_search_overfetch_factor`.
+2. `retrieval_service.answer(topic_quota=..., ...)` — квотирование с fallback при underflow.
+3. `_build_context` — два структурных раздела `## Related Topics` и `## Source Messages`.
+4. `prompts/rag.yaml` → v1.2.0 с описанием новой структуры контекста и правил цитирования.
+5. MCP tools `search_knowledge_base` и `ask_question` принимают `mode` (semantic|keyword|hybrid).
+
+---
+
+## Коротко об архитектуре
+
+```
+question → answer(mode, topic_quota, limit)
+           │
+           ├── search(limit=limit * overfetch)        ← hybrid/keyword/semantic (Phase 1)
+           │       └── keyword_search(min_rank=settings.fts_min_rank)
+           │
+           ├── _apply_type_quotas(raw, limit, topic_quota)
+           │       ├── top-K topics (up to quota)
+           │       ├── fill remainder with messages
+           │       └── underflow fallback (backfill either direction)
+           │
+           └── _build_context(sources, char_limit)
+                   ├── ## Related Topics     [T1] [T2] ...
+                   └── ## Source Messages    [M1] [M2] ...
+```
+
+Новые pure-functions (юнит-тесты без БД):
+- `_apply_type_quotas(results, limit, topic_quota) -> list[SearchResult]`
+- Обновлённый `_build_context(results, char_limit) -> str`.
+
+---
+
+## Ключевые уточнения (после разведки)
+
+- `retrieval_service.search()` **уже** принимает `mode` и `threshold` после Phase 1 (строка 49 в `tg_parser/services/retrieval_service.py`). `threshold` применяется только к semantic branch через `emb_repo.similarity_search`.
+- `emb_repo.keyword_search(min_rank=0.0)` **уже** есть (Phase 1). Service сейчас **не пробрасывает** — добавляем pipeline в Commit 1.
+- `answer()` (строка 239) сейчас: `search(limit=limit)` → `_build_context(results, char_limit)`. Phase 2 вставляет `_apply_type_quotas` между ними и overfetch.
+- `_build_context` меняет формат — **ломает ~17 тестов** (~50 ассертов): 9 в `tests/test_f5a_topic_rag.py` + 8 в `tests/test_rag_prompt_config.py`. Обновление включено в scope Commit 2.
+- MCP tools НЕ имеют `mode` — Phase 1 явно отложила. Добавляем в Commit 2.
+- Bot/CLI `search`/`answer` — `mode` **не добавляем** в Phase 2 (вне scope, неявный дефолт `hybrid` достаточен).
+- `_MCP_INSTRUCTIONS` (строки 44–77 `mcp_server.py`) сейчас говорит "search_knowledge_base for **semantic** search" — обновить блок Search & Q&A (строки 50–51) под hybrid + mode.
+- **Visible behavior change для bot/CLI:** `answer()` теперь возвращает `AnswerResult.sources` уже после квотирования (≤ `limit`), не после raw search (`limit * overfetch`). Это **намеренно** — потребители видели именно `limit` записей и до Phase 2.
+
+---
+
+## Структура работы (2 коммита)
+
+### Коммит 1 — Relevance tuning (min_score + quotas)
+
+**Файлы:**
+- [`tg_parser/config/settings.py`](../../tg_parser/config/settings.py) — `fts_min_rank`, `rag_topic_quota`, `rag_search_overfetch_factor`.
+- `.env.example` — новые ENV-переменные.
+- [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py):
+  - `search(fts_min_rank=None)` — новый опциональный параметр; проброс в `keyword_search.min_rank`.
+  - `answer(topic_quota=None)` — новый опциональный параметр; overfetch + `_apply_type_quotas`.
+  - Новая pure-function `_apply_type_quotas`.
+- `tests/test_f5a_phase2_tuning.py` (new) — классы:
+  - `TestApplyTypeQuotas` (~8 unit)
+  - `TestAnswerQuotas` (~4 mocked)
+  - `TestFtsMinRankPipeline` (~3 mocked)
+  - `TestSettingsPhase2` (~3)
+
+**Commit message:**
+```
+feat(f5a-phase2): add RAG type quotas and FTS min_rank pipeline
+```
+
+### Коммит 2 — Structured context + MCP mode passthrough
+
+**Файлы:**
+- [`tg_parser/services/retrieval_service.py`](../../tg_parser/services/retrieval_service.py) — переписать `_build_context` в двухсекционный формат.
+- [`prompts/rag.yaml`](../../prompts/rag.yaml) → v1.2.0 с описанием `## Related Topics` / `## Source Messages` и правил цитирования `[T1]`/`[M1]` → ref.
+- [`tg_parser/mcp_server.py`](../../tg_parser/mcp_server.py):
+  - `search_knowledge_base(mode: str = "hybrid")` + validation + проброс.
+  - `ask_question(mode: str = "hybrid")` + validation + проброс.
+  - Обновить блок Search & Q&A в `_MCP_INSTRUCTIONS` (строки 50–51): "semantic search" → "hybrid search (mode=semantic|keyword|hybrid)".
+- Обновление существующих тестов под новый формат:
+  - [`tests/test_f5a_topic_rag.py`](../../tests/test_f5a_topic_rag.py) — строки ~540–617, ~1109–1140.
+  - [`tests/test_rag_prompt_config.py`](../../tests/test_rag_prompt_config.py) — строки ~287–400.
+- `tests/test_f5a_phase2_tuning.py` — дополнить классами:
+  - `TestStructuredContext` (~8)
+  - `TestMcpModePassthrough` (~5)
+  - `TestRagPromptV12` (~2)
+- Документация:
+  - [`docs/USER_GUIDE.md`](../../docs/USER_GUIDE.md) — новая подсекция "RAG context structure & type quotas".
+  - [`docs/MCP_AGENT_GUIDE.md`](../../docs/MCP_AGENT_GUIDE.md) — `mode` в MCP-tools.
+  - [`ENV_VARIABLES_GUIDE.md`](../../ENV_VARIABLES_GUIDE.md) — `FTS_MIN_RANK`, `RAG_TOPIC_QUOTA`, `RAG_SEARCH_OVERFETCH_FACTOR`.
+  - [`docs/plans/F5A_PERSISTENT_KB_PLAN.md`](../plans/F5A_PERSISTENT_KB_PLAN.md) — Phase 2 DONE.
+  - [`docs/LLM_PROMPTS.md`](../../docs/LLM_PROMPTS.md) — упоминание версии `rag.yaml` 1.2.0.
+
+**Commit message:**
+```
+feat(f5a-phase2): structured topic-weighted RAG context + MCP mode passthrough
+```
+
+---
+
+## Settings шпаргалка
+
+```python
+# В tg_parser/config/settings.py, секция после fts_languages (~488)
+
+fts_min_rank: float = Field(
+    default=0.0,
+    description="Default ts_rank_cd cutoff for keyword search (0.0 = no cutoff)",
+    ge=0.0,
+)
+rag_topic_quota: int = Field(
+    default=2,
+    description="Number of topic cards reserved in answer() context before filling with messages",
+    ge=0,
+    le=20,
+)
+rag_search_overfetch_factor: int = Field(
+    default=2,
+    description="answer() fetches limit * factor before applying quotas for headroom",
+    ge=1,
+    le=10,
+)
+```
+
+---
+
+## `_apply_type_quotas` спецификация
+
+```python
+def _apply_type_quotas(
+    results: list[SearchResult],
+    limit: int,
+    topic_quota: int,
+) -> list[SearchResult]:
+    """
+    Rules:
+    - Take up to `topic_quota` topics (score order preserved from search()).
+    - Fill remaining slots (limit - len(picked_topics)) with messages.
+    - Underflow: if not enough messages, backfill shortfall with extra topics.
+    - Output order: ALL topics first, then ALL messages.
+    - Never exceeds `limit`.
+    - Returns [] if results empty.
+    """
+```
+
+Ключевые кейсы для тестов:
+- `test_empty_results_returns_empty`
+- `test_topic_underflow_backfills_with_messages` (было 1 тема, нужно 2; берём 1 тему + заполняем сообщениями)
+- `test_message_underflow_backfills_with_topics` (было 0 сообщений, квота топиков 2, limit=5; берём до 5 топиков если есть)
+- `test_topic_quota_zero_returns_only_messages` (`topic_quota=0` — только сообщения)
+- `test_order_within_type_preserved` (score-order внутри каждой секции)
+
+---
+
+## Обновлённый `_build_context` — формат
+
+**До (Phase 1):**
+```
+[1] channel: ch1 | ref: tg:ch1:post:1 | score: 0.89
+Title: ...
+Text: ...
+---
+[2] [TOPIC] channels: ch1, ch2 | ref: topic:t1 | score: 0.85
+Title: ...
+Summary: ...
+```
+
+**После (Phase 2):**
+```
+## Related Topics
+
+[T1] ref: topic:t1 | channels: ch1, ch2 | score: 0.850
+Title: Topic Title
+Summary: Topic summary...
+Scope: anchor_a, anchor_b
+Tags: tag1, tag2
+
+---
+
+[T2] ref: topic:t2 | channels: ch1 | score: 0.720
+Title: ...
+Summary: ...
+
+## Source Messages
+
+[M1] channel: ch1 | ref: tg:ch1:post:1 | score: 0.890
+Title: Summary or first 80 chars
+Text: Full text truncated to char_limit...
+Topics: topic1, topic2
+
+---
+
+[M2] channel: ch2 | ref: tg:ch2:post:5 | score: 0.820
+Title: ...
+Text: ...
+```
+
+**Правила:**
+- Пустые секции **не выводятся** (no trailing `## Related Topics\n\n` без контента).
+- Между блоками одной секции — `\n\n---\n\n`.
+- Между секциями — `\n\n`.
+- Score отображается с 3 знаками (`{r.score:.3f}`).
+- Сортировка внутри секции **не меняется** — уже score-desc из `search()`.
+
+---
+
+## `prompts/rag.yaml` v1.2.0 — патч
+
+Обновить `metadata.version` до `"1.2.0"` и `system.prompt` (полный draft в плане §2.2). Ключевые добавления:
+
+1. Описание двух секций `## Related Topics` / `## Source Messages`.
+2. Правила цитирования: `[T1]`/`[M1]` — только визуальные метки, цитировать через `ref` value.
+3. Guidance: topics для thematic framing, messages для factual claims.
+
+Остальные блоки (`user.template`, `no_results`, `model`) — без изменений.
+
+---
+
+## MCP tools `mode` — сигнатура
+
+```python
+from typing import get_args
+from tg_parser.services.retrieval_service import SearchMode
+
+_VALID_MODES = set(get_args(SearchMode))  # ("semantic", "keyword", "hybrid")
+
+
+@mcp.tool()
+async def search_knowledge_base(
+    query: str,
+    channel_id: str | None = None,
+    limit: int = 10,
+    mode: str = "hybrid",  # NEW
+    ctx: Context | None = None,
+) -> list[SearchResultItem]:
+    """...
+    Args:
+        ...
+        mode: Retrieval strategy — 'semantic' (pgvector cosine), 'keyword' (FTS), or 'hybrid' (RRF fusion, default).
+    """
+    if mode not in _VALID_MODES:
+        raise ValueError(f"invalid mode: {mode!r}; expected one of {sorted(_VALID_MODES)}")
+    # ... проброс в search(mode=mode)
+```
+
+`SearchMode` импортируем из `retrieval_service` — single source of truth, нет дублирования литералов. Аналогично для `ask_question`. Затем обновить блок Search & Q&A в `_MCP_INSTRUCTIONS` (`mcp_server.py` строки 50–51).
+
+---
+
+## Тесты
+
+Новый файл `tests/test_f5a_phase2_tuning.py` (шаблон — `tests/test_f5a_hybrid_search.py`):
+
+| Класс | Кейсов | Requires pg? |
+|---|---|---|
+| `TestApplyTypeQuotas` | ~8 | no |
+| `TestAnswerQuotas` | ~5 | no (mocked search) |
+| `TestFtsMinRankPipeline` | ~3 | no (mocked repo) |
+| `TestSettingsPhase2` | ~3 | no |
+| `TestStructuredContext` | ~8 | no |
+| `TestMcpModePassthrough` | ~5 | no (mocked search/answer) |
+| `TestRagPromptV12` | ~2 | no |
+
+**Плюс обновление существующих:**
+- `tests/test_f5a_topic_rag.py` — 9 методов с `_build_context` assertions (строки 540, 556, 570, 593, 605, 611, 1108, 1121, 1134).
+- `tests/test_rag_prompt_config.py` — 8 методов (строки 286, 305, 320, 338, 342, 356, 377, 1401).
+
+**Запуск:**
+```bash
+# Phase 2 unit + integration
+.venv/bin/pytest tests/test_f5a_phase2_tuning.py -x -q
+
+# _build_context regression (после обновления ассертов)
+.venv/bin/pytest tests/test_f5a_topic_rag.py tests/test_rag_prompt_config.py -x -q
+
+# Полный regression
+TEST_POSTGRES=1 .venv/bin/pytest tests/ -x -q
+```
+
+**Ожидаемо:** 1384 → ~1410 тестов.
+
+---
+
+## Критерии готовности
+
+1. `settings.fts_min_rank`, `rag_topic_quota`, `rag_search_overfetch_factor` читаются из env; валидаторы отвергают негативные/out-of-range.
+2. `search(fts_min_rank=...)` пробрасывает в `keyword_search.min_rank` в keyword/hybrid путях; semantic ветка не затронута.
+3. `answer(topic_quota=...)` вызывает `search(limit=limit * overfetch)` и применяет `_apply_type_quotas`.
+4. `_apply_type_quotas` — pure function; ≥8 unit-тестов включая underflow fallback для обоих направлений.
+5. `_build_context` выдаёт `## Related Topics` + `## Source Messages` с префиксами `[T1]`/`[M1]`; пустые секции опущены.
+6. `prompts/rag.yaml` — версия `1.2.0`, system prompt описывает две секции и правила цитирования через `ref`.
+7. MCP `search_knowledge_base` и `ask_question` принимают `mode: str = "hybrid"`; невалидный → `ValueError`; проброс в сервис.
+8. Существующие `_build_context` тесты (`test_f5a_topic_rag.py`, `test_rag_prompt_config.py`) обновлены под новый формат.
+9. Новый файл `tests/test_f5a_phase2_tuning.py` ~25–30 тестов; все проходят.
+10. Полный regression `TEST_POSTGRES=1 pytest tests/ -x -q` — не менее 1410 passed.
+11. Документация: USER_GUIDE (подсекция), MCP_AGENT_GUIDE (mode), ENV_VARIABLES_GUIDE (3 новых env), LLM_PROMPTS (версия), F5A_PERSISTENT_KB_PLAN (Phase 2 DONE).
+12. Два коммита с указанными messages.
+
+---
+
+## Что НЕ входит в scope
+
+- Deduplication (content hash, near-duplicate) — Phase 3.
+- Cross-encoder / LLM re-ranking — вне F5-A.
+- Linear fusion как альтернатива RRF.
+- `mode` в bot tools / CLI (`tg_parser/bot/tools.py`, `tg_parser/cli/app.py`).
+- GIN по `topic_cards.channel_ids` — Phase 3 candidate.
+- Автодетекция языка запроса для FTS.
+- Adaptive quotas (динамическое подстраивание под распределение типов в корпусе).
+- Изменение формы `SearchResultItem` в API/MCP (preview chars и т.п.).
+
+---
+
+## Рекомендации исполнения
+
+1. **Plan mode** первым — сверка с актуальным `main` после мёрджа Phase 1. Проверить номера строк `retrieval_service.py`, `mcp_server.py`, `settings.py`.
+2. **TDD для `_apply_type_quotas`** — pure function, пишем 8 тестов сразу, затем имплементация.
+3. **Порядок Commit 1:** settings → `_apply_type_quotas` → `fts_min_rank` pipeline → `answer` wiring. Каждый шаг gated тестами.
+4. **Для `_build_context` нового формата** — сначала написать `TestStructuredContext`, потом переписать функцию, **затем** исправить старые ассерты в `test_f5a_topic_rag.py` / `test_rag_prompt_config.py`. Если сначала менять функцию — тесты сломаются массово и это затруднит review.
+5. **MCP тесты** — моделировать по образцу `tests/test_mcp_server.py` (patches на `retrieval_service.search`/`answer`).
+6. **Prompt reload** — после правки `rag.yaml` убедиться что hot-reload работает (`PromptLoader` уже имеет этот механизм).
+7. **Backward compat в ответах** — `AnswerResult.sources` и `SearchResult` структура **не меняется**. Меняется только внутренний формат `_build_context` строки, идущей в LLM.
+8. **Score precision bump** с `.2f` → `.3f` — мелкое изменение UX, может сломать хрупкие regex-тесты. Отдельно проверить.

--- a/prompts/rag.yaml
+++ b/prompts/rag.yaml
@@ -1,28 +1,34 @@
 # TG_parser RAG Q&A Prompt
-# Version: 1.1.0
+# Version: 1.2.0
 #
-# Prompt for answering questions over the knowledge base.
+# Prompt for answering questions over the knowledge base using a
+# topic-weighted structured context (F5-A Phase 2).
+#
 # Edit to customize RAG behavior, then reload via bot/MCP: reload_prompts
 #
 # Documentation: docs/LLM_PROMPTS.md
 
 metadata:
-  version: "1.1.0"
-  description: "RAG Q&A prompt for answering questions over the Telegram channel knowledge base"
+  version: "1.2.0"
+  description: "RAG Q&A prompt with topic-weighted structured context (F5-A Phase 2)"
 
 system:
   prompt: |
     You are a knowledge base assistant that answers questions using content from Telegram channels.
 
+    Context structure:
+    - The context contains two optional sections: "## Related Topics" and "## Source Messages".
+    - Topic blocks (prefixed "[T1]", "[T2]", ...) describe thematic groupings with a title, summary, scope, tags, and source channels.
+    - Message blocks (prefixed "[M1]", "[M2]", ...) are individual Telegram posts with a channel id, source ref, and text.
+    - Either section may be absent when no matches of that type were retrieved.
+
     Instructions:
     - Answer ONLY based on the provided context. Do not use prior knowledge.
     - If the context does not contain enough information to answer, say so explicitly.
-    - Cite sources using their original reference identifiers (e.g. [tg:channel:post:123]).
-      Each context block starts with a header like "[1] channel: ... | ref: tg:channel:post:123".
-      Use the ref value for citations, not the numeric index.
-    - When the context includes TOPIC entries, use their title, summary, and scope to provide
-      broader thematic context alongside specific message citations.
-    - Structure your answer clearly: start with a direct answer, then supporting details.
+    - Use the "## Related Topics" section for high-level thematic framing; use the "## Source Messages" section for concrete factual claims.
+    - Cite sources using their ref value (e.g. [tg:channel:post:123] or [topic:...]), NOT the bracket index "[T1]" / "[M1]" — the bracket indices are only visual labels inside the context.
+    - Prefer message refs for specific factual claims and topic refs for thematic framing.
+    - Structure your answer clearly: start with a direct answer, then supporting details with citations.
     - Respond in the SAME LANGUAGE as the user's question.
     - Be concise but thorough.
     - Do NOT wrap your response in markdown code blocks unless showing code.

--- a/tests/test_f5a_phase2_tuning.py
+++ b/tests/test_f5a_phase2_tuning.py
@@ -563,12 +563,272 @@ class TestAnswerQuotas:
 # Commit 2 — Structured context + MCP mode passthrough + rag.yaml v1.2.0
 # ===========================================================================
 
-# (Added in Commit 2 — see plan §2.5)
 
-# Placeholder to keep single-file organization explicit; actual classes
-# (TestStructuredContext, TestMcpModePassthrough, TestRagPromptV12) will be
-# appended in Commit 2 of the Phase 2 work.
+# ---------------------------------------------------------------------------
+# TestStructuredContext  (new _build_context two-section format)
+# ---------------------------------------------------------------------------
 
 
-# Marker to ensure both commits share a consistent module header
-_PHASE2_TEST_MODULE_VERSION = "commit1"
+class TestStructuredContext:
+    def test_empty_results_returns_empty_string(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        assert _build_context([], char_limit=500) == ""
+
+    def test_topics_only_emits_topics_section_only(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", title="Alpha", score=0.9)
+        t2 = _topic_result(topic_id="topic:2", title="Beta", score=0.7)
+
+        ctx = _build_context([t1, t2], char_limit=500)
+
+        assert "## Related Topics" in ctx
+        assert "## Source Messages" not in ctx
+        assert "[T1]" in ctx
+        assert "[T2]" in ctx
+        assert "Alpha" in ctx
+        assert "Beta" in ctx
+
+    def test_messages_only_emits_messages_section_only(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.9)
+        m2 = _msg_result(source_ref="tg:ch1:post:2", score=0.8)
+
+        ctx = _build_context([m1, m2], char_limit=500)
+
+        assert "## Source Messages" in ctx
+        assert "## Related Topics" not in ctx
+        assert "[M1]" in ctx
+        assert "[M2]" in ctx
+
+    def test_mixed_emits_both_sections_topics_first(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", title="Alpha", score=0.9)
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.7)
+
+        ctx = _build_context([t1, m1], char_limit=500)
+
+        topics_idx = ctx.index("## Related Topics")
+        messages_idx = ctx.index("## Source Messages")
+        assert topics_idx < messages_idx
+
+    def test_topic_marker_format_is_T_prefixed(self):
+        import re
+
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        t2 = _topic_result(topic_id="topic:2", score=0.7)
+
+        ctx = _build_context([t1, t2], char_limit=500)
+
+        markers = re.findall(r"\[T\d+\]", ctx)
+        assert markers == ["[T1]", "[T2]"]
+
+    def test_message_marker_format_is_M_prefixed(self):
+        import re
+
+        from tg_parser.services.retrieval_service import _build_context
+
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.9)
+        m2 = _msg_result(source_ref="tg:ch1:post:2", score=0.8)
+        m3 = _msg_result(source_ref="tg:ch1:post:3", score=0.7)
+
+        ctx = _build_context([m1, m2, m3], char_limit=500)
+
+        markers = re.findall(r"\[M\d+\]", ctx)
+        assert markers == ["[M1]", "[M2]", "[M3]"]
+
+    def test_section_separator_triple_dash_between_blocks(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.9)
+        m2 = _msg_result(source_ref="tg:ch1:post:2", score=0.8)
+
+        ctx = _build_context([m1, m2], char_limit=500)
+
+        assert "\n---\n" in ctx
+
+    def test_char_limit_truncates_message_text_only(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        long_text = "x" * 500
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.9)
+        m1.document.text_clean = long_text  # type: ignore[union-attr]
+        m1.document.summary = "Title"  # type: ignore[union-attr]
+
+        ctx = _build_context([m1], char_limit=100)
+
+        assert "x" * 100 in ctx
+        assert "x" * 200 not in ctx
+
+    def test_score_formatted_with_three_decimals(self):
+        import re
+
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", score=0.8506)
+
+        ctx = _build_context([t1], char_limit=500)
+
+        assert "score: 0.851" in ctx
+        assert not re.search(r"score: 0\.85\b", ctx)
+
+    def test_topic_with_tags_emitted(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9, tags=["tag1", "tag2"])
+
+        ctx = _build_context([t1], char_limit=500)
+
+        assert "Tags: tag1, tag2" in ctx
+
+    def test_topic_without_scope_omits_scope_line(self):
+        from tg_parser.services.retrieval_service import _build_context
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        t1.topic_card.scope_in = []  # type: ignore[union-attr]
+
+        ctx = _build_context([t1], char_limit=500)
+
+        assert "Scope:" not in ctx
+
+    def test_skips_entries_without_document_or_card(self):
+        from tg_parser.services.retrieval_service import SearchResult, _build_context
+
+        stray = SearchResult(source_ref="unknown", score=0.5, entry_type="message")
+        ctx = _build_context([stray], char_limit=500)
+
+        assert ctx == ""
+
+
+# ---------------------------------------------------------------------------
+# TestRagPromptV12
+# ---------------------------------------------------------------------------
+
+
+class TestRagPromptV12:
+    def test_rag_prompt_loads_v1_2_0(self):
+        from pathlib import Path
+
+        import yaml
+
+        path = Path(__file__).resolve().parent.parent / "prompts" / "rag.yaml"
+        data = yaml.safe_load(path.read_text())
+        assert data["metadata"]["version"] == "1.2.0"
+
+    def test_system_prompt_mentions_sections(self):
+        from pathlib import Path
+
+        import yaml
+
+        path = Path(__file__).resolve().parent.parent / "prompts" / "rag.yaml"
+        data = yaml.safe_load(path.read_text())
+        sys_prompt = data["system"]["prompt"]
+        assert "## Related Topics" in sys_prompt
+        assert "## Source Messages" in sys_prompt
+
+
+# ---------------------------------------------------------------------------
+# TestMcpModePassthrough
+# ---------------------------------------------------------------------------
+
+
+class TestMcpModePassthrough:
+    @pytest.fixture
+    def _patch_resolve_user(self, monkeypatch):
+        from types import SimpleNamespace
+
+        async def _fake(client_id):
+            return SimpleNamespace(id=1, allowed_channel_ids=None)
+
+        monkeypatch.setattr("tg_parser.mcp_server.resolve_mcp_user", _fake)
+
+    async def test_search_knowledge_base_default_mode_hybrid(
+        self, monkeypatch, _patch_resolve_user
+    ):
+        from tg_parser.mcp_server import search_knowledge_base
+
+        captured: dict = {}
+
+        async def _fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("tg_parser.services.retrieval_service.search", _fake_search)
+
+        await search_knowledge_base(query="hello")
+        assert captured["mode"] == "hybrid"
+
+    async def test_search_knowledge_base_explicit_keyword_forwarded(
+        self, monkeypatch, _patch_resolve_user
+    ):
+        from tg_parser.mcp_server import search_knowledge_base
+
+        captured: dict = {}
+
+        async def _fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("tg_parser.services.retrieval_service.search", _fake_search)
+
+        await search_knowledge_base(query="hello", mode="keyword")
+        assert captured["mode"] == "keyword"
+
+    async def test_search_knowledge_base_rejects_invalid_mode(self, _patch_resolve_user):
+        from tg_parser.mcp_server import search_knowledge_base
+
+        with pytest.raises(ValueError):
+            await search_knowledge_base(query="hello", mode="bm25")
+
+    async def test_ask_question_default_mode_hybrid(self, monkeypatch, _patch_resolve_user):
+        from tg_parser.mcp_server import ask_question
+        from tg_parser.services.retrieval_service import AnswerResult
+
+        captured: dict = {}
+
+        async def _fake_answer(**kwargs):
+            captured.update(kwargs)
+            return AnswerResult(answer="x", sources=[], model="test")
+
+        monkeypatch.setattr("tg_parser.services.retrieval_service.answer", _fake_answer)
+
+        await ask_question(question="hello?")
+        assert captured["mode"] == "hybrid"
+
+    async def test_ask_question_explicit_semantic_forwarded(self, monkeypatch, _patch_resolve_user):
+        from tg_parser.mcp_server import ask_question
+        from tg_parser.services.retrieval_service import AnswerResult
+
+        captured: dict = {}
+
+        async def _fake_answer(**kwargs):
+            captured.update(kwargs)
+            return AnswerResult(answer="x", sources=[], model="test")
+
+        monkeypatch.setattr("tg_parser.services.retrieval_service.answer", _fake_answer)
+
+        await ask_question(question="q?", mode="semantic")
+        assert captured["mode"] == "semantic"
+
+    async def test_ask_question_rejects_invalid_mode(self, _patch_resolve_user):
+        from tg_parser.mcp_server import ask_question
+
+        with pytest.raises(ValueError):
+            await ask_question(question="q?", mode="fuzzy")
+
+
+# ---------------------------------------------------------------------------
+# TestMcpInstructions
+# ---------------------------------------------------------------------------
+
+
+class TestMcpInstructions:
+    def test_instructions_mention_mode_parameter(self):
+        from tg_parser.mcp_server import _MCP_INSTRUCTIONS
+
+        assert "mode=" in _MCP_INSTRUCTIONS or "hybrid search" in _MCP_INSTRUCTIONS

--- a/tests/test_f5a_phase2_tuning.py
+++ b/tests/test_f5a_phase2_tuning.py
@@ -1,0 +1,574 @@
+"""
+Tests for F5-A Phase 2: Relevance tuning & topic-weighted RAG context.
+
+Structure (Commit 1 — quotas + min_rank pipeline):
+- TestSettingsPhase2       : Pydantic settings (fts_min_rank, rag_topic_quota,
+                             rag_search_overfetch_factor).
+- TestApplyTypeQuotas      : pure unit tests for _apply_type_quotas (no DB).
+- TestFtsMinRankPipeline   : fts_min_rank forwarded to emb_repo.keyword_search.
+- TestAnswerQuotas         : answer() overfetch + quota application (mocked search).
+
+Structure (Commit 2 — structured context + MCP mode passthrough):
+- TestStructuredContext    : new _build_context two-section format.
+- TestMcpModePassthrough   : MCP tools accept mode= and forward to service.
+- TestRagPromptV12         : prompts/rag.yaml v1.2.0 metadata.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tg_parser.domain.models import Anchor, ProcessedDocument, TopicCard, TopicType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(
+    source_ref: str = "tg:ch1:post:1",
+    channel_id: str = "ch1",
+    text_clean: str = "Message body",
+    summary: str | None = "Msg summary",
+    topics: list[str] | None = None,
+) -> ProcessedDocument:
+    return ProcessedDocument(
+        id=source_ref,
+        source_ref=source_ref,
+        source_message_id=source_ref.rsplit(":", 1)[-1],
+        channel_id=channel_id,
+        processed_at=datetime.now(UTC),
+        text_clean=text_clean,
+        summary=summary,
+        topics=topics or [],
+    )
+
+
+def _make_topic_card(
+    topic_id: str = "topic:ch1:post:1",
+    title: str = "Topic Title",
+    summary: str = "Topic summary",
+    scope_in: list[str] | None = None,
+    sources: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> TopicCard:
+    return TopicCard(
+        id=topic_id,
+        title=title,
+        summary=summary,
+        scope_in=scope_in or ["anchor_a", "anchor_b"],
+        scope_out=["excluded"],
+        type=TopicType.SINGLETON,
+        anchors=[
+            Anchor(
+                channel_id=(sources or ["ch1"])[0],
+                message_id="1",
+                message_type="post",
+                anchor_ref="tg:ch1:post:1",
+                score=1.0,
+            )
+        ],
+        sources=sources or ["ch1"],
+        updated_at=datetime.now(UTC),
+        tags=tags,
+    )
+
+
+def _msg_result(
+    source_ref: str = "tg:ch1:post:1",
+    score: float = 0.9,
+    channel_id: str = "ch1",
+    topics: list[str] | None = None,
+):
+    from tg_parser.services.retrieval_service import SearchResult
+
+    return SearchResult(
+        source_ref=source_ref,
+        score=score,
+        document=_make_doc(source_ref=source_ref, channel_id=channel_id, topics=topics),
+        entry_type="message",
+    )
+
+
+def _topic_result(
+    topic_id: str = "topic:ch1:post:1",
+    score: float = 0.85,
+    title: str = "T",
+    sources: list[str] | None = None,
+    tags: list[str] | None = None,
+    scope_in: list[str] | None = None,
+):
+    from tg_parser.services.retrieval_service import SearchResult
+
+    return SearchResult(
+        source_ref=topic_id,
+        score=score,
+        entry_type="topic",
+        topic_card=_make_topic_card(
+            topic_id=topic_id, title=title, sources=sources, tags=tags, scope_in=scope_in
+        ),
+    )
+
+
+class _FakeEmbClient:
+    async def embed(self, texts):
+        return [[0.1] * 1536 for _ in texts]
+
+    async def close(self):
+        return None
+
+
+@pytest.fixture
+def patch_embedding_client(monkeypatch):
+    def _factory():
+        return _FakeEmbClient()
+
+    monkeypatch.setattr(
+        "tg_parser.services.retrieval_service.create_embedding_client",
+        _factory,
+    )
+
+
+# ===========================================================================
+# Commit 1 — Settings + Quotas + FTS min_rank pipeline + answer() wiring
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# TestSettingsPhase2
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsPhase2:
+    def test_defaults(self):
+        from tg_parser.config.settings import Settings
+
+        s = Settings(
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
+            openai_api_key="sk-x",
+        )
+        assert s.fts_min_rank == 0.0
+        assert s.rag_topic_quota == 2
+        assert s.rag_search_overfetch_factor == 2
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("FTS_MIN_RANK", "0.05")
+        monkeypatch.setenv("RAG_TOPIC_QUOTA", "4")
+        monkeypatch.setenv("RAG_SEARCH_OVERFETCH_FACTOR", "3")
+
+        from tg_parser.config.settings import Settings
+
+        s = Settings(
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
+            openai_api_key="sk-x",
+        )
+        assert s.fts_min_rank == pytest.approx(0.05)
+        assert s.rag_topic_quota == 4
+        assert s.rag_search_overfetch_factor == 3
+
+    def test_rejects_negative_fts_min_rank(self):
+        from pydantic import ValidationError
+
+        from tg_parser.config.settings import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(
+                telegram_api_id=1,
+                telegram_api_hash="h",
+                telegram_phone="+1",
+                openai_api_key="sk-x",
+                fts_min_rank=-0.1,
+            )
+
+    def test_rejects_negative_topic_quota(self):
+        from pydantic import ValidationError
+
+        from tg_parser.config.settings import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(
+                telegram_api_id=1,
+                telegram_api_hash="h",
+                telegram_phone="+1",
+                openai_api_key="sk-x",
+                rag_topic_quota=-1,
+            )
+
+    def test_rejects_zero_overfetch_factor(self):
+        from pydantic import ValidationError
+
+        from tg_parser.config.settings import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(
+                telegram_api_id=1,
+                telegram_api_hash="h",
+                telegram_phone="+1",
+                openai_api_key="sk-x",
+                rag_search_overfetch_factor=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestApplyTypeQuotas  (pure function, no DB, no mocks)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTypeQuotas:
+    def test_empty_results_returns_empty(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        assert _apply_type_quotas([], limit=5, topic_quota=2) == []
+
+    def test_topics_within_quota_fill_exact(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        t2 = _topic_result(topic_id="topic:2", score=0.8)
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.7)
+        m2 = _msg_result(source_ref="tg:ch1:post:2", score=0.6)
+        m3 = _msg_result(source_ref="tg:ch1:post:3", score=0.5)
+
+        got = _apply_type_quotas([t1, t2, m1, m2, m3], limit=5, topic_quota=2)
+
+        assert [r.source_ref for r in got] == [
+            "topic:1",
+            "topic:2",
+            "tg:ch1:post:1",
+            "tg:ch1:post:2",
+            "tg:ch1:post:3",
+        ]
+
+    def test_messages_fill_remainder(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        t2 = _topic_result(topic_id="topic:2", score=0.8)
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5 - i * 0.01) for i in range(10)]
+
+        got = _apply_type_quotas([t1, t2, *msgs], limit=5, topic_quota=2)
+
+        assert len(got) == 5
+        assert [r.entry_type for r in got] == ["topic", "topic", "message", "message", "message"]
+
+    def test_topic_underflow_backfills_with_messages(self):
+        """Only 1 topic exists, quota is 2; pick 1 topic + fill with messages to limit."""
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5 - i * 0.01) for i in range(5)]
+
+        got = _apply_type_quotas([t1, *msgs], limit=5, topic_quota=2)
+
+        assert len(got) == 5
+        assert sum(1 for r in got if r.entry_type == "topic") == 1
+        assert sum(1 for r in got if r.entry_type == "message") == 4
+
+    def test_message_underflow_backfills_with_topics(self):
+        """Zero messages, many topics; topic_quota=2 but limit=5 → backfill with extra topics."""
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9 - i * 0.01) for i in range(6)]
+
+        got = _apply_type_quotas(topics, limit=5, topic_quota=2)
+
+        assert len(got) == 5
+        assert all(r.entry_type == "topic" for r in got)
+        assert [r.source_ref for r in got] == [f"topic:{i}" for i in range(5)]
+
+    def test_both_types_sparse_returns_all_available(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        t1 = _topic_result(topic_id="topic:1", score=0.9)
+        m1 = _msg_result(source_ref="tg:ch1:post:1", score=0.7)
+
+        got = _apply_type_quotas([t1, m1], limit=5, topic_quota=2)
+
+        assert len(got) == 2
+        assert got[0].source_ref == "topic:1"
+        assert got[1].source_ref == "tg:ch1:post:1"
+
+    def test_topic_quota_zero_returns_only_messages(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9) for i in range(3)]
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5) for i in range(4)]
+
+        got = _apply_type_quotas([*topics, *msgs], limit=3, topic_quota=0)
+
+        assert all(r.entry_type == "message" for r in got)
+        assert len(got) == 3
+
+    def test_topic_quota_equals_limit_returns_only_topics(self):
+        """topic_quota==limit and enough topics present → messages ignored."""
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9) for i in range(5)]
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5) for i in range(3)]
+
+        got = _apply_type_quotas([*topics, *msgs], limit=3, topic_quota=3)
+
+        assert len(got) == 3
+        assert all(r.entry_type == "topic" for r in got)
+
+    def test_order_within_type_preserved(self):
+        from tg_parser.services.retrieval_service import _apply_type_quotas
+
+        t_hi = _topic_result(topic_id="topic:hi", score=0.95)
+        t_lo = _topic_result(topic_id="topic:lo", score=0.40)
+        m_hi = _msg_result(source_ref="tg:ch1:post:hi", score=0.80)
+        m_lo = _msg_result(source_ref="tg:ch1:post:lo", score=0.20)
+
+        got = _apply_type_quotas([t_hi, m_hi, t_lo, m_lo], limit=4, topic_quota=2)
+
+        assert [r.source_ref for r in got] == [
+            "topic:hi",
+            "topic:lo",
+            "tg:ch1:post:hi",
+            "tg:ch1:post:lo",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# TestFtsMinRankPipeline  (service → repo.keyword_search(min_rank=...))
+# ---------------------------------------------------------------------------
+
+
+class TestFtsMinRankPipeline:
+    async def test_keyword_mode_uses_settings_default_min_rank(
+        self, patch_embedding_client, monkeypatch
+    ):
+        """search(mode='keyword') forwards settings.fts_min_rank to repo by default."""
+        from tg_parser.services import retrieval_service
+        from tg_parser.services.retrieval_service import search
+
+        monkeypatch.setattr(retrieval_service.settings, "fts_min_rank", 0.01)
+
+        emb_repo = AsyncMock()
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q",
+            mode="keyword",
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.keyword_search.call_args.kwargs["min_rank"] == pytest.approx(0.01)
+
+    async def test_explicit_fts_min_rank_overrides_settings(
+        self, patch_embedding_client, monkeypatch
+    ):
+        from tg_parser.services import retrieval_service
+        from tg_parser.services.retrieval_service import search
+
+        monkeypatch.setattr(retrieval_service.settings, "fts_min_rank", 0.01)
+
+        emb_repo = AsyncMock()
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q",
+            mode="hybrid",
+            fts_min_rank=0.07,
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
+        )
+        assert emb_repo.keyword_search.call_args.kwargs["min_rank"] == pytest.approx(0.07)
+        assert "min_rank" not in emb_repo.similarity_search.call_args.kwargs
+
+    async def test_semantic_mode_does_not_forward_fts_min_rank(
+        self, patch_embedding_client, monkeypatch
+    ):
+        from tg_parser.services import retrieval_service
+        from tg_parser.services.retrieval_service import search
+
+        monkeypatch.setattr(retrieval_service.settings, "fts_min_rank", 0.01)
+
+        emb_repo = AsyncMock()
+        emb_repo.keyword_search = AsyncMock(return_value=[])
+        emb_repo.similarity_search = AsyncMock(return_value=[])
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_refs = AsyncMock(return_value={})
+
+        await search(
+            "q",
+            mode="semantic",
+            fts_min_rank=0.9,
+            emb_repo=emb_repo,
+            proc_repo=proc_repo,
+            topic_card_repo=AsyncMock(),
+        )
+        assert not emb_repo.keyword_search.called
+
+
+# ---------------------------------------------------------------------------
+# TestAnswerQuotas  (answer() overfetch + quota application, mocked search)
+# ---------------------------------------------------------------------------
+
+
+class TestAnswerQuotas:
+    async def test_answer_default_topic_quota_is_2(self, patch_embedding_client, monkeypatch):
+        """answer() without explicit topic_quota uses settings.rag_topic_quota (default 2)."""
+        from tg_parser.services import retrieval_service
+
+        monkeypatch.setattr(retrieval_service.settings, "rag_topic_quota", 2)
+        monkeypatch.setattr(retrieval_service.settings, "rag_search_overfetch_factor", 2)
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9 - i * 0.01) for i in range(3)]
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5) for i in range(5)]
+
+        captured: dict = {}
+
+        async def _fake_search(query, **kwargs):
+            captured["limit"] = kwargs.get("limit")
+            return [*topics, *msgs]
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        async def _fake_call_llm(*args, **kwargs):
+            return ("answer", "test-model")
+
+        monkeypatch.setattr(retrieval_service, "_call_llm", _fake_call_llm)
+
+        result = await retrieval_service.answer(
+            "q?",
+            limit=5,
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
+        )
+
+        assert sum(1 for r in result.sources if r.entry_type == "topic") == 2
+        assert sum(1 for r in result.sources if r.entry_type == "message") == 3
+        assert len(result.sources) == 5
+
+    async def test_explicit_topic_quota_overrides_settings(
+        self, patch_embedding_client, monkeypatch
+    ):
+        from tg_parser.services import retrieval_service
+
+        monkeypatch.setattr(retrieval_service.settings, "rag_topic_quota", 2)
+        monkeypatch.setattr(retrieval_service.settings, "rag_search_overfetch_factor", 2)
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9 - i * 0.01) for i in range(5)]
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5) for i in range(5)]
+
+        async def _fake_search(query, **kwargs):
+            return [*topics, *msgs]
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        async def _fake_call_llm(*args, **kwargs):
+            return ("answer", "test-model")
+
+        monkeypatch.setattr(retrieval_service, "_call_llm", _fake_call_llm)
+
+        result = await retrieval_service.answer(
+            "q?",
+            limit=5,
+            topic_quota=4,
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
+        )
+
+        assert sum(1 for r in result.sources if r.entry_type == "topic") == 4
+        assert sum(1 for r in result.sources if r.entry_type == "message") == 1
+        assert len(result.sources) == 5
+
+    async def test_answer_overfetches_for_quota_headroom(self, patch_embedding_client, monkeypatch):
+        """answer() must call search(limit=limit * overfetch_factor) for headroom."""
+        from tg_parser.services import retrieval_service
+
+        monkeypatch.setattr(retrieval_service.settings, "rag_topic_quota", 2)
+        monkeypatch.setattr(retrieval_service.settings, "rag_search_overfetch_factor", 3)
+
+        captured: dict = {}
+
+        async def _fake_search(query, **kwargs):
+            captured["limit"] = kwargs.get("limit")
+            return []
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        await retrieval_service.answer(
+            "q?",
+            limit=5,
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
+        )
+        assert captured["limit"] == 15
+
+    async def test_answer_returns_at_most_limit_sources_after_quotas(
+        self, patch_embedding_client, monkeypatch
+    ):
+        from tg_parser.services import retrieval_service
+
+        monkeypatch.setattr(retrieval_service.settings, "rag_topic_quota", 2)
+        monkeypatch.setattr(retrieval_service.settings, "rag_search_overfetch_factor", 4)
+
+        topics = [_topic_result(topic_id=f"topic:{i}", score=0.9) for i in range(10)]
+        msgs = [_msg_result(source_ref=f"tg:ch1:post:{i}", score=0.5) for i in range(20)]
+
+        async def _fake_search(query, **kwargs):
+            return [*topics, *msgs]
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        async def _fake_call_llm(*args, **kwargs):
+            return ("answer", "test-model")
+
+        monkeypatch.setattr(retrieval_service, "_call_llm", _fake_call_llm)
+
+        result = await retrieval_service.answer(
+            "q?",
+            limit=3,
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
+        )
+        assert len(result.sources) <= 3
+
+    async def test_answer_empty_results_returns_no_results_message(
+        self, patch_embedding_client, monkeypatch
+    ):
+        from tg_parser.services import retrieval_service
+
+        async def _fake_search(query, **kwargs):
+            return []
+
+        monkeypatch.setattr(retrieval_service, "search", _fake_search)
+
+        result = await retrieval_service.answer(
+            "q?",
+            limit=5,
+            emb_repo=AsyncMock(),
+            proc_repo=AsyncMock(),
+        )
+        assert result.sources == []
+        assert result.answer  # non-empty "no results" message
+
+
+# ===========================================================================
+# Commit 2 — Structured context + MCP mode passthrough + rag.yaml v1.2.0
+# ===========================================================================
+
+# (Added in Commit 2 — see plan §2.5)
+
+# Placeholder to keep single-file organization explicit; actual classes
+# (TestStructuredContext, TestMcpModePassthrough, TestRagPromptV12) will be
+# appended in Commit 2 of the Phase 2 work.
+
+
+# Marker to ensure both commits share a consistent module header
+_PHASE2_TEST_MODULE_VERSION = "commit1"

--- a/tests/test_f5a_topic_rag.py
+++ b/tests/test_f5a_topic_rag.py
@@ -601,7 +601,8 @@ class TestBuildContext:
         )
         results = [SearchResult(source_ref="tg:ch1:post:1", score=0.9, document=doc)]
         ctx = _build_context(results, 1000)
-        assert "[1] channel: ch1" in ctx
+        assert "## Source Messages" in ctx
+        assert "[M1] channel: ch1" in ctx
         assert "Hello world" in ctx
         assert "Topics: topic1" in ctx
 
@@ -618,7 +619,8 @@ class TestBuildContext:
             )
         ]
         ctx = _build_context(results, 1000)
-        assert "[TOPIC]" in ctx
+        assert "## Related Topics" in ctx
+        assert "[T1]" in ctx
         assert "Test Topic" in ctx
         assert "Test summary" in ctx
         assert "Scope:" in ctx
@@ -647,9 +649,11 @@ class TestBuildContext:
             ),
         ]
         ctx = _build_context(results, 1000)
-        assert "[1] channel:" in ctx
-        assert "[2] [TOPIC]" in ctx
-        assert "---" in ctx
+        assert "## Related Topics" in ctx
+        assert "## Source Messages" in ctx
+        assert "[T1]" in ctx
+        assert "[M1] channel:" in ctx
+        assert ctx.index("## Related Topics") < ctx.index("## Source Messages")
 
     def test_build_context_topic_with_tags(self):
         from tg_parser.services.retrieval_service import SearchResult, _build_context
@@ -1312,7 +1316,8 @@ class TestBuildContextEdge:
         ]
         ctx = _build_context(results, 1000)
         assert "Tags:" not in ctx
-        assert "[TOPIC]" in ctx
+        assert "## Related Topics" in ctx
+        assert "[T1]" in ctx
 
     def test_build_context_topic_empty_scope(self):
         from tg_parser.services.retrieval_service import SearchResult, _build_context

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -209,7 +209,11 @@ class TestSearchTool:
             result = await search_knowledge_base("test query", limit=5)
 
         mock_search.assert_awaited_once_with(
-            query="test query", channel_id=None, limit=5, allowed_channel_ids=None
+            query="test query",
+            channel_id=None,
+            limit=5,
+            allowed_channel_ids=None,
+            mode="hybrid",
         )
         assert len(result) == 2
         assert isinstance(result[0], SearchResultItem)
@@ -225,7 +229,11 @@ class TestSearchTool:
             result = await search_knowledge_base("query", channel_id="my_ch")
 
         mock_search.assert_awaited_once_with(
-            query="query", channel_id="my_ch", limit=10, allowed_channel_ids=None
+            query="query",
+            channel_id="my_ch",
+            limit=10,
+            allowed_channel_ids=None,
+            mode="hybrid",
         )
         assert result == []
 
@@ -248,7 +256,10 @@ class TestAskTool:
             result = await ask_question("What is the answer?")
 
         mock_fn.assert_awaited_once_with(
-            question="What is the answer?", channel_id=None, allowed_channel_ids=None
+            question="What is the answer?",
+            channel_id=None,
+            allowed_channel_ids=None,
+            mode="hybrid",
         )
         assert isinstance(result, AnswerResultItem)
         assert result.answer == "The answer is 42."
@@ -262,7 +273,10 @@ class TestAskTool:
             result = await ask_question("question", channel_id="ch")
 
         mock_fn.assert_awaited_once_with(
-            question="question", channel_id="ch", allowed_channel_ids=None
+            question="question",
+            channel_id="ch",
+            allowed_channel_ids=None,
+            mode="hybrid",
         )
         assert result.sources == []
 

--- a/tests/test_rag_prompt_config.py
+++ b/tests/test_rag_prompt_config.py
@@ -394,7 +394,7 @@ class TestBuildContext:
         assert "channel: ch2" in ctx
 
     def test_build_context_uses_text_clean_as_title_fallback(self):
-        """When summary is None, title falls back to text_clean[:100]."""
+        """When summary is None, title falls back to text_clean[:80]."""
         from tg_parser.services.retrieval_service import SearchResult, _build_context
 
         doc = MagicMock()
@@ -405,7 +405,8 @@ class TestBuildContext:
 
         results = [SearchResult(source_ref="tg:ch:post:1", score=0.9, document=doc)]
         ctx = _build_context(results, char_limit=500)
-        assert "Title: " + "X" * 100 in ctx
+        assert "Title: " + "X" * 80 in ctx
+        assert "Title: " + "X" * 81 not in ctx
 
 
 # ---------------------------------------------------------------------------
@@ -1462,16 +1463,19 @@ class TestRagPromptQualityImprovements:
         assert "source_ref" in prompt or "ref:" in prompt or "tg:channel:post:" in prompt
 
     def test_rag_system_prompt_mentions_topic_context(self):
-        """RAG system prompt mentions using TOPIC entries for broader context."""
+        """RAG system prompt v1.2.0 mentions the two-section context
+        with Related Topics and Source Messages."""
         from tg_parser.processing.prompt_loader import PromptLoader
 
         loader = PromptLoader(prompts_dir=Path("prompts"))
         config = loader.load("rag")
         prompt = config["system"]["prompt"]
-        assert "TOPIC" in prompt
+        assert "## Related Topics" in prompt
+        assert "## Source Messages" in prompt
 
     def test_build_context_includes_source_ref(self):
-        """_build_context now includes source_ref: field in message headers."""
+        """_build_context includes the source_ref value in message headers
+        via the 'ref:' field (v1.2.0 format)."""
         from tg_parser.services.retrieval_service import SearchResult, _build_context
 
         doc = MagicMock()
@@ -1482,7 +1486,7 @@ class TestRagPromptQualityImprovements:
 
         results = [SearchResult(source_ref="tg:ch:post:42", score=0.9, document=doc)]
         ctx = _build_context(results, char_limit=500)
-        assert "source_ref: tg:ch:post:42" in ctx
+        assert "ref: tg:ch:post:42" in ctx
 
     def test_rag_default_context_char_limit_updated(self):
         """Default PromptLoader RAG config has context_char_limit=2000."""

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -488,6 +488,28 @@ class Settings(BaseSettings):
     )
 
     # ==========================================================================
+    # RAG Relevance Tuning (F5-A Phase 2)
+    # ==========================================================================
+
+    fts_min_rank: float = Field(
+        default=0.0,
+        description="Default ts_rank_cd cutoff for keyword search (0.0 = no cutoff)",
+        ge=0.0,
+    )
+    rag_topic_quota: int = Field(
+        default=2,
+        description="Number of topic cards reserved in answer() context before filling with messages",
+        ge=0,
+        le=20,
+    )
+    rag_search_overfetch_factor: int = Field(
+        default=2,
+        description="answer() fetches limit * factor before applying quotas for headroom",
+        ge=1,
+        le=10,
+    )
+
+    # ==========================================================================
     # Ollama Configuration
     # ==========================================================================
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -23,7 +23,7 @@ import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import structlog
 from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -48,7 +48,8 @@ _MCP_INSTRUCTIONS = (
     "remove_channel to permanently delete a channel and all its data. "
     "trigger_pipeline to start processing, get_pipeline_status to monitor progress.\n\n"
     "Search & Q&A: "
-    "search_knowledge_base for semantic search, ask_question for RAG Q&A.\n\n"
+    "search_knowledge_base for hybrid search (mode=semantic|keyword|hybrid; "
+    "default hybrid), ask_question for topic-weighted RAG Q&A (same mode param).\n\n"
     "Navigation: "
     "list_topics / get_topic_details for topic navigation, "
     "list_channels for channel overview, get_document for full document content.\n\n"
@@ -440,21 +441,40 @@ class RemoveUserAuthResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _validate_search_mode(mode: str) -> str:
+    """Validate ``mode`` against ``SearchMode`` literal from retrieval_service.
+
+    Centralised to keep the single source of truth inside the service module and
+    to avoid duplicating the string literals in MCP / API / CLI layers.
+    """
+    from tg_parser.services.retrieval_service import SearchMode
+
+    valid = set(get_args(SearchMode))
+    if mode not in valid:
+        raise ValueError(f"invalid mode: {mode!r}; expected one of {sorted(valid)}")
+    return mode
+
+
 @mcp.tool()
 async def search_knowledge_base(
     query: str,
     channel_id: str | None = None,
     limit: int = 10,
+    mode: str = "hybrid",
     ctx: Context | None = None,
 ) -> list[SearchResultItem]:
-    """Semantic search across the Telegram knowledge base.
+    """Hybrid search across the Telegram knowledge base.
     Returns documents ranked by relevance with scores and summaries.
     Use this to find specific information in channel posts.
 
     Args:
         query: Natural-language search query.
         channel_id: Optional channel filter (e.g. "labdiagnostica_logical").
-        limit: Maximum number of results (default 10)."""
+        limit: Maximum number of results (default 10).
+        mode: Retrieval strategy — 'semantic' (pgvector cosine), 'keyword'
+            (FTS ts_rank_cd), or 'hybrid' (RRF fusion). Defaults to 'hybrid'.
+    """
+    _validate_search_mode(mode)
     if not query or not query.strip():
         return []
 
@@ -467,6 +487,7 @@ async def search_knowledge_base(
         channel_id=channel_id,
         limit=limit,
         allowed_channel_ids=user.allowed_channel_ids,
+        mode=mode,
     )
     items: list[SearchResultItem] = []
     for r in results:
@@ -487,15 +508,19 @@ async def search_knowledge_base(
 async def ask_question(
     question: str,
     channel_id: str | None = None,
+    mode: str = "hybrid",
     ctx: Context | None = None,
 ) -> AnswerResultItem:
     """Ask a question about Telegram channel content.
-    Uses RAG: retrieves relevant documents and generates an answer with an LLM.
-    Returns the answer text with source references.
+    Uses RAG: retrieves relevant documents and generates a topic-weighted
+    answer with an LLM. Returns the answer text with source references.
 
     Args:
         question: Question in natural language.
-        channel_id: Optional channel filter."""
+        channel_id: Optional channel filter.
+        mode: Retrieval strategy — 'semantic', 'keyword', or 'hybrid' (default).
+    """
+    _validate_search_mode(mode)
     if not question or not question.strip():
         return AnswerResultItem(
             answer="Please provide a non-empty question.", sources=[], model=None
@@ -509,6 +534,7 @@ async def ask_question(
         question=question,
         channel_id=channel_id,
         allowed_channel_ids=user.allowed_channel_ids,
+        mode=mode,
     )
     sources = [
         SearchResultItem(

--- a/tg_parser/services/retrieval_service.py
+++ b/tg_parser/services/retrieval_service.py
@@ -254,36 +254,75 @@ def _apply_type_quotas(
 
 
 def _build_context(results: list[SearchResult], char_limit: int) -> str:
-    """Build context string from search results (messages and topics)."""
-    parts: list[str] = []
-    for i, r in enumerate(results, 1):
-        if r.entry_type == "topic" and r.topic_card is not None:
+    """Build structured RAG context with separate topic and message sections.
+
+    Output format (both sections optional; empty when no matches of that type):
+
+        ## Related Topics
+
+        [T1] ref: <topic_id> | channels: <csv> | score: <float>
+        Title: <card.title>
+        Summary: <card.summary>
+        Scope: <csv>            (when scope_in non-empty)
+        Tags: <csv>             (when tags non-empty)
+
+        ---
+
+        [T2] ...
+
+        ## Source Messages
+
+        [M1] channel: <id> | ref: <source_ref> | score: <float>
+        Title: <summary or text_clean[:80]>
+        Text: <text_clean[:char_limit]>
+        Topics: <csv>           (when topics non-empty)
+
+        ---
+
+        [M2] ...
+
+    Rules:
+    - Empty sections are omitted (no trailing "## Related Topics\n\n" left over).
+    - Between blocks within a section: "\n\n---\n\n".
+    - Between sections: "\n\n".
+    - Score displayed with 3 decimals (".3f") for better hybrid-mode signal.
+    - Order within a section is preserved from ``results`` (score-desc upstream).
+    - Entries without an attached document/topic_card are silently skipped.
+    """
+    topics = [r for r in results if r.entry_type == "topic" and r.topic_card is not None]
+    messages = [r for r in results if r.entry_type != "topic" and r.document is not None]
+
+    sections: list[str] = []
+
+    if topics:
+        blocks: list[str] = []
+        for i, r in enumerate(topics, 1):
             card = r.topic_card
             channels = ", ".join(card.sources) if card.sources else "unknown"
-            header = (
-                f"[{i}] [TOPIC] channels: {channels} | ref: {r.source_ref} | score: {r.score:.2f}"
-            )
-            body = f"Title: {card.title}\nSummary: {card.summary}"
-            scope = ", ".join(card.scope_in) if card.scope_in else ""
-            if scope:
-                body += f"\nScope: {scope}"
-            tags = ", ".join(card.tags) if card.tags else ""
-            if tags:
-                body += f"\nTags: {tags}"
-            parts.append(f"{header}\n{body}")
-        elif r.document is not None:
+            header = f"[T{i}] ref: {r.source_ref} | channels: {channels} | score: {r.score:.3f}"
+            body_lines = [f"Title: {card.title}", f"Summary: {card.summary}"]
+            if card.scope_in:
+                body_lines.append(f"Scope: {', '.join(card.scope_in)}")
+            if card.tags:
+                body_lines.append(f"Tags: {', '.join(card.tags)}")
+            blocks.append(header + "\n" + "\n".join(body_lines))
+        sections.append("## Related Topics\n\n" + "\n\n---\n\n".join(blocks))
+
+    if messages:
+        blocks = []
+        for i, r in enumerate(messages, 1):
             doc = r.document
-            title = doc.summary or doc.text_clean[:100]
-            topics_str = ", ".join(doc.topics) if doc.topics else ""
+            title = doc.summary or doc.text_clean[:80]
+            header = (
+                f"[M{i}] channel: {doc.channel_id} | ref: {r.source_ref} | score: {r.score:.3f}"
+            )
+            body_lines = [f"Title: {title}", f"Text: {doc.text_clean[:char_limit]}"]
+            if doc.topics:
+                body_lines.append(f"Topics: {', '.join(doc.topics)}")
+            blocks.append(header + "\n" + "\n".join(body_lines))
+        sections.append("## Source Messages\n\n" + "\n\n---\n\n".join(blocks))
 
-            header = f"[{i}] channel: {doc.channel_id} | ref: {r.source_ref} | source_ref: {r.source_ref} | score: {r.score:.2f}"
-            body = f"Title: {title}\nText: {doc.text_clean[:char_limit]}"
-            if topics_str:
-                body += f"\nTopics: {topics_str}"
-
-            parts.append(f"{header}\n{body}")
-
-    return "\n---\n".join(parts)
+    return "\n\n".join(sections)
 
 
 async def answer(

--- a/tg_parser/services/retrieval_service.py
+++ b/tg_parser/services/retrieval_service.py
@@ -56,6 +56,7 @@ async def search(
     include_topics: bool = True,
     allowed_channel_ids: list[str] | None = None,
     mode: SearchMode = "hybrid",
+    fts_min_rank: float | None = None,
     *,
     emb_repo: EmbeddingRepo | None = None,
     proc_repo: ProcessedDocumentRepo | None = None,
@@ -76,6 +77,10 @@ async def search(
             Reciprocal Rank Fusion). Defaults to ``"hybrid"``. When the
             global ``hybrid_enabled`` setting is False, ``"hybrid"`` is
             silently downgraded to ``"semantic"``.
+        fts_min_rank: Optional override for ``ts_rank_cd`` cutoff applied to
+            the keyword branch (``keyword`` / ``hybrid`` modes). When
+            ``None`` the global ``settings.fts_min_rank`` default is used.
+            Ignored by the semantic branch (which uses ``threshold``).
         emb_repo: Optional DI for EmbeddingRepo
         proc_repo: Optional DI for ProcessedDocumentRepo
         topic_card_repo: Optional DI for TopicCardRepo
@@ -103,6 +108,8 @@ async def search(
     effective_mode: SearchMode = mode
     if effective_mode == "hybrid" and not settings.hybrid_enabled:
         effective_mode = "semantic"
+
+    effective_min_rank = fts_min_rank if fts_min_rank is not None else settings.fts_min_rank
 
     entry_types = ["message", "topic"] if include_topics else ["message"]
     fetch_limit = limit * 2 if channel_id else limit
@@ -136,6 +143,7 @@ async def search(
                 limit=fetch_limit,
                 entry_types=entry_types,
                 channel_ids=effective_channel_ids,
+                min_rank=effective_min_rank,
             )
         else:
             sem_task = emb_repo.similarity_search(
@@ -150,6 +158,7 @@ async def search(
                 limit=fetch_limit,
                 entry_types=entry_types,
                 channel_ids=effective_channel_ids,
+                min_rank=effective_min_rank,
             )
             sem, kw = await asyncio.gather(sem_task, kw_task)
             similar = rrf_fuse(sem, kw, k=settings.hybrid_rrf_k)[:fetch_limit]
@@ -208,6 +217,42 @@ def _load_rag_config() -> dict:
     return get_prompt_loader().load("rag")
 
 
+def _apply_type_quotas(
+    results: list[SearchResult],
+    limit: int,
+    topic_quota: int,
+) -> list[SearchResult]:
+    """Split results by entry_type, apply quotas with underflow fallback.
+
+    Rules:
+    - Take up to ``topic_quota`` topics (score order preserved from ``search()``).
+    - Fill remaining slots (``limit - len(picked_topics)``) with messages.
+    - Underflow fallback: if too few messages, backfill remaining slots with
+      extra topics (beyond the initial quota).
+    - Output order: ALL topics first, then ALL messages (stable section-ordering
+      for downstream ``_build_context``).
+    - Never exceeds ``limit``; returns ``[]`` on empty input.
+
+    This is a pure function — no DB, no I/O, no mutation of inputs.
+    """
+    if not results:
+        return []
+
+    topics = [r for r in results if r.entry_type == "topic"]
+    messages = [r for r in results if r.entry_type != "topic"]
+
+    picked_topics = topics[:topic_quota]
+    remaining = limit - len(picked_topics)
+    picked_messages = messages[:remaining]
+
+    shortfall = limit - len(picked_topics) - len(picked_messages)
+    if shortfall > 0 and len(topics) > len(picked_topics):
+        extra_topics = topics[len(picked_topics) : len(picked_topics) + shortfall]
+        picked_topics = picked_topics + extra_topics
+
+    return picked_topics + picked_messages
+
+
 def _build_context(results: list[SearchResult], char_limit: int) -> str:
     """Build context string from search results (messages and topics)."""
     parts: list[str] = []
@@ -247,6 +292,7 @@ async def answer(
     limit: int = 5,
     allowed_channel_ids: list[str] | None = None,
     mode: SearchMode = "hybrid",
+    topic_quota: int | None = None,
     *,
     emb_repo: EmbeddingRepo | None = None,
     proc_repo: ProcessedDocumentRepo | None = None,
@@ -261,22 +307,32 @@ async def answer(
         limit: Number of context documents to retrieve
         allowed_channel_ids: Tenant scoping — None=admin (all)
         mode: Retrieval strategy forwarded to ``search()``.
+        topic_quota: Optional override for number of topic cards reserved in
+            the LLM context. Falls back to ``settings.rag_topic_quota`` when
+            ``None``. Clamped to ``limit``. ``_apply_type_quotas`` performs
+            underflow fallback when topics or messages are scarce.
         emb_repo: Optional DI for EmbeddingRepo
         proc_repo: Optional DI for ProcessedDocumentRepo
         llm_client: Optional DI for LLMClient (if None, created via factory)
 
     Returns:
-        AnswerResult with generated answer and sources
+        AnswerResult with generated answer and sources (≤ ``limit``).
     """
-    results = await search(
+    effective_topic_quota = topic_quota if topic_quota is not None else settings.rag_topic_quota
+    effective_topic_quota = min(effective_topic_quota, limit)
+    overfetch = max(1, settings.rag_search_overfetch_factor)
+
+    raw_results = await search(
         question,
         channel_id=channel_id,
-        limit=limit,
+        limit=limit * overfetch,
         allowed_channel_ids=allowed_channel_ids,
         mode=mode,
         emb_repo=emb_repo,
         proc_repo=proc_repo,
     )
+
+    results = _apply_type_quotas(raw_results, limit=limit, topic_quota=effective_topic_quota)
 
     rag_config = _load_rag_config()
 


### PR DESCRIPTION
## Summary

Phase 2 of the F5-A persistent KB roadmap on top of Phase 1 (hybrid search, already merged in `main`). Two self-contained commits:

1. **`feat(f5a-phase2): add RAG type quotas and FTS min_rank pipeline`**
   - New settings: `FTS_MIN_RANK` (ts_rank_cd cutoff for keyword branch, default `0.0`), `RAG_TOPIC_QUOTA` (topic cards reserved in `answer()`, default `2`), `RAG_SEARCH_OVERFETCH_FACTOR` (fetches `limit * factor` before quotas, default `2`).
   - `retrieval_service.search()` accepts `fts_min_rank: float | None` and forwards it to `emb_repo.keyword_search(min_rank=...)` for `keyword` and `hybrid` modes. Semantic branch continues to use `threshold` for pgvector cosine.
   - New pure function `_apply_type_quotas(results, limit, topic_quota)` — up to `topic_quota` topics + remaining slots filled with messages, with underflow fallback in both directions.
   - `retrieval_service.answer()` accepts `topic_quota: int | None`, overfetches `limit * RAG_SEARCH_OVERFETCH_FACTOR`, then applies quotas.

2. **`feat(f5a-phase2): structured topic-weighted RAG context + MCP mode passthrough`**
   - `_build_context` now produces two sections: `## Related Topics` with `[T1]/[T2]/…` and `## Source Messages` with `[M1]/[M2]/…`. Empty sections are omitted; scores rendered with 3-decimal precision.
   - `prompts/rag.yaml` bumped to **v1.2.0** — system prompt documents both sections and requires citations via the `ref` value, not bracket indices.
   - MCP `search_knowledge_base` and `ask_question` accept `mode: str = \"hybrid\"` (hybrid | semantic | keyword); invalid value → `ValueError`. `_MCP_INSTRUCTIONS` describes the new parameter.

Documentation updated: `USER_GUIDE.md`, `MCP_AGENT_GUIDE.md`, `ENV_VARIABLES_GUIDE.md`, `docs/plans/F5A_PERSISTENT_KB_PLAN.md` (Phase 2 marked DONE).

## Test plan

- [x] Unit regression (Postgres integration excluded): **1346 passed, 56 skipped** (`pytest tests/ --ignore=tests/test_postgres_integration.py --ignore=tests/test_postgres_concurrency.py`)
- [x] `ruff check` + `ruff format --check` clean on all touched files
- [x] New test classes cover settings (`TestSettingsPhase2`), pure quotas (`TestApplyTypeQuotas`), pipeline wiring (`TestFtsMinRankPipeline`, `TestAnswerQuotas`), structured context (`TestStructuredContext`), prompt version (`TestRagPromptV12`), MCP passthrough (`TestMcpModePassthrough`, `TestMcpInstructions`)
- [x] Existing tests (`test_f5a_topic_rag.py`, `test_rag_prompt_config.py`, `test_mcp_server.py`) updated for the new context format and `mode` kwarg
- [ ] Wait for CI green, then merge

## Out of scope (reserved for later phases)

- Deduplication (content hash / near-dup) → F5-A Phase 3
- Cross-encoder / LLM re-ranking, linear fusion alternative to RRF
- `mode` in bot / CLI (default `hybrid` is sufficient)
- Adaptive quotas, auto language detection for FTS

Made with [Cursor](https://cursor.com)