### PR TITLE
feat(f2): Channel Content Export (Parse-Only) — level=raw|processed|full

### DIFF
--- a/ENV_VARIABLES_GUIDE.md
+++ b/ENV_VARIABLES_GUIDE.md
@@ -478,6 +478,11 @@ API_KEYS='{"sk-prod-abc123": "production", "sk-dev-xyz789": "development"}'
 - **Default**: `10/minute`
 - **Description**: Rate limit for POST /api/v1/process
 
+#### `RATE_LIMIT_EXPORT`
+- **Type**: string
+- **Default**: `20/minute`
+- **Description**: Rate limit for POST /api/v1/export (applies to all export levels: `raw`, `processed`, `full`; see F2 Parse-Only Export in `docs/USER_GUIDE.md`). For large raw exports, prefer the CLI over the API.
+
 #### `CORS_ORIGINS`
 - **Type**: JSON array
 - **Default**: `["*"]`

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # TG_parser — MCP Agent Guide
 
-**Version:** 4.3 | **Tools:** 24 | **Transport:** Streamable HTTP | **Auth:** Bearer token
+**Version:** 4.4 | **Tools:** 26 | **Transport:** Streamable HTTP | **Auth:** Bearer token
 
 This guide is optimized for AI agents interacting with TG_parser via MCP. For human-oriented documentation, see [USER_GUIDE.md](USER_GUIDE.md).
 
@@ -56,6 +56,13 @@ Auth: Bearer <MCP_AUTH_TOKEN>
 |------|------|-------------|
 | `trigger_pipeline` | any | Start ingestion+processing for a channel |
 | `get_pipeline_status` | any | Scheduler status and per-source pipeline state |
+
+### Export (F2)
+
+| Tool | Auth | Description |
+|------|------|-------------|
+| `export_channel` | owner/admin | Submit export job for a channel (level=raw/processed/full) |
+| `get_export_status` | owner/admin | Poll job status + download URL when completed |
 
 ### LLM Configuration
 
@@ -274,6 +281,51 @@ Returns: PipelineStatusResult
     # source_id, channel_id, status, last_attempt_at, last_success_at, fail_count, last_error
 ```
 
+### `export_channel`
+
+```
+Parameters:
+  channel_id: str                # Required. Channel to export.
+  level: str = "raw"             # "raw" | "processed" | "full" (default: raw)
+  format: str = "json"           # "json" | "ndjson" (for level=raw; ignored for processed/full)
+  from_date: str | null          # ISO-8601 UTC datetime filter (optional)
+  to_date: str | null            # ISO-8601 UTC datetime filter (optional)
+
+Returns: ExportChannelResult
+  job_id: str | null             # null if rejected
+  status: str                    # "pending" | "rejected"
+  channel_id: str
+  level: str
+  format: str
+  download_url: str | null       # populated after job completes (via get_export_status)
+  message: str                   # human-readable status line
+```
+
+Behaviour:
+
+- `level="raw"` requires non-empty `channel_id` (per-channel export only in F2).
+- Ownership is enforced via `assert_channel_access` — non-owners get a rejected result.
+- Invalid `level` / `format` raises `ValueError`.
+- The job runs in the background; poll `get_export_status(job_id)` until
+  `status="completed"`, then fetch the file via `download_url`
+  (`GET /api/v1/export/download/{job_id}`).
+
+### `get_export_status`
+
+```
+Parameters:
+  job_id: str                    # Required.
+
+Returns: ExportStatusResult
+  job_id: str
+  status: str                    # "pending" | "running" | "completed" | "failed"
+  channel_id: str | null
+  level: str                     # "raw" | "processed" | "full"
+  format: str                    # "json" | "ndjson"
+  download_url: str | null       # populated when status == "completed"
+  error: str | null              # populated when status == "failed"
+```
+
 ### `get_llm_config`
 
 ```
@@ -430,7 +482,25 @@ Returns: dict
 4. list_users()                              # verify
 ```
 
-### 5. Switch LLM provider at runtime
+### 5. Export a channel (F2 Parse-Only)
+
+```
+1. result = export_channel(channel_id="mychannel", level="raw", format="json")
+   # returns {job_id, status: "pending", ...}
+2. status = get_export_status(job_id=result.job_id)   # poll every 2-5 sec
+   # status.status transitions: pending → running → completed
+3. When status.status == "completed":
+   # GET status.download_url with the same MCP/API credentials
+   # -> raw_messages.json (or raw_messages.ndjson for format="ndjson")
+```
+
+Notes:
+- `level="raw"` exports raw Telegram messages (parse-only, no LLM). Requires `channel_id`.
+- `level="processed"` exports `kb_entries.ndjson` (post-LLM KnowledgeBaseEntry[]).
+- `level="full"` (legacy default) adds `topics.json` + `topic_<id>.json`.
+- `raw_payload` (private Telethon structures) is intentionally excluded from all levels.
+
+### 6. Switch LLM provider at runtime
 
 ```
 1. get_llm_config()                         # see current config + available providers

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -767,26 +767,139 @@ python -m tg_parser.cli export --out <directory>
 - `--from-date` — фильтр по дате от (формат: YYYY-MM-DD)
 - `--to-date` — фильтр по дате до (формат: YYYY-MM-DD)
 - `--pretty` — форматированный JSON
+- `--level` — уровень экспорта: `raw` | `processed` | `full` (default: `full`, см. ниже)
+- `--format` — формат для `--level raw`: `json` | `ndjson` (default: `json`)
 
-**Выходные файлы:**
-- `kb_entries.ndjson` — записи базы знаний (NDJSON формат)
-- `topics.json` — каталог всех тем
-- `topic_<id>.json` — детальные карточки отдельных тем
+**Выходные файлы (по уровням):**
+- `full` (default): `kb_entries.ndjson` + `topics.json` + `topic_<id>.json` (legacy)
+- `processed`: только `kb_entries.ndjson` (без topics)
+- `raw`: `raw_messages.json` или `raw_messages.ndjson`
 
 **Примеры:**
 ```bash
-# Экспорт всех данных
 python -m tg_parser.cli export --out ./output
 
-# Экспорт конкретного канала
 python -m tg_parser.cli export --channel @durov --out ./output
 
-# Экспорт за период
 python -m tg_parser.cli export --from-date 2025-01-01 --to-date 2025-12-31 --out ./output
 
-# Форматированный JSON для чтения
 python -m tg_parser.cli export --out ./output --pretty
 ```
+
+### Parse-Only Export (F2) — `--level raw`
+
+**Назначение:** экспорт сырых Telegram-сообщений (`raw_messages`) без LLM-обработки.
+Полезно для использования системы как чистого парсера (ETL-пайплайны, архивация, внешний анализ).
+
+**Поддерживаемые уровни (`--level`):**
+
+| Level | Что экспортирует | Файлы |
+|-------|------------------|-------|
+| `raw` | Сырые Telegram-сообщения (посты + комментарии, без LLM) | `raw_messages.{json,ndjson}` |
+| `processed` | `ProcessedDocument[]` → `KnowledgeBaseEntry[]` (после LLM) | `kb_entries.ndjson` |
+| `full` | `processed` + `topics.json` + `topic_<id>.json` (legacy default) | все три |
+
+**Ограничения `--level raw`:**
+- Требует `--channel` (per-channel экспорт; экспорт всех каналов сразу не поддерживается в F2).
+- `--topic-id` игнорируется.
+- `raw_payload` (приватные Telethon-структуры, session artifacts) **не включается** в вывод — это намеренное ограничение приватности, изменение требует отдельной фичи.
+
+**JSON envelope vs NDJSON:**
+
+`--format json` (envelope) — удобно для небольших каналов, агрегированная структура с группировкой комментариев под постами:
+
+```json
+{
+  "schema_version": "raw_channel_export.v1",
+  "channel_id": "1234567890",
+  "channel_username": "example_channel",
+  "exported_at": "2026-04-18T12:00:00Z",
+  "filters": {"from_date": null, "to_date": null},
+  "messages_count": 542,
+  "comments_count": 1287,
+  "orphan_comments_count": 3,
+  "messages": [
+    {
+      "id": "987",
+      "source_ref": "tg:1234567890:post:987",
+      "message_type": "post",
+      "date": "2026-01-15T10:30:00Z",
+      "text": "Текст поста...",
+      "comments": [
+        {"id": "988", "parent_message_id": "987", "text": "Ответ...", "date": "..."}
+      ]
+    }
+  ],
+  "orphan_comments": []
+}
+```
+
+**Orphan comments** — комментарии, чей родительский пост вне диапазона `--from-date`/`--to-date`. Сохраняются в отдельном bucket'е, чтобы не теряться молча.
+
+`--format ndjson` (stream) — рекомендуется для больших каналов (>10K сообщений) или ETL-пайплайнов: одно сообщение на строку, без envelope, без группировки (сначала все посты по дате, потом все комментарии по дате).
+
+**Примеры CLI:**
+
+```bash
+python -m tg_parser.cli export \
+  --level raw \
+  --channel @durov \
+  --format json \
+  --out ./raw_export
+
+python -m tg_parser.cli export \
+  --level raw \
+  --channel @durov \
+  --format ndjson \
+  --out ./raw_export
+
+python -m tg_parser.cli export \
+  --level raw \
+  --channel @durov \
+  --from-date 2026-01-01 \
+  --to-date 2026-03-31 \
+  --format ndjson \
+  --out ./raw_q1
+
+python -m tg_parser.cli export \
+  --level processed \
+  --channel @durov \
+  --out ./processed_export
+```
+
+**Пример API (`POST /api/v1/export`):**
+
+```bash
+curl -X POST http://localhost:8000/api/v1/export \
+  -H "X-API-Key: $TG_PARSER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "channel_id": "1234567890",
+    "level": "raw",
+    "format": "json",
+    "from_date": "2026-01-01T00:00:00Z"
+  }'
+
+curl http://localhost:8000/api/v1/export/status/$JOB_ID \
+  -H "X-API-Key: $TG_PARSER_API_KEY"
+
+curl -O -J http://localhost:8000/api/v1/export/download/$JOB_ID \
+  -H "X-API-Key: $TG_PARSER_API_KEY"
+```
+
+Rate-limit API: 20 запросов/минуту (настройка `RATE_LIMIT_EXPORT`). Для больших каналов предпочтительнее CLI.
+
+**Пример через Telegram-бот:**
+
+Достаточно попросить ассистента на естественном языке:
+
+> "Экспортируй канал @durov в raw JSON"
+
+Бот вызовет tool `export_channel`, дождётся завершения фонового задания и:
+- отправит файл в чат (если < 50 MB — лимит Telegram Bot API);
+- вернёт download URL и короткую статистику (если ≥ 50 MB).
+
+**Пример через MCP:** см. `docs/MCP_AGENT_GUIDE.md` §"export_channel".
 
 ### `run` — One-shot Pipeline ⭐
 

--- a/docs/notes/FUTURE_FEATURES.md
+++ b/docs/notes/FUTURE_FEATURES.md
@@ -292,11 +292,22 @@ class PromptConfigService:
 
 ---
 
-## F2: Channel Content Export (Parse-Only Mode)
+## F2: Channel Content Export (Parse-Only Mode) ✅ DONE
 
+**Статус:** Реализовано в `feat/f2-parse-only-export` (апрель 2026).
 **Приоритет:** Средний
 **Сложность:** ~0.5 сессии (низкая)
 **Зависимости:** нет
+
+### Итог реализации
+
+- `ExportLevel ∈ {raw, processed, full}` — новое измерение в `ExportService.run_export`, API `/api/v1/export`, CLI `tg_parser export`, MCP-tool `export_channel`, bot-tool `export_channel`.
+- `tg_parser/export/raw_export.py` — pure writer: JSON envelope v1 + NDJSON stream; `raw_payload` excluded by default; orphan comments bucket.
+- `processed` и `full` сохраняют существующее поведение (backward-compat — `run_export(channel_id=X)` без `level` = `full`).
+- Bot-tool уважает Telegram-лимит `send_document` 50 MB → при превышении возвращает download URL вместо файла.
+- Подробный user-facing гайд: `docs/USER_GUIDE.md` §"Parse-Only Export (F2)".
+- MCP workflow (submit→poll→download): `docs/MCP_AGENT_GUIDE.md` §"export_channel".
+
 
 ### Мотивация
 

--- a/tests/test_bot_tools_v11.py
+++ b/tests/test_bot_tools_v11.py
@@ -95,7 +95,7 @@ class TestBotToolDeclarations:
         assert "get_pipeline_status" in names
         assert "pause_channel" in names
         assert "resume_channel" in names
-        assert len(TOOL_DECLARATIONS) == 24
+        assert len(TOOL_DECLARATIONS) == 25
 
 
 class TestExecuteToolTriggerPipeline:

--- a/tests/test_bot_tools_v12.py
+++ b/tests/test_bot_tools_v12.py
@@ -147,7 +147,7 @@ class TestBotToolDeclarationsV12:
             assert name in names, f"{name} not in TOOL_DECLARATIONS"
 
     def test_total_tool_count(self):
-        assert len(TOOL_DECLARATIONS) == 24
+        assert len(TOOL_DECLARATIONS) == 25
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f2_parse_only_export.py
+++ b/tests/test_f2_parse_only_export.py
@@ -36,7 +36,6 @@ from tg_parser.export.raw_export import (
     export_raw_channel_ndjson,
 )
 
-
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -104,12 +103,8 @@ class TestGroupMessages:
 
     def test_multiple_comments_under_one_post_ordered_by_date(self):
         post = _raw_post("1", date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC))
-        c_late = _raw_comment(
-            "20", "1", date=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
-        )
-        c_early = _raw_comment(
-            "21", "1", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC)
-        )
+        c_late = _raw_comment("20", "1", date=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC))
+        c_early = _raw_comment("21", "1", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC))
 
         posts, grouped, orphans = _group_messages([post, c_late, c_early])
 
@@ -197,12 +192,8 @@ class TestRawExportWriter:
     def test_post_with_comments_grouped_by_parent_message_id(self, tmp_path: Path):
         out = tmp_path / "raw.json"
         post = _raw_post("100")
-        c1 = _raw_comment(
-            "101", "100", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC)
-        )
-        c2 = _raw_comment(
-            "102", "100", date=datetime(2026, 1, 15, 11, 30, 0, tzinfo=UTC)
-        )
+        c1 = _raw_comment("101", "100", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC))
+        c2 = _raw_comment("102", "100", date=datetime(2026, 1, 15, 11, 30, 0, tzinfo=UTC))
 
         export_raw_channel_json(
             messages=[c2, c1, post],
@@ -238,9 +229,7 @@ class TestRawExportWriter:
         assert data["orphan_comments_count"] == 1
         assert data["orphan_comments"][0]["id"] == "77"
 
-    def test_ndjson_one_message_per_line_posts_first_then_comments(
-        self, tmp_path: Path
-    ):
+    def test_ndjson_one_message_per_line_posts_first_then_comments(self, tmp_path: Path):
         out = tmp_path / "raw.ndjson"
         p1 = _raw_post("1", date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC))
         p2 = _raw_post("2", date=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC))
@@ -296,9 +285,7 @@ class TestRawExportWriter:
     def test_raw_payload_excluded_by_default_in_json(self, tmp_path: Path):
         out = tmp_path / "raw.json"
         p = _raw_post("1", raw_payload={"secret": "telethon", "views": 100})
-        c = _raw_comment(
-            "2", "1", raw_payload={"secret": "file_ref", "edit": None}
-        )
+        c = _raw_comment("2", "1", raw_payload={"secret": "file_ref", "edit": None})
 
         export_raw_channel_json(
             messages=[p, c],
@@ -414,9 +401,7 @@ class TestExportServiceRawMocked:
         assert data["channel_id"] == "ch1"
         assert data["channel_username"] == "my_channel"
 
-    async def test_run_export_level_raw_ndjson_writes_line_per_message(
-        self, tmp_path: Path
-    ):
+    async def test_run_export_level_raw_ndjson_writes_line_per_message(self, tmp_path: Path):
         from tg_parser.services.export_service import run_export
 
         raw_repo = AsyncMock()
@@ -528,9 +513,7 @@ class TestExportServiceRawMocked:
 class TestExportServiceBackwardCompat:
     """Backward-compat: callers that don't pass ``level=`` must keep working."""
 
-    async def test_run_export_default_call_signature_still_works(
-        self, tmp_path: Path
-    ):
+    async def test_run_export_default_call_signature_still_works(self, tmp_path: Path):
         from tg_parser.services.export_service import run_export
 
         processed_repo = AsyncMock()
@@ -756,9 +739,7 @@ class TestExportServiceRawPostgres:
     """End-to-end ``run_export(level=raw)`` with real Postgres."""
 
     @pytest.mark.asyncio
-    async def test_run_export_level_raw_end_to_end(
-        self, postgres_test_db, tmp_path: Path
-    ):
+    async def test_run_export_level_raw_end_to_end(self, postgres_test_db, tmp_path: Path):
         from tg_parser.services.export_service import run_export
         from tg_parser.storage.sqlalchemy import (
             SAIngestionStateRepo,
@@ -1068,9 +1049,7 @@ class TestMCPExportChannel:
         from tg_parser.mcp_server import export_channel
 
         with pytest.raises(ValueError, match="invalid format"):
-            await export_channel(
-                channel_id="ch1", level="raw", format="yaml", ctx=None
-            )
+            await export_channel(channel_id="ch1", level="raw", format="yaml", ctx=None)
 
     @pytest.mark.asyncio
     async def test_mcp_export_channel_raw_requires_channel_id(self):
@@ -1092,7 +1071,10 @@ class TestMCPExportChannel:
 
         async def fake_resolve(_client_id):
             return CurrentUser(
-                id="u1", name="tester", role="user", allowed_channel_ids=None,
+                id="u1",
+                name="tester",
+                role="user",
+                allowed_channel_ids=None,
                 max_channels=20,
             )
 
@@ -1108,15 +1090,9 @@ class TestMCPExportChannel:
             captured["called_level"] = request.level
 
         monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure
-        )
-        monkeypatch.setattr(
-            "tg_parser.api.routes.export._run_export_job", fake_run_export_job
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure)
+        monkeypatch.setattr("tg_parser.api.routes.export._run_export_job", fake_run_export_job)
 
         result = await mcp_mod.export_channel(
             channel_id="ch1", level="raw", format="json", ctx=None
@@ -1138,17 +1114,18 @@ class TestMCPExportChannel:
 
         async def fake_resolve(_client_id):
             return CurrentUser(
-                id="u-non-owner", name="other", role="user",
-                allowed_channel_ids=["other_ch"], max_channels=10,
+                id="u-non-owner",
+                name="other",
+                role="user",
+                allowed_channel_ids=["other_ch"],
+                max_channels=10,
             )
 
         async def fake_assert(_user, channel_id):
             raise PermissionDenied(f"No access to {channel_id}")
 
         monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
 
         result = await mcp_mod.export_channel(
             channel_id="ch1", level="raw", format="json", ctx=None
@@ -1164,7 +1141,10 @@ class TestMCPExportChannel:
 
         async def fake_resolve(_client_id):
             return CurrentUser(
-                id="u1", name="t", role="user", allowed_channel_ids=None,
+                id="u1",
+                name="t",
+                role="user",
+                allowed_channel_ids=None,
                 max_channels=20,
             )
 
@@ -1182,15 +1162,9 @@ class TestMCPExportChannel:
             return None
 
         monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure
-        )
-        monkeypatch.setattr(
-            "tg_parser.api.routes.export._run_export_job", fake_run
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure)
+        monkeypatch.setattr("tg_parser.api.routes.export._run_export_job", fake_run)
 
         result = await mcp_mod.export_channel(channel_id="ch1", ctx=None)
         assert result.level == "raw"
@@ -1228,9 +1202,7 @@ class _FakeBot:
     async def send_document(self, *, chat_id, document, caption=None):  # noqa: ANN001
         if self.send_document_should_raise is not None:
             raise self.send_document_should_raise
-        self.sent_documents.append(
-            {"chat_id": chat_id, "document": document, "caption": caption}
-        )
+        self.sent_documents.append({"chat_id": chat_id, "document": document, "caption": caption})
 
     async def delete_message(self, *, chat_id, message_id):  # noqa: ANN001
         self.deleted_messages.append({"chat_id": chat_id, "message_id": message_id})
@@ -1246,7 +1218,10 @@ class TestBotExportChannel:
         from tg_parser.auth.models import CurrentUser
 
         return CurrentUser(
-            id="u1", name="tester", role="user", allowed_channel_ids=None,
+            id="u1",
+            name="tester",
+            role="user",
+            allowed_channel_ids=None,
             max_channels=20,
         )
 
@@ -1280,9 +1255,7 @@ class TestBotExportChannel:
         assert "invalid format" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_bot_export_channel_raw_requires_channel_id(
-        self, fake_bot, test_user
-    ):
+    async def test_bot_export_channel_raw_requires_channel_id(self, fake_bot, test_user):
         from tg_parser.bot.tools import execute_tool
 
         result = await execute_tool(
@@ -1296,18 +1269,14 @@ class TestBotExportChannel:
         assert "channel_id" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_bot_export_channel_ownership_enforced(
-        self, monkeypatch, fake_bot, test_user
-    ):
+    async def test_bot_export_channel_ownership_enforced(self, monkeypatch, fake_bot, test_user):
         from tg_parser.auth.ownership import PermissionDenied
         from tg_parser.bot.tools import execute_tool
 
         async def fake_assert(_user, channel_id):
             raise PermissionDenied(f"No access to {channel_id}")
 
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
 
         result = await execute_tool(
             "export_channel",
@@ -1340,12 +1309,8 @@ class TestBotExportChannel:
                 "channels_count": 1,
             }
 
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.services.export_service.run_export", fake_run_export
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.services.export_service.run_export", fake_run_export)
         monkeypatch.setattr(settings, "output_dir", str(tmp_path))
 
         result = await execute_tool(
@@ -1394,17 +1359,15 @@ class TestBotExportChannel:
 
         def fake_stat(self, *args, **kwargs):
             if self.name == "raw_messages.json":
+
                 class _S:
                     st_size = oversize
+
                 return _S()
             return original_stat(self, *args, **kwargs)
 
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.services.export_service.run_export", fake_run_export
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.services.export_service.run_export", fake_run_export)
         monkeypatch.setattr(settings, "output_dir", str(tmp_path))
         monkeypatch.setattr(Path, "stat", fake_stat)
 
@@ -1441,12 +1404,8 @@ class TestBotExportChannel:
                 "channels_count": 1,
             }
 
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.services.export_service.run_export", fake_run_export
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.services.export_service.run_export", fake_run_export)
         monkeypatch.setattr(settings, "output_dir", str(tmp_path))
 
         await execute_tool(
@@ -1481,12 +1440,8 @@ class TestBotExportChannel:
                 "channels_count": 1,
             }
 
-        monkeypatch.setattr(
-            "tg_parser.auth.ownership.assert_channel_access", fake_assert
-        )
-        monkeypatch.setattr(
-            "tg_parser.services.export_service.run_export", fake_run_export
-        )
+        monkeypatch.setattr("tg_parser.auth.ownership.assert_channel_access", fake_assert)
+        monkeypatch.setattr("tg_parser.services.export_service.run_export", fake_run_export)
         monkeypatch.setattr(settings, "output_dir", str(tmp_path))
 
         result = await execute_tool(

--- a/tests/test_f2_parse_only_export.py
+++ b/tests/test_f2_parse_only_export.py
@@ -863,11 +863,18 @@ class TestCLIExportLevel:
         assert "format" in result.output.lower() or "format" in (result.stderr or "").lower()
 
     def test_cli_export_help_mentions_level_and_format(self):
+        import re
+
         runner = CliRunner()
         result = runner.invoke(cli_app, ["export", "--help"])
         assert result.exit_code == 0
-        assert "--level" in result.output
-        assert "--format" in result.output
+        # Strip ANSI escape sequences and collapse whitespace so the assertion
+        # is robust against Rich/Typer help rendering on CI (color + wrapping).
+        ansi_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+        plain = ansi_re.sub("", result.output)
+        plain = re.sub(r"\s+", " ", plain)
+        assert "--level" in plain
+        assert "--format" in plain
 
 
 # ============================================================================

--- a/tests/test_f2_parse_only_export.py
+++ b/tests/test_f2_parse_only_export.py
@@ -1,0 +1,1043 @@
+"""Tests for F2 Parse-Only Export (raw channel export).
+
+Covers:
+
+- ``tg_parser.export.raw_export`` pure writer (JSON envelope + NDJSON).
+- ``_group_messages`` helper (posts/comments/orphans grouping).
+- ``tg_parser.services.export_service.run_export(level=...)`` branching
+  (raw + backward-compat for processed / full).
+- CLI ``tg_parser export --level ... --format ...`` wiring + validation.
+- API ``POST /api/v1/export`` level-aware job creation + download media types.
+
+MCP + Bot tests live in the same file but are added in Commit 2.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from typer.testing import CliRunner
+
+from tg_parser.api.main import create_app
+from tg_parser.api.schemas import ExportFormat, ExportLevel
+from tg_parser.cli.app import app as cli_app
+from tg_parser.domain.models import MessageType, RawTelegramMessage
+from tg_parser.export.raw_export import (
+    SCHEMA_VERSION,
+    _group_messages,
+    _message_payload,
+    export_raw_channel_json,
+    export_raw_channel_ndjson,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _raw_post(
+    msg_id: str,
+    *,
+    channel_id: str = "ch1",
+    date: datetime | None = None,
+    text: str = "post body",
+    language: str | None = "ru",
+    raw_payload: dict | None = None,
+) -> RawTelegramMessage:
+    return RawTelegramMessage(
+        id=msg_id,
+        message_type=MessageType.POST,
+        source_ref=f"tg:{channel_id}:post:{msg_id}",
+        channel_id=channel_id,
+        date=date or datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC),
+        text=text,
+        language=language,
+        raw_payload=raw_payload,
+    )
+
+
+def _raw_comment(
+    msg_id: str,
+    parent_id: str | None,
+    *,
+    channel_id: str = "ch1",
+    date: datetime | None = None,
+    text: str = "comment body",
+    language: str | None = "ru",
+    thread_id: str | None = None,
+    raw_payload: dict | None = None,
+) -> RawTelegramMessage:
+    return RawTelegramMessage(
+        id=msg_id,
+        message_type=MessageType.COMMENT,
+        source_ref=f"tg:{channel_id}:comment:{msg_id}",
+        channel_id=channel_id,
+        date=date or datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC),
+        text=text,
+        language=language,
+        parent_message_id=parent_id,
+        thread_id=thread_id or parent_id,
+        raw_payload=raw_payload,
+    )
+
+
+# ============================================================================
+# TestGroupMessages — pure helper
+# ============================================================================
+
+
+class TestGroupMessages:
+    def test_post_with_no_comments(self):
+        post = _raw_post("1")
+        posts, grouped, orphans = _group_messages([post])
+
+        assert posts == [post]
+        assert grouped == {}
+        assert orphans == []
+
+    def test_multiple_comments_under_one_post_ordered_by_date(self):
+        post = _raw_post("1", date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC))
+        c_late = _raw_comment(
+            "20", "1", date=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        )
+        c_early = _raw_comment(
+            "21", "1", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC)
+        )
+
+        posts, grouped, orphans = _group_messages([post, c_late, c_early])
+
+        assert posts == [post]
+        assert list(grouped.keys()) == ["1"]
+        assert [c.id for c in grouped["1"]] == ["21", "20"]
+        assert orphans == []
+
+    def test_orphan_comments_collected_separately(self):
+        post = _raw_post("1")
+        orphan = _raw_comment("99", "NONEXISTENT")
+
+        posts, grouped, orphans = _group_messages([post, orphan])
+
+        assert posts == [post]
+        assert grouped == {}
+        assert orphans == [orphan]
+
+    def test_orphan_comment_without_parent_id_also_classified_as_orphan(self):
+        orphan = _raw_comment("77", None)
+        posts, grouped, orphans = _group_messages([orphan])
+
+        assert posts == []
+        assert grouped == {}
+        assert orphans == [orphan]
+
+    def test_multiple_posts_sorted_by_date(self):
+        p_late = _raw_post("1", date=datetime(2026, 1, 16, 10, 0, 0, tzinfo=UTC))
+        p_early = _raw_post("2", date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC))
+
+        posts, _grouped, _orphans = _group_messages([p_late, p_early])
+
+        assert [p.id for p in posts] == ["2", "1"]
+
+
+# ============================================================================
+# TestRawExportWriter — pure writer to tmp_path
+# ============================================================================
+
+
+class TestRawExportWriter:
+    def test_json_envelope_schema_version_present(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        export_raw_channel_json(
+            messages=[],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+        )
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["schema_version"] == SCHEMA_VERSION
+        assert SCHEMA_VERSION == "raw_channel_export.v1"
+
+    def test_json_envelope_fields(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        from_dt = datetime(2026, 1, 1, tzinfo=UTC)
+        to_dt = datetime(2026, 1, 31, tzinfo=UTC)
+        stats = export_raw_channel_json(
+            messages=[_raw_post("1"), _raw_comment("2", "1")],
+            channel_id="ch1",
+            channel_username="my_channel",
+            from_date=from_dt,
+            to_date=to_dt,
+            output_path=out,
+        )
+        data = json.loads(out.read_text(encoding="utf-8"))
+
+        assert data["channel_id"] == "ch1"
+        assert data["channel_username"] == "my_channel"
+        assert "exported_at" in data
+        assert data["filters"] == {
+            "from_date": from_dt.isoformat(),
+            "to_date": to_dt.isoformat(),
+        }
+        assert data["messages_count"] == 1
+        assert data["comments_count"] == 1
+        assert data["orphan_comments_count"] == 0
+        assert isinstance(data["messages"], list)
+        assert isinstance(data["orphan_comments"], list)
+
+        assert stats == {"posts": 1, "comments": 1, "orphan_comments": 0}
+
+    def test_post_with_comments_grouped_by_parent_message_id(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        post = _raw_post("100")
+        c1 = _raw_comment(
+            "101", "100", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC)
+        )
+        c2 = _raw_comment(
+            "102", "100", date=datetime(2026, 1, 15, 11, 30, 0, tzinfo=UTC)
+        )
+
+        export_raw_channel_json(
+            messages=[c2, c1, post],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+        )
+
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert len(data["messages"]) == 1
+        post_payload = data["messages"][0]
+        assert post_payload["id"] == "100"
+        assert [c["id"] for c in post_payload["comments"]] == ["101", "102"]
+
+    def test_orphan_comments_bucket_when_parent_out_of_range(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        orphan = _raw_comment("77", "999")  # parent 999 not in messages list
+
+        export_raw_channel_json(
+            messages=[orphan],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+        )
+
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["messages_count"] == 0
+        assert data["comments_count"] == 0
+        assert data["orphan_comments_count"] == 1
+        assert data["orphan_comments"][0]["id"] == "77"
+
+    def test_ndjson_one_message_per_line_posts_first_then_comments(
+        self, tmp_path: Path
+    ):
+        out = tmp_path / "raw.ndjson"
+        p1 = _raw_post("1", date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC))
+        p2 = _raw_post("2", date=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC))
+        c = _raw_comment("3", "1", date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC))
+
+        stats = export_raw_channel_ndjson(messages=[c, p2, p1], output_path=out)
+
+        assert stats == {"posts": 2, "comments": 1, "orphan_comments": 0}
+
+        lines = out.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+
+        parsed = [json.loads(ln) for ln in lines]
+        assert [p["id"] for p in parsed] == ["1", "2", "3"]
+        assert parsed[0]["message_type"] == "post"
+        assert parsed[-1]["message_type"] == "comment"
+
+        # Every line is valid JSON (no stray newlines inside records)
+        for ln in lines:
+            assert json.loads(ln) is not None
+
+    def test_pretty_flag_produces_indented_json(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        export_raw_channel_json(
+            messages=[_raw_post("1")],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+            pretty=True,
+        )
+        content = out.read_text(encoding="utf-8")
+        assert "\n" in content
+        assert "  " in content
+
+    def test_compact_json_no_indent(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        export_raw_channel_json(
+            messages=[_raw_post("1")],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+            pretty=False,
+        )
+        content = out.read_text(encoding="utf-8")
+        # Compact JSON must still parse and must not contain the pretty-print indent
+        assert json.loads(content)
+        assert "\n  " not in content
+
+    def test_raw_payload_excluded_by_default_in_json(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        p = _raw_post("1", raw_payload={"secret": "telethon", "views": 100})
+        c = _raw_comment(
+            "2", "1", raw_payload={"secret": "file_ref", "edit": None}
+        )
+
+        export_raw_channel_json(
+            messages=[p, c],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+        )
+        data = json.loads(out.read_text(encoding="utf-8"))
+
+        # Deep assertion across every serialized message in the envelope
+        for msg in data["messages"]:
+            assert "raw_payload" not in msg, msg
+            for cm in msg.get("comments", []):
+                assert "raw_payload" not in cm, cm
+        for msg in data.get("orphan_comments", []):
+            assert "raw_payload" not in msg, msg
+
+    def test_raw_payload_excluded_by_default_in_ndjson(self, tmp_path: Path):
+        out = tmp_path / "raw.ndjson"
+        p = _raw_post("1", raw_payload={"secret": "telethon"})
+        c = _raw_comment("2", "1", raw_payload={"secret": "oof"})
+
+        export_raw_channel_ndjson(messages=[p, c], output_path=out)
+
+        for line in out.read_text(encoding="utf-8").splitlines():
+            parsed = json.loads(line)
+            assert "raw_payload" not in parsed, parsed
+
+    def test_empty_messages_writes_valid_envelope(self, tmp_path: Path):
+        out = tmp_path / "raw.json"
+        stats = export_raw_channel_json(
+            messages=[],
+            channel_id="ch1",
+            channel_username=None,
+            from_date=None,
+            to_date=None,
+            output_path=out,
+        )
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["messages"] == []
+        assert data["orphan_comments"] == []
+        assert data["messages_count"] == 0
+        assert data["comments_count"] == 0
+        assert data["orphan_comments_count"] == 0
+        assert stats == {"posts": 0, "comments": 0, "orphan_comments": 0}
+
+    def test_message_payload_excludes_raw_payload(self):
+        msg = _raw_post("1", raw_payload={"x": "y"})
+        payload = _message_payload(msg)
+        assert "raw_payload" not in payload
+        assert payload["id"] == "1"
+        assert payload["text"] == "post body"
+
+
+# ============================================================================
+# TestExportServiceRawMocked — run_export level=raw with mocked repos
+# ============================================================================
+
+
+class TestExportServiceRawMocked:
+    """Tests ``run_export(level=RAW)`` branching via AsyncMock repos."""
+
+    async def test_run_export_level_raw_requires_channel_id(self, tmp_path: Path):
+        from tg_parser.services.export_service import run_export
+
+        with pytest.raises(ValueError, match="level='raw' requires channel_id"):
+            await run_export(
+                output_dir=str(tmp_path),
+                level=ExportLevel.RAW,
+                raw_repo=AsyncMock(),
+                processed_repo=AsyncMock(),
+                topic_card_repo=AsyncMock(),
+                topic_bundle_repo=AsyncMock(),
+                ingestion_repo=AsyncMock(),
+            )
+
+    async def test_run_export_level_raw_writes_json(self, tmp_path: Path):
+        from tg_parser.services.export_service import run_export
+
+        raw_repo = AsyncMock()
+        raw_repo.list_by_channel.return_value = [
+            _raw_post("1"),
+            _raw_comment("2", "1"),
+        ]
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {"ch1": "my_channel"}
+
+        stats = await run_export(
+            output_dir=str(tmp_path),
+            channel_id="ch1",
+            level=ExportLevel.RAW,
+            format=ExportFormat.JSON,
+            raw_repo=raw_repo,
+            ingestion_repo=ingestion_repo,
+            processed_repo=AsyncMock(),
+            topic_card_repo=AsyncMock(),
+            topic_bundle_repo=AsyncMock(),
+        )
+
+        assert stats == {
+            "raw_posts_count": 1,
+            "raw_comments_count": 1,
+            "raw_orphan_comments_count": 0,
+            "channels_count": 1,
+        }
+
+        out_file = tmp_path / "raw_messages.json"
+        assert out_file.exists()
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["schema_version"] == SCHEMA_VERSION
+        assert data["channel_id"] == "ch1"
+        assert data["channel_username"] == "my_channel"
+
+    async def test_run_export_level_raw_ndjson_writes_line_per_message(
+        self, tmp_path: Path
+    ):
+        from tg_parser.services.export_service import run_export
+
+        raw_repo = AsyncMock()
+        raw_repo.list_by_channel.return_value = [
+            _raw_post("1"),
+            _raw_post("2"),
+            _raw_comment("3", "1"),
+        ]
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {}
+
+        stats = await run_export(
+            output_dir=str(tmp_path),
+            channel_id="ch1",
+            level=ExportLevel.RAW,
+            format=ExportFormat.NDJSON,
+            raw_repo=raw_repo,
+            ingestion_repo=ingestion_repo,
+            processed_repo=AsyncMock(),
+            topic_card_repo=AsyncMock(),
+            topic_bundle_repo=AsyncMock(),
+        )
+
+        out_file = tmp_path / "raw_messages.ndjson"
+        assert out_file.exists()
+        lines = out_file.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+        # All lines must be valid JSON and must not contain raw_payload
+        for line in lines:
+            parsed = json.loads(line)
+            assert "raw_payload" not in parsed
+
+        assert stats["raw_posts_count"] == 2
+        assert stats["raw_comments_count"] == 1
+        assert stats["raw_orphan_comments_count"] == 0
+
+    async def test_run_export_level_raw_respects_date_filter(self, tmp_path: Path):
+        from tg_parser.services.export_service import run_export
+
+        raw_repo = AsyncMock()
+        raw_repo.list_by_channel.return_value = []
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {}
+
+        from_dt = datetime(2026, 1, 1, tzinfo=UTC)
+        to_dt = datetime(2026, 1, 31, tzinfo=UTC)
+
+        await run_export(
+            output_dir=str(tmp_path),
+            channel_id="ch1",
+            level=ExportLevel.RAW,
+            format=ExportFormat.JSON,
+            from_date=from_dt,
+            to_date=to_dt,
+            raw_repo=raw_repo,
+            ingestion_repo=ingestion_repo,
+            processed_repo=AsyncMock(),
+            topic_card_repo=AsyncMock(),
+            topic_bundle_repo=AsyncMock(),
+        )
+
+        raw_repo.list_by_channel.assert_awaited_once_with(
+            channel_id="ch1",
+            from_date=from_dt,
+            to_date=to_dt,
+        )
+
+    async def test_run_export_level_raw_channel_without_messages_returns_empty_envelope(
+        self, tmp_path: Path
+    ):
+        from tg_parser.services.export_service import run_export
+
+        raw_repo = AsyncMock()
+        raw_repo.list_by_channel.return_value = []
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {}
+
+        stats = await run_export(
+            output_dir=str(tmp_path),
+            channel_id="unknown_channel",
+            level=ExportLevel.RAW,
+            format=ExportFormat.JSON,
+            raw_repo=raw_repo,
+            ingestion_repo=ingestion_repo,
+            processed_repo=AsyncMock(),
+            topic_card_repo=AsyncMock(),
+            topic_bundle_repo=AsyncMock(),
+        )
+
+        out_file = tmp_path / "raw_messages.json"
+        assert out_file.exists()
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["messages"] == []
+        assert data["channel_id"] == "unknown_channel"
+
+        assert stats == {
+            "raw_posts_count": 0,
+            "raw_comments_count": 0,
+            "raw_orphan_comments_count": 0,
+            "channels_count": 0,
+        }
+
+
+# ============================================================================
+# TestExportServiceBackwardCompat — ensure level=FULL default matches pre-F2
+# ============================================================================
+
+
+class TestExportServiceBackwardCompat:
+    """Backward-compat: callers that don't pass ``level=`` must keep working."""
+
+    async def test_run_export_default_call_signature_still_works(
+        self, tmp_path: Path
+    ):
+        from tg_parser.services.export_service import run_export
+
+        processed_repo = AsyncMock()
+        processed_repo.list_all.return_value = []
+        processed_repo.list_by_channel.return_value = []
+
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {}
+
+        result = await run_export(
+            output_dir=str(tmp_path),
+            processed_repo=processed_repo,
+            topic_card_repo=topic_card_repo,
+            topic_bundle_repo=topic_bundle_repo,
+            ingestion_repo=ingestion_repo,
+            raw_repo=AsyncMock(),
+        )
+
+        assert result["kb_entries_count"] == 0
+        assert result["topics_count"] == 0
+        assert result["channels_count"] == 0
+
+    async def test_run_export_default_level_is_full(self, tmp_path: Path):
+        """``run_export`` without ``level=`` must equal ``level=FULL`` behaviour."""
+        from tg_parser.services.export_service import run_export
+
+        processed_repo = AsyncMock()
+        processed_repo.list_all.return_value = []
+        processed_repo.list_by_channel.return_value = []
+        topic_card_repo = AsyncMock()
+        topic_card_repo.list_by_channel.return_value = []
+        topic_bundle_repo = AsyncMock()
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {}
+
+        out_default = tmp_path / "default"
+        out_full = tmp_path / "full"
+
+        stats_default = await run_export(
+            output_dir=str(out_default),
+            channel_id="ch1",
+            processed_repo=processed_repo,
+            topic_card_repo=topic_card_repo,
+            topic_bundle_repo=topic_bundle_repo,
+            ingestion_repo=ingestion_repo,
+            raw_repo=AsyncMock(),
+        )
+        stats_full = await run_export(
+            output_dir=str(out_full),
+            channel_id="ch1",
+            level=ExportLevel.FULL,
+            processed_repo=processed_repo,
+            topic_card_repo=topic_card_repo,
+            topic_bundle_repo=topic_bundle_repo,
+            ingestion_repo=ingestion_repo,
+            raw_repo=AsyncMock(),
+        )
+
+        assert stats_default == stats_full
+        # No raw files leaked into FULL path
+        assert not (out_default / "raw_messages.json").exists()
+        assert not (out_default / "raw_messages.ndjson").exists()
+
+    async def test_run_export_level_processed_skips_topics(self, tmp_path: Path):
+        """``level=PROCESSED`` must NOT write ``topics.json`` even when cards exist."""
+        from tg_parser.domain.ids import make_processed_document_id
+        from tg_parser.domain.models import (
+            Anchor,
+            MessageType,
+            ProcessedDocument,
+            TopicCard,
+            TopicType,
+        )
+        from tg_parser.services.export_service import run_export
+
+        now = datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC)
+        source_ref = "tg:ch1:post:1"
+        doc = ProcessedDocument(
+            id=make_processed_document_id(source_ref),
+            source_ref=source_ref,
+            channel_id="ch1",
+            source_message_id="1",
+            processed_at=now,
+            text_clean="processed body",
+            summary="Summary",
+            topics=["topic_a"],
+            entities=[],
+            metadata={
+                "pipeline_version": "test",
+                "model_id": "test",
+                "prompt_id": "test",
+            },
+        )
+        topic_card = TopicCard(
+            id="topic:tg:ch1:post:1",
+            title="T",
+            summary="S",
+            scope_in=["x"],
+            scope_out=["y"],
+            type=TopicType.SINGLETON,
+            anchors=[
+                Anchor(
+                    channel_id="ch1",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    anchor_ref=source_ref,
+                    score=1.0,
+                )
+            ],
+            sources=["ch1"],
+            updated_at=now,
+        )
+
+        processed_repo = AsyncMock()
+        processed_repo.list_by_channel.return_value = [doc]
+        processed_repo.list_all.return_value = [doc]
+        topic_card_repo = AsyncMock()
+        topic_card_repo.list_by_channel.return_value = [topic_card]
+        topic_bundle_repo = AsyncMock()
+        topic_bundle_repo.get_by_topic_id.return_value = None
+        ingestion_repo = AsyncMock()
+        ingestion_repo.get_channel_usernames.return_value = {"ch1": "chan"}
+
+        # level=PROCESSED — must NOT produce topics.json
+        await run_export(
+            output_dir=str(tmp_path / "processed"),
+            channel_id="ch1",
+            level=ExportLevel.PROCESSED,
+            processed_repo=processed_repo,
+            topic_card_repo=topic_card_repo,
+            topic_bundle_repo=topic_bundle_repo,
+            ingestion_repo=ingestion_repo,
+            raw_repo=AsyncMock(),
+        )
+        assert (tmp_path / "processed" / "kb_entries.ndjson").exists()
+        assert not (tmp_path / "processed" / "topics.json").exists()
+
+        # level=FULL — must produce topics.json (legacy behaviour)
+        await run_export(
+            output_dir=str(tmp_path / "full"),
+            channel_id="ch1",
+            level=ExportLevel.FULL,
+            processed_repo=processed_repo,
+            topic_card_repo=topic_card_repo,
+            topic_bundle_repo=topic_bundle_repo,
+            ingestion_repo=ingestion_repo,
+            raw_repo=AsyncMock(),
+        )
+        assert (tmp_path / "full" / "kb_entries.ndjson").exists()
+        assert (tmp_path / "full" / "topics.json").exists()
+
+
+# ============================================================================
+# TestExportServiceRawPostgres — integration with real Postgres (opt-in)
+# ============================================================================
+
+
+@pytest.fixture
+async def postgres_test_db():
+    """Integration Postgres DB: init schemas + clear tables."""
+    if not os.environ.get("TEST_POSTGRES"):
+        pytest.skip("Postgres integration disabled (set TEST_POSTGRES=1)")
+
+    from sqlalchemy import text
+
+    from tg_parser.config.settings import Settings
+    from tg_parser.storage.sqlalchemy import (
+        Database,
+        init_ingestion_state_schema,
+        init_processing_storage_schema,
+        init_raw_storage_schema,
+    )
+
+    Database.reset_instance()
+    s = Settings(
+        db_host=os.environ.get("DB_HOST", "localhost"),
+        db_port=int(os.environ.get("DB_PORT", "5432")),
+        db_name=os.environ.get("TEST_DB_NAME", "tg_parser_test"),
+        db_user=os.environ.get("DB_USER", "tg_parser_user"),
+        db_password=os.environ.get("DB_PASSWORD", ""),
+        db_pool_size=2,
+        db_max_overflow=3,
+        telegram_api_id=12345,
+        telegram_api_hash="test_hash",
+        telegram_phone="+1234567890",
+        openai_api_key="sk-test-key",
+    )
+    db = Database.get_instance(s)
+    await db.init()
+
+    await init_ingestion_state_schema(db.ingestion_state_engine)
+    await init_raw_storage_schema(db.raw_storage_engine)
+    await init_processing_storage_schema(db.processing_storage_engine)
+
+    async with db.ingestion_state_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM source_attempts"))
+        await conn.execute(text("DELETE FROM sources"))
+    async with db.raw_storage_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM raw_conflicts"))
+        await conn.execute(text("DELETE FROM raw_messages"))
+    async with db.processing_storage_engine.begin() as conn:
+        await conn.execute(text("DELETE FROM topic_links"))
+        await conn.execute(text("DELETE FROM handoff_history"))
+        await conn.execute(text("DELETE FROM task_history"))
+        await conn.execute(text("DELETE FROM agent_stats"))
+        await conn.execute(text("DELETE FROM agent_states"))
+        await conn.execute(text("DELETE FROM topic_bundles"))
+        await conn.execute(text("DELETE FROM topic_cards"))
+        await conn.execute(text("DELETE FROM processing_failures"))
+        await conn.execute(text("DELETE FROM processed_documents"))
+        await conn.execute(text("DELETE FROM api_jobs"))
+
+    try:
+        yield db
+    finally:
+        await db.close()
+        Database.reset_instance()
+
+
+class TestExportServiceRawPostgres:
+    """End-to-end ``run_export(level=raw)`` with real Postgres."""
+
+    @pytest.mark.asyncio
+    async def test_run_export_level_raw_end_to_end(
+        self, postgres_test_db, tmp_path: Path
+    ):
+        from tg_parser.services.export_service import run_export
+        from tg_parser.storage.sqlalchemy import (
+            SAIngestionStateRepo,
+            SARawMessageRepo,
+        )
+
+        channel_id = "f2_test_channel"
+
+        # Seed raw messages: 2 posts, 1 comment
+        async with postgres_test_db.raw_storage_session() as session:
+            raw_repo = SARawMessageRepo(session)
+            await raw_repo.upsert(
+                _raw_post(
+                    "100",
+                    channel_id=channel_id,
+                    date=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC),
+                    text="First post",
+                )
+            )
+            await raw_repo.upsert(
+                _raw_post(
+                    "101",
+                    channel_id=channel_id,
+                    date=datetime(2026, 1, 16, 10, 0, 0, tzinfo=UTC),
+                    text="Second post",
+                )
+            )
+            await raw_repo.upsert(
+                _raw_comment(
+                    "102",
+                    "100",
+                    channel_id=channel_id,
+                    date=datetime(2026, 1, 15, 11, 0, 0, tzinfo=UTC),
+                    text="Comment on first",
+                )
+            )
+
+        # Seed source for channel_username resolution
+        async with postgres_test_db.ingestion_state_session() as session:
+            from tg_parser.storage.ports import Source
+
+            state_repo = SAIngestionStateRepo(session)
+            await state_repo.upsert_source(
+                Source(
+                    source_id="src_f2",
+                    channel_id=channel_id,
+                    status="active",
+                    include_comments=True,
+                    channel_username="f2_channel",
+                )
+            )
+
+        stats = await run_export(
+            output_dir=str(tmp_path),
+            channel_id=channel_id,
+            level=ExportLevel.RAW,
+            format=ExportFormat.JSON,
+        )
+
+        assert stats["raw_posts_count"] == 2
+        assert stats["raw_comments_count"] == 1
+        assert stats["raw_orphan_comments_count"] == 0
+        assert stats["channels_count"] == 1
+
+        out_file = tmp_path / "raw_messages.json"
+        data = json.loads(out_file.read_text(encoding="utf-8"))
+        assert data["schema_version"] == SCHEMA_VERSION
+        assert data["channel_id"] == channel_id
+        assert data["channel_username"] == "f2_channel"
+        assert data["messages_count"] == 2
+        assert data["comments_count"] == 1
+
+        # raw_payload invariant end-to-end
+        for msg in data["messages"]:
+            assert "raw_payload" not in msg
+            for cm in msg.get("comments", []):
+                assert "raw_payload" not in cm
+
+
+# ============================================================================
+# TestCLIExportLevel
+# ============================================================================
+
+
+class TestCLIExportLevel:
+    def test_cli_level_raw_requires_channel(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            ["export", "--level", "raw", "--out", "/tmp/f2_cli_test"],
+        )
+        assert result.exit_code != 0
+        assert "--level=raw" in result.output or "--level=raw" in (result.stderr or "")
+
+    def test_cli_invalid_level_rejected(self, tmp_path: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            ["export", "--level", "nonsense", "--out", str(tmp_path)],
+        )
+        assert result.exit_code != 0
+        assert "level" in result.output.lower() or "level" in (result.stderr or "").lower()
+
+    def test_cli_invalid_format_rejected(self, tmp_path: Path):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            [
+                "export",
+                "--level",
+                "raw",
+                "--channel",
+                "ch1",
+                "--format",
+                "yaml",
+                "--out",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "format" in result.output.lower() or "format" in (result.stderr or "").lower()
+
+    def test_cli_export_help_mentions_level_and_format(self):
+        runner = CliRunner()
+        result = runner.invoke(cli_app, ["export", "--help"])
+        assert result.exit_code == 0
+        assert "--level" in result.output
+        assert "--format" in result.output
+
+
+# ============================================================================
+# TestAPIExportLevel
+# ============================================================================
+
+
+@pytest.fixture
+def api_app():
+    return create_app()
+
+
+@pytest.fixture
+async def api_client(api_app):
+    transport = ASGITransport(app=api_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+class TestAPIExportLevel:
+    @pytest.mark.asyncio
+    async def test_post_export_level_raw_creates_job(self, api_client):
+        resp = await api_client.post(
+            "/api/v1/export",
+            json={
+                "channel_id": "ch1",
+                "level": "raw",
+                "format": "json",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["level"] == "raw"
+        assert data["format"] == "json"
+        assert "job_id" in data
+
+    @pytest.mark.asyncio
+    async def test_post_export_level_raw_without_channel_returns_400(self, api_client):
+        resp = await api_client.post(
+            "/api/v1/export",
+            json={"level": "raw", "format": "json"},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "raw" in str(body).lower()
+
+    @pytest.mark.asyncio
+    async def test_post_export_without_level_defaults_to_full(self, api_client):
+        resp = await api_client.post("/api/v1/export", json={"format": "ndjson"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["level"] == "full"
+
+    @pytest.mark.asyncio
+    async def test_get_status_includes_level(self, api_client):
+        import uuid
+
+        from tg_parser.api.job_store import ensure_job_store_initialized
+        from tg_parser.storage.ports import Job, JobStatus, JobType
+
+        job_store = await ensure_job_store_initialized()
+        job_id = f"test-raw-{uuid.uuid4()}"
+        pending_job = Job(
+            job_id=job_id,
+            job_type=JobType.EXPORT,
+            status=JobStatus.PENDING,
+            created_at=datetime.now(UTC),
+            channel_id="ch1",
+            export_format="json",
+            progress={"level": "raw"},
+        )
+        await job_store.create_job(pending_job)
+
+        resp = await api_client.get(f"/api/v1/export/status/{job_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["level"] == "raw"
+        assert data["format"] == "json"
+
+    @pytest.mark.asyncio
+    async def test_download_raw_ndjson_has_correct_media_type_and_filename(
+        self, api_client, tmp_path: Path
+    ):
+        import uuid
+
+        from tg_parser.api.job_store import ensure_job_store_initialized
+        from tg_parser.storage.ports import Job, JobStatus, JobType
+
+        # Simulate a completed raw/ndjson job pointing at a real file
+        file_path = tmp_path / "raw_messages.ndjson"
+        file_path.write_text(
+            json.dumps({"id": "1", "message_type": "post"}) + "\n",
+            encoding="utf-8",
+        )
+
+        job_store = await ensure_job_store_initialized()
+        job_id = f"test-raw-complete-{uuid.uuid4()}"
+        completed_job = Job(
+            job_id=job_id,
+            job_type=JobType.EXPORT,
+            status=JobStatus.COMPLETED,
+            created_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            channel_id="ch1",
+            export_format="ndjson",
+            file_path=str(file_path),
+            download_url=f"/api/v1/export/download/{job_id}",
+            progress={"level": "raw"},
+            result={"format": "ndjson", "level": "raw", "file_size": file_path.stat().st_size},
+        )
+        await job_store.create_job(completed_job)
+
+        resp = await api_client.get(f"/api/v1/export/download/{job_id}")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/x-ndjson")
+        # FastAPI FileResponse sets filename through content-disposition
+        cd = resp.headers.get("content-disposition", "")
+        assert "raw_messages.ndjson" in cd
+
+    @pytest.mark.asyncio
+    async def test_download_raw_json_has_correct_media_type_and_filename(
+        self, api_client, tmp_path: Path
+    ):
+        import uuid
+
+        from tg_parser.api.job_store import ensure_job_store_initialized
+        from tg_parser.storage.ports import Job, JobStatus, JobType
+
+        file_path = tmp_path / "raw_messages.json"
+        file_path.write_text(json.dumps({"messages": []}), encoding="utf-8")
+
+        job_store = await ensure_job_store_initialized()
+        job_id = f"test-raw-json-{uuid.uuid4()}"
+        completed_job = Job(
+            job_id=job_id,
+            job_type=JobType.EXPORT,
+            status=JobStatus.COMPLETED,
+            created_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            channel_id="ch1",
+            export_format="json",
+            file_path=str(file_path),
+            download_url=f"/api/v1/export/download/{job_id}",
+            progress={"level": "raw"},
+            result={"format": "json", "level": "raw", "file_size": file_path.stat().st_size},
+        )
+        await job_store.create_job(completed_job)
+
+        resp = await api_client.get(f"/api/v1/export/download/{job_id}")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        cd = resp.headers.get("content-disposition", "")
+        assert "raw_messages.json" in cd

--- a/tests/test_f2_parse_only_export.py
+++ b/tests/test_f2_parse_only_export.py
@@ -8,8 +8,8 @@ Covers:
   (raw + backward-compat for processed / full).
 - CLI ``tg_parser export --level ... --format ...`` wiring + validation.
 - API ``POST /api/v1/export`` level-aware job creation + download media types.
-
-MCP + Bot tests live in the same file but are added in Commit 2.
+- MCP ``export_channel`` / ``get_export_status`` tools.
+- Bot ``export_channel`` tool with FSInputFile delivery + 50 MB size gate.
 """
 
 from __future__ import annotations
@@ -1041,3 +1041,459 @@ class TestAPIExportLevel:
         assert resp.headers["content-type"].startswith("application/json")
         cd = resp.headers.get("content-disposition", "")
         assert "raw_messages.json" in cd
+
+
+# ============================================================================
+# TestMCPExportChannel
+# ============================================================================
+
+
+class _StubMCPCtx:
+    """Minimal stand-in for ``mcp.server.fastmcp.Context`` used in MCP tools."""
+
+    def __init__(self, client_id: str | None = None) -> None:
+        self.client_id = client_id
+
+
+class TestMCPExportChannel:
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_invalid_level_raises(self):
+        from tg_parser.mcp_server import export_channel
+
+        with pytest.raises(ValueError, match="invalid level"):
+            await export_channel(channel_id="ch1", level="bogus", ctx=None)
+
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_invalid_format_raises(self):
+        from tg_parser.mcp_server import export_channel
+
+        with pytest.raises(ValueError, match="invalid format"):
+            await export_channel(
+                channel_id="ch1", level="raw", format="yaml", ctx=None
+            )
+
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_raw_requires_channel_id(self):
+        from tg_parser.mcp_server import export_channel
+
+        with pytest.raises(ValueError, match="channel_id"):
+            await export_channel(channel_id="", level="raw", ctx=None)
+
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_submits_job(self, monkeypatch):
+        import tg_parser.mcp_server as mcp_mod
+        from tg_parser.api.schemas import ExportLevel
+        from tg_parser.auth.models import CurrentUser
+
+        captured: dict[str, object] = {}
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        async def fake_resolve(_client_id):
+            return CurrentUser(
+                id="u1", name="tester", role="user", allowed_channel_ids=None,
+                max_channels=20,
+            )
+
+        class FakeJobStore:
+            async def create_job(self, job):
+                captured["job"] = job
+
+        async def fake_ensure():
+            return FakeJobStore()
+
+        async def fake_run_export_job(job_id, request):
+            captured["called_job_id"] = job_id
+            captured["called_level"] = request.level
+
+        monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure
+        )
+        monkeypatch.setattr(
+            "tg_parser.api.routes.export._run_export_job", fake_run_export_job
+        )
+
+        result = await mcp_mod.export_channel(
+            channel_id="ch1", level="raw", format="json", ctx=None
+        )
+        assert result.status == "pending"
+        assert result.channel_id == "ch1"
+        assert result.level == ExportLevel.RAW.value
+        assert result.format == "json"
+        assert result.job_id
+        assert "Poll" in result.message or "poll" in result.message.lower()
+        assert captured["job"].channel_id == "ch1"
+        assert captured["job"].progress == {"level": "raw"}
+
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_ownership_denied(self, monkeypatch):
+        import tg_parser.mcp_server as mcp_mod
+        from tg_parser.auth.models import CurrentUser
+        from tg_parser.auth.ownership import PermissionDenied
+
+        async def fake_resolve(_client_id):
+            return CurrentUser(
+                id="u-non-owner", name="other", role="user",
+                allowed_channel_ids=["other_ch"], max_channels=10,
+            )
+
+        async def fake_assert(_user, channel_id):
+            raise PermissionDenied(f"No access to {channel_id}")
+
+        monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+
+        result = await mcp_mod.export_channel(
+            channel_id="ch1", level="raw", format="json", ctx=None
+        )
+        assert result.status == "rejected"
+        assert "no access" in result.message.lower()
+        assert result.job_id == ""
+
+    @pytest.mark.asyncio
+    async def test_mcp_export_channel_defaults_to_raw_json(self, monkeypatch):
+        import tg_parser.mcp_server as mcp_mod
+        from tg_parser.auth.models import CurrentUser
+
+        async def fake_resolve(_client_id):
+            return CurrentUser(
+                id="u1", name="t", role="user", allowed_channel_ids=None,
+                max_channels=20,
+            )
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        class FakeJobStore:
+            async def create_job(self, _job):
+                return None
+
+        async def fake_ensure():
+            return FakeJobStore()
+
+        async def fake_run(_jid, _req):
+            return None
+
+        monkeypatch.setattr(mcp_mod, "resolve_mcp_user", fake_resolve)
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.api.job_store.ensure_job_store_initialized", fake_ensure
+        )
+        monkeypatch.setattr(
+            "tg_parser.api.routes.export._run_export_job", fake_run
+        )
+
+        result = await mcp_mod.export_channel(channel_id="ch1", ctx=None)
+        assert result.level == "raw"
+        assert result.format == "json"
+
+
+# ============================================================================
+# TestBotExportChannel (mocked aiogram Bot)
+# ============================================================================
+
+
+class _FakeBot:
+    """Aiogram-Bot-like double recording calls made by ``_exec_export_channel``."""
+
+    def __init__(self) -> None:
+        self.sent_messages: list[dict] = []
+        self.sent_documents: list[dict] = []
+        self.deleted_messages: list[dict] = []
+        self._next_message_id = 1
+        self.send_document_should_raise: Exception | None = None
+
+    async def send_message(self, *, chat_id, text, parse_mode=None):  # noqa: ANN001
+        mid = self._next_message_id
+        self._next_message_id += 1
+        self.sent_messages.append(
+            {"chat_id": chat_id, "text": text, "parse_mode": parse_mode, "id": mid}
+        )
+
+        class _Msg:
+            def __init__(self, message_id):
+                self.message_id = message_id
+
+        return _Msg(mid)
+
+    async def send_document(self, *, chat_id, document, caption=None):  # noqa: ANN001
+        if self.send_document_should_raise is not None:
+            raise self.send_document_should_raise
+        self.sent_documents.append(
+            {"chat_id": chat_id, "document": document, "caption": caption}
+        )
+
+    async def delete_message(self, *, chat_id, message_id):  # noqa: ANN001
+        self.deleted_messages.append({"chat_id": chat_id, "message_id": message_id})
+
+
+class TestBotExportChannel:
+    @pytest.fixture
+    def fake_bot(self):
+        return _FakeBot()
+
+    @pytest.fixture
+    def test_user(self):
+        from tg_parser.auth.models import CurrentUser
+
+        return CurrentUser(
+            id="u1", name="tester", role="user", allowed_channel_ids=None,
+            max_channels=20,
+        )
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_invalid_level(self, fake_bot, test_user):
+        from tg_parser.bot.tools import execute_tool
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "bogus"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert "error" in result
+        assert "invalid level" in result["error"]
+        assert fake_bot.sent_documents == []
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_invalid_format(self, fake_bot, test_user):
+        from tg_parser.bot.tools import execute_tool
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw", "format": "yaml"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert "error" in result
+        assert "invalid format" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_raw_requires_channel_id(
+        self, fake_bot, test_user
+    ):
+        from tg_parser.bot.tools import execute_tool
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "", "level": "raw"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert "error" in result
+        assert "channel_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_ownership_enforced(
+        self, monkeypatch, fake_bot, test_user
+    ):
+        from tg_parser.auth.ownership import PermissionDenied
+        from tg_parser.bot.tools import execute_tool
+
+        async def fake_assert(_user, channel_id):
+            raise PermissionDenied(f"No access to {channel_id}")
+
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert "error" in result
+        assert "no access" in result["error"].lower()
+        assert fake_bot.sent_documents == []
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_small_file_sent_as_document(
+        self, monkeypatch, tmp_path, fake_bot, test_user
+    ):
+        from tg_parser.bot.tools import execute_tool
+        from tg_parser.config import settings
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        async def fake_run_export(*, output_dir, **_kwargs):
+            file_path = Path(output_dir) / "raw_messages.json"
+            file_path.write_text(json.dumps({"messages": []}), encoding="utf-8")
+            return {
+                "raw_posts_count": 0,
+                "raw_comments_count": 0,
+                "raw_orphan_comments_count": 0,
+                "channels_count": 1,
+            }
+
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.services.export_service.run_export", fake_run_export
+        )
+        monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw", "format": "json"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert result.get("sent") is True
+        assert result["channel_id"] == "ch1"
+        assert result["file_name"] == "raw_messages.json"
+        assert len(fake_bot.sent_documents) == 1
+        sent = fake_bot.sent_documents[0]
+        assert sent["chat_id"] == 42
+        # Progress message sent and then deleted
+        assert len(fake_bot.sent_messages) == 1
+        assert "Готовлю экспорт" in fake_bot.sent_messages[0]["text"]
+        assert len(fake_bot.deleted_messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_large_file_returns_url_no_send_document(
+        self, monkeypatch, tmp_path, fake_bot, test_user
+    ):
+        from tg_parser.bot.tools import (
+            TG_BOT_DOCUMENT_LIMIT_BYTES,
+            execute_tool,
+        )
+        from tg_parser.config import settings
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        async def fake_run_export(*, output_dir, **_kwargs):
+            file_path = Path(output_dir) / "raw_messages.json"
+            file_path.write_text("x", encoding="utf-8")
+            return {
+                "raw_posts_count": 1,
+                "raw_comments_count": 0,
+                "raw_orphan_comments_count": 0,
+                "channels_count": 1,
+            }
+
+        original_stat = Path.stat
+        oversize = TG_BOT_DOCUMENT_LIMIT_BYTES + 1
+
+        def fake_stat(self, *args, **kwargs):
+            if self.name == "raw_messages.json":
+                class _S:
+                    st_size = oversize
+                return _S()
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.services.export_service.run_export", fake_run_export
+        )
+        monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+        monkeypatch.setattr(Path, "stat", fake_stat)
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw", "format": "json"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=42,
+        )
+        assert result.get("sent") is False
+        assert result["reason"] == "file_too_large"
+        assert result["file_size"] == oversize
+        assert "50" in result["message"] or "лимит" in result["message"]
+        assert fake_bot.sent_documents == []
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_progress_message_sent_and_deleted(
+        self, monkeypatch, tmp_path, fake_bot, test_user
+    ):
+        from tg_parser.bot.tools import execute_tool
+        from tg_parser.config import settings
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        async def fake_run_export(*, output_dir, **_kwargs):
+            file_path = Path(output_dir) / "raw_messages.json"
+            file_path.write_text(json.dumps({"messages": []}), encoding="utf-8")
+            return {
+                "raw_posts_count": 0,
+                "raw_comments_count": 0,
+                "raw_orphan_comments_count": 0,
+                "channels_count": 1,
+            }
+
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.services.export_service.run_export", fake_run_export
+        )
+        monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+        await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw", "format": "json"},
+            current_user=test_user,
+            bot=fake_bot,
+            chat_id=99,
+        )
+        assert len(fake_bot.sent_messages) == 1
+        assert fake_bot.sent_messages[0]["chat_id"] == 99
+        assert len(fake_bot.deleted_messages) == 1
+        assert fake_bot.deleted_messages[0]["chat_id"] == 99
+
+    @pytest.mark.asyncio
+    async def test_bot_export_channel_no_bot_context_returns_summary(
+        self, monkeypatch, tmp_path, test_user
+    ):
+        from tg_parser.bot.tools import execute_tool
+        from tg_parser.config import settings
+
+        async def fake_assert(_user, _channel_id):
+            return None
+
+        async def fake_run_export(*, output_dir, **_kwargs):
+            file_path = Path(output_dir) / "raw_messages.json"
+            file_path.write_text(json.dumps({"messages": []}), encoding="utf-8")
+            return {
+                "raw_posts_count": 0,
+                "raw_comments_count": 0,
+                "raw_orphan_comments_count": 0,
+                "channels_count": 1,
+            }
+
+        monkeypatch.setattr(
+            "tg_parser.auth.ownership.assert_channel_access", fake_assert
+        )
+        monkeypatch.setattr(
+            "tg_parser.services.export_service.run_export", fake_run_export
+        )
+        monkeypatch.setattr(settings, "output_dir", str(tmp_path))
+
+        result = await execute_tool(
+            "export_channel",
+            {"channel_id": "ch1", "level": "raw", "format": "json"},
+            current_user=test_user,
+        )
+        assert result.get("sent") is False
+        assert result.get("reason") == "no_bot_context"
+        assert "channel_id" in result and result["channel_id"] == "ch1"

--- a/tg_parser/api/routes/export.py
+++ b/tg_parser/api/routes/export.py
@@ -64,9 +64,7 @@ def _resolve_job_level(job: Job) -> ExportLevel:
         return ExportLevel.FULL
 
 
-def _resolve_export_file(
-    *, output_dir: Path, level: ExportLevel, format: ExportFormat
-) -> Path:
+def _resolve_export_file(*, output_dir: Path, level: ExportLevel, format: ExportFormat) -> Path:
     """Pick the export artefact path based on level + format (F2).
 
     - ``level=RAW``: ``raw_messages.{ndjson,json}``.

--- a/tg_parser/api/routes/export.py
+++ b/tg_parser/api/routes/export.py
@@ -20,6 +20,7 @@ from tg_parser.api.middleware import limiter
 from tg_parser.api.schemas import (
     ErrorResponse,
     ExportFormat,
+    ExportLevel,
     ExportRequest,
     ExportResponse,
 )
@@ -42,6 +43,46 @@ def _job_status_to_api(status: JobStatus) -> APIJobStatus:
     return APIJobStatus(status.value)
 
 
+def _resolve_job_level(job: Job) -> ExportLevel:
+    """Recover ``ExportLevel`` stored on the job.
+
+    We stash ``body.level.value`` into ``job.progress['level']`` at
+    creation time (and copy into ``result`` on completion). For pre-F2
+    jobs that never saw ``level`` (no such key) we default to
+    ``ExportLevel.FULL`` — the legacy behaviour.
+    """
+    candidate: str | None = None
+    if job.result and isinstance(job.result, dict):
+        candidate = job.result.get("level") or candidate
+    if not candidate and job.progress and isinstance(job.progress, dict):
+        candidate = job.progress.get("level")
+    if not candidate:
+        return ExportLevel.FULL
+    try:
+        return ExportLevel(candidate)
+    except ValueError:
+        return ExportLevel.FULL
+
+
+def _resolve_export_file(
+    *, output_dir: Path, level: ExportLevel, format: ExportFormat
+) -> Path:
+    """Pick the export artefact path based on level + format (F2).
+
+    - ``level=RAW``: ``raw_messages.{ndjson,json}``.
+    - ``level=PROCESSED`` / ``level=FULL`` + ``format=NDJSON``: ``kb_entries.ndjson``.
+    - ``level=FULL`` + ``format=JSON``: ``topics.json`` (legacy).
+    """
+    if level == ExportLevel.RAW:
+        ext = "ndjson" if format == ExportFormat.NDJSON else "json"
+        return output_dir / f"raw_messages.{ext}"
+
+    if format == ExportFormat.NDJSON or level == ExportLevel.PROCESSED:
+        return output_dir / "kb_entries.ndjson"
+
+    return output_dir / "topics.json"
+
+
 async def _run_export_job(job_id: str, request: ExportRequest) -> None:
     """
     Background task to run export.
@@ -60,20 +101,28 @@ async def _run_export_job(job_id: str, request: ExportRequest) -> None:
         job.started_at = datetime.now(UTC)
         await job_store.update_job(job)
 
-        logger.info("Starting export job %s", job_id)
+        logger.info(
+            "Starting export job %s (level=%s, format=%s)",
+            job_id,
+            request.level.value,
+            request.format.value,
+        )
 
         output_dir = Path(settings.output_dir)
 
         export_stats = await run_export(
             output_dir=str(output_dir),
             channel_id=request.channel_id,
+            level=request.level,
+            format=request.format,
+            from_date=request.from_date,
+            to_date=request.to_date,
         )
         logger.info("Export job %s stats: %s", job_id, export_stats)
 
-        if request.format == ExportFormat.NDJSON:
-            export_file = output_dir / "kb_entries.ndjson"
-        else:
-            export_file = output_dir / "topics.json"
+        export_file = _resolve_export_file(
+            output_dir=output_dir, level=request.level, format=request.format
+        )
 
         if not export_file.exists():
             raise FileNotFoundError(
@@ -86,6 +135,7 @@ async def _run_export_job(job_id: str, request: ExportRequest) -> None:
         job.download_url = f"/api/v1/export/download/{job_id}"
         job.result = {
             "format": request.format.value,
+            "level": request.level.value,
             "file_size": export_file.stat().st_size,
         }
         await job_store.update_job(job)
@@ -168,6 +218,11 @@ async def start_export(
     **Authentication**: Required if API_KEY_REQUIRED=true
     **Rate Limit**: 20 requests per minute
     """
+    if body.level == ExportLevel.RAW and not body.channel_id:
+        raise HTTPException(
+            status_code=400,
+            detail="level='raw' requires channel_id",
+        )
     if body.channel_id:
         await assert_channel_access(user, body.channel_id)
     job_store = await ensure_job_store_initialized()
@@ -183,6 +238,7 @@ async def start_export(
         channel_id=body.channel_id,
         client=user.name,
         export_format=body.format.value,
+        progress={"level": body.level.value},
         webhook_url=body.webhook_url,
         webhook_secret=body.webhook_secret,
     )
@@ -193,13 +249,18 @@ async def start_export(
     logger.info(
         "Created export job %s",
         job_id,
-        extra={"client": user.name, "format": body.format.value},
+        extra={
+            "client": user.name,
+            "format": body.format.value,
+            "level": body.level.value,
+        },
     )
 
     return ExportResponse(
         job_id=job_id,
         status=APIJobStatus.PENDING,
         format=body.format,
+        level=body.level,
         created_at=created_at,
         download_url=None,
         message="Export job created. Check status for download URL.",
@@ -230,11 +291,13 @@ async def get_export_status(
 
     # Parse export format from stored value
     export_format = ExportFormat(job.export_format) if job.export_format else ExportFormat.NDJSON
+    export_level = _resolve_job_level(job)
 
     return ExportResponse(
         job_id=job.job_id,
         status=_job_status_to_api(job.status),
         format=export_format,
+        level=export_level,
         created_at=job.created_at,
         download_url=job.download_url,
         message=job.error or f"Status: {job.status.value}",
@@ -275,10 +338,18 @@ async def download_export(
             detail="Export file not found",
         )
 
-    # Determine media type
+    # Determine media type / filename by (level, format). F2 adds raw_messages.*.
     export_format = ExportFormat(job.export_format) if job.export_format else ExportFormat.NDJSON
+    export_level = _resolve_job_level(job)
 
-    if export_format == ExportFormat.NDJSON:
+    if export_level == ExportLevel.RAW:
+        if export_format == ExportFormat.NDJSON:
+            media_type = "application/x-ndjson"
+            filename = "raw_messages.ndjson"
+        else:
+            media_type = "application/json"
+            filename = "raw_messages.json"
+    elif export_format == ExportFormat.NDJSON or export_level == ExportLevel.PROCESSED:
         media_type = "application/x-ndjson"
         filename = "kb_entries.ndjson"
     else:

--- a/tg_parser/api/schemas.py
+++ b/tg_parser/api/schemas.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+# Re-export shared enums from the domain layer to keep the public API surface
+# unchanged while avoiding a circular import between api.schemas and services.
+from tg_parser.domain.export import ExportFormat, ExportLevel
+
 # ============================================================================
 # Enums
 # ============================================================================
@@ -22,11 +26,19 @@ class JobStatus(StrEnum):
     FAILED = "failed"
 
 
-class ExportFormat(StrEnum):
-    """Supported export formats."""
-
-    NDJSON = "ndjson"
-    JSON = "json"
+__all__ = [
+    "JobStatus",
+    "ExportFormat",
+    "ExportLevel",
+    "HealthResponse",
+    "StatusResponse",
+    "ProcessRequest",
+    "ProcessResponse",
+    "JobStatusResponse",
+    "ExportRequest",
+    "ExportResponse",
+    "ErrorResponse",
+]
 
 
 # ============================================================================
@@ -133,9 +145,28 @@ class JobStatusResponse(BaseModel):
 class ExportRequest(BaseModel):
     """Request to export processed data."""
 
-    channel_id: str | None = Field(default=None, description="Filter by channel (optional)")
+    channel_id: str | None = Field(
+        default=None,
+        description="Filter by channel (required when level='raw')",
+    )
+    level: ExportLevel = Field(
+        default=ExportLevel.FULL,
+        description=(
+            "Export level: 'raw' = RawTelegramMessage[] (parse-only, no LLM), "
+            "'processed' = KnowledgeBaseEntry[] only, "
+            "'full' = processed + topics (legacy default)"
+        ),
+    )
     format: ExportFormat = Field(default=ExportFormat.NDJSON, description="Export format")
     include_topics: bool = Field(default=True, description="Include topicized data")
+    from_date: datetime | None = Field(
+        default=None,
+        description="Filter messages from this UTC datetime (inclusive)",
+    )
+    to_date: datetime | None = Field(
+        default=None,
+        description="Filter messages up to this UTC datetime (inclusive)",
+    )
 
     # Webhook configuration (Phase 2F)
     webhook_url: str | None = Field(
@@ -156,6 +187,11 @@ class ExportRequest(BaseModel):
                     "include_topics": True,
                 },
                 {
+                    "channel_id": "labdiagnostica",
+                    "level": "raw",
+                    "format": "json",
+                },
+                {
                     "format": "json",
                     "webhook_url": "https://myapp.com/export-webhook",
                 },
@@ -170,6 +206,10 @@ class ExportResponse(BaseModel):
     job_id: str = Field(description="Export job identifier")
     status: JobStatus = Field(description="Current job status")
     format: ExportFormat = Field(description="Export format")
+    level: ExportLevel = Field(
+        default=ExportLevel.FULL,
+        description="Export level that produced this job",
+    )
     created_at: datetime = Field(description="Job creation time")
     download_url: str | None = Field(default=None, description="Download URL when ready")
     message: str = Field(description="Status message")

--- a/tg_parser/bot/agent.py
+++ b/tg_parser/bot/agent.py
@@ -57,7 +57,7 @@ class GeminiAgent:
         self,
         user_message: str,
         current_user: CurrentUser | None = None,
-        bot: "Bot | None" = None,
+        bot: Bot | None = None,
         chat_id: int | None = None,
     ) -> str:
         """Process a user message through the agent loop.

--- a/tg_parser/bot/agent.py
+++ b/tg_parser/bot/agent.py
@@ -8,13 +8,16 @@ capabilities to invoke, executes them, and returns a structured answer.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
 
 from tg_parser.auth.models import CurrentUser
 from tg_parser.bot.tools import TOOL_DECLARATIONS, execute_tool
+
+if TYPE_CHECKING:
+    from aiogram import Bot
 
 logger = structlog.get_logger(__name__)
 
@@ -54,8 +57,13 @@ class GeminiAgent:
         self,
         user_message: str,
         current_user: CurrentUser | None = None,
+        bot: "Bot | None" = None,
+        chat_id: int | None = None,
     ) -> str:
         """Process a user message through the agent loop.
+
+        ``bot`` and ``chat_id`` are forwarded to tool executors that need
+        direct chat access (e.g. ``export_channel`` to upload files).
 
         Returns the final text response to send to the user.
         """
@@ -111,6 +119,8 @@ class GeminiAgent:
                     tool_args,
                     timeout=self._tool_timeout,
                     current_user=current_user,
+                    bot=bot,
+                    chat_id=chat_id,
                 )
 
                 function_responses.append(

--- a/tg_parser/bot/handlers.py
+++ b/tg_parser/bot/handlers.py
@@ -141,7 +141,12 @@ async def handle_text(
     typing_task = asyncio.create_task(_keep_typing())
 
     try:
-        response_text = await agent.process_message(user_text, current_user=current_user)
+        response_text = await agent.process_message(
+            user_text,
+            current_user=current_user,
+            bot=message.bot,
+            chat_id=message.chat.id,
+        )
     except TimeoutError:
         typing_task.cancel()
         await message.answer(format_timeout())

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -9,13 +9,22 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from tg_parser.auth.models import CurrentUser
 
+if TYPE_CHECKING:
+    from aiogram import Bot
+
 logger = structlog.get_logger(__name__)
+
+# Telegram Bot API limit on send_document: 50 MB.
+TG_BOT_DOCUMENT_LIMIT_BYTES: int = 50 * 1024 * 1024
+
+# Tools that need access to the bot instance / chat_id (e.g. to upload files).
+_TOOLS_NEEDING_BOT_CONTEXT: set[str] = {"export_channel"}
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -520,6 +529,47 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
             "required": ["mapping_id"],
         },
     },
+    {
+        "name": "export_channel",
+        "description": (
+            "Export channel content (F2 Parse-Only). "
+            "level='raw' produces raw Telegram messages without LLM processing "
+            "(default for parse-only use); 'processed' produces KnowledgeBaseEntry[]; "
+            "'full' (legacy) produces processed + topics. "
+            "format='json' or 'ndjson' applies to level='raw'. "
+            "Sends the result file directly into the chat when its size is within "
+            "Telegram's 50 MB document limit; otherwise returns a download URL. "
+            "raw_payload is never included (privacy)."
+        ),
+        "parameters": {
+            "type": "OBJECT",
+            "properties": {
+                "channel_id": {
+                    "type": "STRING",
+                    "description": "Telegram channel ID (required for level='raw')",
+                },
+                "level": {
+                    "type": "STRING",
+                    "enum": ["raw", "processed", "full"],
+                    "description": "Export level (default 'raw')",
+                },
+                "format": {
+                    "type": "STRING",
+                    "enum": ["json", "ndjson"],
+                    "description": "Output format for level='raw' (default 'json')",
+                },
+                "from_date": {
+                    "type": "STRING",
+                    "description": "Optional ISO-8601 UTC datetime filter (inclusive)",
+                },
+                "to_date": {
+                    "type": "STRING",
+                    "description": "Optional ISO-8601 UTC datetime filter (inclusive)",
+                },
+            },
+            "required": ["channel_id"],
+        },
+    },
 ]
 
 
@@ -533,8 +583,13 @@ async def execute_tool(
     args: dict[str, Any],
     timeout: float = 60.0,
     current_user: CurrentUser | None = None,
+    bot: "Bot | None" = None,
+    chat_id: int | None = None,
 ) -> dict[str, Any]:
     """Execute a tool by name, calling the corresponding internal service.
+
+    ``bot`` and ``chat_id`` are forwarded only to executors that need them
+    (e.g. ``export_channel`` uses them to deliver files via aiogram).
 
     Returns a JSON-serializable dict with the result or error.
     """
@@ -542,9 +597,14 @@ async def execute_tool(
     if executor is None:
         return {"error": f"Unknown tool: {name}"}
 
+    kwargs: dict[str, Any] = {"current_user": current_user}
+    if name in _TOOLS_NEEDING_BOT_CONTEXT:
+        kwargs["bot"] = bot
+        kwargs["chat_id"] = chat_id
+
     try:
         result = await asyncio.wait_for(
-            executor(args, current_user=current_user),
+            executor(args, **kwargs),
             timeout=timeout,
         )
         return result
@@ -1615,6 +1675,189 @@ async def _exec_add_user_auth(
     return {"mapping_id": mapping.id, "auth_type": auth_type}
 
 
+async def _exec_export_channel(
+    args: dict[str, Any],
+    current_user: CurrentUser | None = None,
+    bot: "Bot | None" = None,
+    chat_id: int | None = None,
+) -> dict[str, Any]:
+    """Run a channel export and deliver the file via Telegram (F2: Parse-Only).
+
+    Runs synchronously (in-process) — there is no need for the persistent-job
+    machinery here because the bot already controls the user's chat session.
+    For files within the Telegram 50 MB document limit the file is sent as a
+    document via ``FSInputFile``; otherwise we return a download URL hint.
+    """
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    from aiogram.types import FSInputFile
+
+    from tg_parser.api.schemas import ExportFormat, ExportLevel
+    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.auth.resolvers import get_default_admin
+    from tg_parser.config import settings
+    from tg_parser.services.export_service import run_export
+
+    user = current_user or await get_default_admin()
+
+    raw_channel_id = args.get("channel_id")
+    if not raw_channel_id:
+        return {"error": "channel_id is required"}
+    normalized = str(raw_channel_id).lstrip("@")
+
+    level_raw = str(args.get("level", "raw"))
+    format_raw = str(args.get("format", "json"))
+
+    try:
+        level_enum = ExportLevel(level_raw)
+    except ValueError:
+        return {
+            "error": (
+                f"invalid level: {level_raw!r}; expected one of "
+                f"{[lv.value for lv in ExportLevel]}"
+            )
+        }
+    try:
+        format_enum = ExportFormat(format_raw)
+    except ValueError:
+        return {
+            "error": (
+                f"invalid format: {format_raw!r}; expected one of "
+                f"{[fm.value for fm in ExportFormat]}"
+            )
+        }
+
+    if level_enum == ExportLevel.RAW and not normalized:
+        return {"error": "level='raw' requires channel_id"}
+
+    try:
+        await assert_channel_access(user, normalized)
+    except PermissionDenied as e:
+        return {"error": e.message}
+
+    def _parse_iso(value: Any, *, field: str) -> Any:
+        if value is None:
+            return None
+        try:
+            return _dt.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return f"__INVALID__:{field}"
+
+    parsed_from = _parse_iso(args.get("from_date"), field="from_date")
+    if isinstance(parsed_from, str) and parsed_from.startswith("__INVALID__"):
+        return {"error": f"invalid from_date: {args.get('from_date')!r}"}
+    parsed_to = _parse_iso(args.get("to_date"), field="to_date")
+    if isinstance(parsed_to, str) and parsed_to.startswith("__INVALID__"):
+        return {"error": f"invalid to_date: {args.get('to_date')!r}"}
+
+    progress_message_id: int | None = None
+    if bot is not None and chat_id is not None:
+        try:
+            msg = await bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    f"⏳ Готовлю экспорт канала <code>{normalized}</code> "
+                    f"(level={level_enum.value}, format={format_enum.value})..."
+                ),
+                parse_mode="HTML",
+            )
+            progress_message_id = getattr(msg, "message_id", None)
+        except Exception:
+            logger.warning("bot_export_progress_send_failed", exc_info=True)
+
+    output_dir = Path(settings.output_dir)
+
+    try:
+        export_stats = await run_export(
+            output_dir=str(output_dir),
+            channel_id=normalized,
+            level=level_enum,
+            format=format_enum,
+            from_date=parsed_from,
+            to_date=parsed_to,
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    if level_enum == ExportLevel.RAW:
+        ext = "ndjson" if format_enum == ExportFormat.NDJSON else "json"
+        export_file = output_dir / f"raw_messages.{ext}"
+    elif format_enum == ExportFormat.NDJSON or level_enum == ExportLevel.PROCESSED:
+        export_file = output_dir / "kb_entries.ndjson"
+    else:
+        export_file = output_dir / "topics.json"
+
+    if not export_file.exists():
+        return {
+            "error": (
+                f"Export produced no file: {export_file.name} "
+                f"(stats: {export_stats})"
+            )
+        }
+
+    file_size = export_file.stat().st_size
+    file_size_mb = round(file_size / (1024 * 1024), 2)
+
+    summary: dict[str, Any] = {
+        "channel_id": normalized,
+        "level": level_enum.value,
+        "format": format_enum.value,
+        "file_name": export_file.name,
+        "file_size": file_size,
+        "file_size_mb": file_size_mb,
+        "stats": export_stats,
+    }
+
+    if progress_message_id is not None and bot is not None and chat_id is not None:
+        try:
+            await bot.delete_message(chat_id=chat_id, message_id=progress_message_id)
+        except Exception:
+            logger.debug("bot_export_progress_delete_failed", exc_info=True)
+
+    if file_size > TG_BOT_DOCUMENT_LIMIT_BYTES:
+        summary["sent"] = False
+        summary["reason"] = "file_too_large"
+        summary["limit_bytes"] = TG_BOT_DOCUMENT_LIMIT_BYTES
+        summary["message"] = (
+            f"Файл экспорта ({file_size_mb} MB) превышает лимит Telegram "
+            f"(50 MB). Используйте CLI или API для скачивания: путь на сервере "
+            f"{export_file}."
+        )
+        return summary
+
+    if bot is None or chat_id is None:
+        summary["sent"] = False
+        summary["reason"] = "no_bot_context"
+        summary["message"] = (
+            "Бот не имеет контекста чата для отправки файла; экспорт сохранён "
+            f"в {export_file}."
+        )
+        return summary
+
+    try:
+        await bot.send_document(
+            chat_id=chat_id,
+            document=FSInputFile(str(export_file), filename=export_file.name),
+            caption=(
+                f"📎 {export_file.name} "
+                f"(level={level_enum.value}, {file_size_mb} MB)"
+            ),
+        )
+        summary["sent"] = True
+        summary["message"] = (
+            f"Файл {export_file.name} отправлен в чат "
+            f"({file_size_mb} MB, level={level_enum.value})."
+        )
+    except Exception as exc:
+        logger.exception("bot_export_send_document_failed")
+        summary["sent"] = False
+        summary["reason"] = "send_failed"
+        summary["message"] = f"Не удалось отправить файл: {exc}"
+
+    return summary
+
+
 async def _exec_remove_user_auth(
     args: dict[str, Any],
     current_user: CurrentUser | None = None,
@@ -1662,4 +1905,5 @@ _TOOL_EXECUTORS: dict[str, Any] = {
     "whoami": _exec_whoami,
     "add_user_auth": _exec_add_user_auth,
     "remove_user_auth": _exec_remove_user_auth,
+    "export_channel": _exec_export_channel,
 }

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -583,7 +583,7 @@ async def execute_tool(
     args: dict[str, Any],
     timeout: float = 60.0,
     current_user: CurrentUser | None = None,
-    bot: "Bot | None" = None,
+    bot: Bot | None = None,
     chat_id: int | None = None,
 ) -> dict[str, Any]:
     """Execute a tool by name, calling the corresponding internal service.
@@ -1678,7 +1678,7 @@ async def _exec_add_user_auth(
 async def _exec_export_channel(
     args: dict[str, Any],
     current_user: CurrentUser | None = None,
-    bot: "Bot | None" = None,
+    bot: Bot | None = None,
     chat_id: int | None = None,
 ) -> dict[str, Any]:
     """Run a channel export and deliver the file via Telegram (F2: Parse-Only).
@@ -1688,7 +1688,6 @@ async def _exec_export_channel(
     For files within the Telegram 50 MB document limit the file is sent as a
     document via ``FSInputFile``; otherwise we return a download URL hint.
     """
-    from datetime import UTC as _UTC
     from datetime import datetime as _dt
 
     from aiogram.types import FSInputFile
@@ -1714,8 +1713,7 @@ async def _exec_export_channel(
     except ValueError:
         return {
             "error": (
-                f"invalid level: {level_raw!r}; expected one of "
-                f"{[lv.value for lv in ExportLevel]}"
+                f"invalid level: {level_raw!r}; expected one of {[lv.value for lv in ExportLevel]}"
             )
         }
     try:
@@ -1789,12 +1787,7 @@ async def _exec_export_channel(
         export_file = output_dir / "topics.json"
 
     if not export_file.exists():
-        return {
-            "error": (
-                f"Export produced no file: {export_file.name} "
-                f"(stats: {export_stats})"
-            )
-        }
+        return {"error": (f"Export produced no file: {export_file.name} (stats: {export_stats})")}
 
     file_size = export_file.stat().st_size
     file_size_mb = round(file_size / (1024 * 1024), 2)
@@ -1830,8 +1823,7 @@ async def _exec_export_channel(
         summary["sent"] = False
         summary["reason"] = "no_bot_context"
         summary["message"] = (
-            "Бот не имеет контекста чата для отправки файла; экспорт сохранён "
-            f"в {export_file}."
+            f"Бот не имеет контекста чата для отправки файла; экспорт сохранён в {export_file}."
         )
         return summary
 
@@ -1839,10 +1831,7 @@ async def _exec_export_channel(
         await bot.send_document(
             chat_id=chat_id,
             document=FSInputFile(str(export_file), filename=export_file.name),
-            caption=(
-                f"📎 {export_file.name} "
-                f"(level={level_enum.value}, {file_size_mb} MB)"
-            ),
+            caption=(f"📎 {export_file.name} (level={level_enum.value}, {file_size_mb} MB)"),
         )
         summary["sent"] = True
         summary["message"] = (

--- a/tg_parser/cli/app.py
+++ b/tg_parser/cli/app.py
@@ -679,21 +679,56 @@ def export(
     from_date: str = typer.Option(None, help="Дата от (ISO format: YYYY-MM-DD)"),
     to_date: str = typer.Option(None, help="Дата до (ISO format: YYYY-MM-DD)"),
     pretty: bool = typer.Option(False, help="Pretty-print JSON"),
+    level: str = typer.Option(
+        "full",
+        help="Уровень экспорта: raw | processed | full (по умолчанию full — legacy)",
+    ),
+    format: str = typer.Option(
+        "json",
+        help="Формат для level=raw: json | ndjson (для processed/full игнорируется)",
+    ),
 ):
     """
-    Экспортировать артефакты (TR-56..TR-64).
+    Экспортировать артефакты (TR-56..TR-64 + F2 Parse-Only).
 
-    Создаёт kb_entries.ndjson в указанной директории.
-    В будущем: topics.json, topic_<id>.json.
+    Уровни экспорта (F2):
+
+    - ``--level full`` (по умолчанию): ``kb_entries.ndjson`` + ``topics.json``
+      + ``topic_<id>.json`` (legacy behaviour; обратная совместимость).
+    - ``--level processed``: только ``kb_entries.ndjson`` (без topics).
+    - ``--level raw``: ``raw_messages.{json,ndjson}`` (parse-only, без LLM).
+      Требует ``--channel``.
     """
     import asyncio
     from datetime import datetime
 
+    from tg_parser.api.schemas import ExportFormat, ExportLevel
     from tg_parser.cli.export_cmd import run_export
 
-    typer.echo(f"📤 Экспорт в: {out}\n")
+    try:
+        level_enum = ExportLevel(level)
+    except ValueError as e:
+        typer.echo(
+            f"❌ Неверный --level: {level} (ожидается: raw | processed | full)",
+            err=True,
+        )
+        raise typer.Exit(code=1) from e
 
-    # Парсинг дат
+    try:
+        format_enum = ExportFormat(format)
+    except ValueError as e:
+        typer.echo(
+            f"❌ Неверный --format: {format} (ожидается: json | ndjson)",
+            err=True,
+        )
+        raise typer.Exit(code=1) from e
+
+    if level_enum == ExportLevel.RAW and not channel:
+        typer.echo("❌ --level=raw требует --channel", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(f"📤 Экспорт в: {out} (уровень: {level_enum.value})\n")
+
     from_datetime = None
     to_datetime = None
 
@@ -719,7 +754,6 @@ def export(
         typer.echo(f"   Фильтр: тема={topic_id}")
 
     try:
-        # Запускаем async функцию
         stats = asyncio.run(
             run_export(
                 output_dir=out,
@@ -728,22 +762,41 @@ def export(
                 from_date=from_datetime,
                 to_date=to_datetime,
                 pretty=pretty,
+                level=level_enum,
+                format=format_enum,
             )
         )
 
-        # Выводим статистику
         typer.echo("\n✅ Экспорт завершён:")
-        typer.echo(f"   • KB entries: {stats['kb_entries_count']}")
-        typer.echo(f"   • Topics: {stats['topics_count']}")
-        typer.echo(f"   • Каналов: {stats['channels_count']}")
 
-        if stats["kb_entries_count"] > 0:
-            typer.echo(f"   • Файл: {out}/kb_entries.ndjson")
-        if stats["topics_count"] > 0:
-            typer.echo(f"   • Файлы: {out}/topics.json, {out}/topic_*.json")
+        if level_enum == ExportLevel.RAW:
+            typer.echo(f"   • Posts: {stats['raw_posts_count']}")
+            typer.echo(f"   • Comments: {stats['raw_comments_count']}")
+            if stats.get("raw_orphan_comments_count"):
+                typer.echo(
+                    "   • Orphan comments (parent out of range): "
+                    f"{stats['raw_orphan_comments_count']}"
+                )
+            typer.echo(f"   • Каналов: {stats['channels_count']}")
+            typer.echo(f"   • Файл: {out}/raw_messages.{format_enum.value}")
+            if (
+                stats["raw_posts_count"] == 0
+                and stats["raw_comments_count"] == 0
+                and stats.get("raw_orphan_comments_count", 0) == 0
+            ):
+                typer.echo("\n⚠️  Нет сообщений для экспорта (пустой envelope записан)")
+        else:
+            typer.echo(f"   • KB entries: {stats['kb_entries_count']}")
+            typer.echo(f"   • Topics: {stats['topics_count']}")
+            typer.echo(f"   • Каналов: {stats['channels_count']}")
 
-        if stats["kb_entries_count"] == 0 and stats["topics_count"] == 0:
-            typer.echo("\n⚠️  Нет данных для экспорта")
+            if stats["kb_entries_count"] > 0:
+                typer.echo(f"   • Файл: {out}/kb_entries.ndjson")
+            if stats["topics_count"] > 0:
+                typer.echo(f"   • Файлы: {out}/topics.json, {out}/topic_*.json")
+
+            if stats["kb_entries_count"] == 0 and stats["topics_count"] == 0:
+                typer.echo("\n⚠️  Нет данных для экспорта")
 
     except Exception as e:
         typer.echo(f"\n❌ Ошибка: {e}", err=True)

--- a/tg_parser/domain/export.py
+++ b/tg_parser/domain/export.py
@@ -1,0 +1,31 @@
+"""Export-related enums shared across layers.
+
+These live in the ``domain`` package so that services, CLI, API, MCP and bot
+layers can all depend on a single source of truth without introducing a
+circular import (``tg_parser.api.schemas`` pulls ``tg_parser.api.__init__``,
+which wires up FastAPI routes that in turn depend on services).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ExportFormat(StrEnum):
+    """Supported export formats."""
+
+    NDJSON = "ndjson"
+    JSON = "json"
+
+
+class ExportLevel(StrEnum):
+    """Export level — controls what gets exported (F2: Parse-Only Export).
+
+    - ``RAW``: raw Telegram messages (parse-only, no LLM). Requires channel_id.
+    - ``PROCESSED``: ``KnowledgeBaseEntry[]`` only (post-LLM; skip topics).
+    - ``FULL``: PROCESSED + ``topics.json`` + ``topic_<id>.json`` (legacy default).
+    """
+
+    RAW = "raw"
+    PROCESSED = "processed"
+    FULL = "full"

--- a/tg_parser/export/raw_export.py
+++ b/tg_parser/export/raw_export.py
@@ -44,9 +44,7 @@ def export_raw_channel_json(
         "messages_count": len(posts_sorted),
         "comments_count": sum(len(g) for g in grouped.values()),
         "orphan_comments_count": len(orphan_comments),
-        "messages": [
-            _post_with_comments(post, grouped.get(post.id, [])) for post in posts_sorted
-        ],
+        "messages": [_post_with_comments(post, grouped.get(post.id, [])) for post in posts_sorted],
         "orphan_comments": [_message_payload(c) for c in orphan_comments],
     }
 

--- a/tg_parser/export/raw_export.py
+++ b/tg_parser/export/raw_export.py
@@ -1,0 +1,145 @@
+"""Raw Telegram message export (F2: Parse-Only).
+
+Pure writer module — takes ``list[RawTelegramMessage]`` + channel metadata,
+writes JSON envelope or NDJSON stream. No I/O to DB.
+
+Privacy invariant: ``raw_payload`` is ALWAYS excluded from the output
+(private Telethon structs, file_refs, auth artefacts).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from tg_parser.domain.json_utils import stable_json_dumps
+from tg_parser.domain.models import MessageType, RawTelegramMessage
+
+SCHEMA_VERSION: Final[str] = "raw_channel_export.v1"
+
+
+def export_raw_channel_json(
+    *,
+    messages: list[RawTelegramMessage],
+    channel_id: str,
+    channel_username: str | None,
+    from_date: datetime | None,
+    to_date: datetime | None,
+    output_path: Path,
+    pretty: bool = False,
+) -> dict[str, int]:
+    """Write grouped JSON envelope to ``output_path``. Returns stats dict."""
+    posts_sorted, grouped, orphan_comments = _group_messages(messages)
+
+    envelope: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "channel_id": channel_id,
+        "channel_username": channel_username,
+        "exported_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "filters": {
+            "from_date": _iso_or_none(from_date),
+            "to_date": _iso_or_none(to_date),
+        },
+        "messages_count": len(posts_sorted),
+        "comments_count": sum(len(g) for g in grouped.values()),
+        "orphan_comments_count": len(orphan_comments),
+        "messages": [
+            _post_with_comments(post, grouped.get(post.id, [])) for post in posts_sorted
+        ],
+        "orphan_comments": [_message_payload(c) for c in orphan_comments],
+    }
+
+    payload = stable_json_dumps(envelope, pretty=pretty)
+    output_path.write_text(payload, encoding="utf-8")
+
+    return {
+        "posts": len(posts_sorted),
+        "comments": envelope["comments_count"],
+        "orphan_comments": len(orphan_comments),
+    }
+
+
+def export_raw_channel_ndjson(
+    *,
+    messages: list[RawTelegramMessage],
+    output_path: Path,
+) -> dict[str, int]:
+    """Write one message per line (no grouping, stream-friendly).
+
+    Order: posts first (by date), then comments (by date). Caller is responsible
+    for providing pre-filtered messages.
+    """
+    posts = sorted(
+        [m for m in messages if m.message_type == MessageType.POST],
+        key=lambda m: m.date,
+    )
+    comments = sorted(
+        [m for m in messages if m.message_type == MessageType.COMMENT],
+        key=lambda m: m.date,
+    )
+
+    with output_path.open("w", encoding="utf-8") as f:
+        for msg in [*posts, *comments]:
+            f.write(stable_json_dumps(_message_payload(msg)))
+            f.write("\n")
+
+    return {"posts": len(posts), "comments": len(comments), "orphan_comments": 0}
+
+
+def _group_messages(
+    messages: list[RawTelegramMessage],
+) -> tuple[
+    list[RawTelegramMessage],
+    dict[str, list[RawTelegramMessage]],
+    list[RawTelegramMessage],
+]:
+    """Split into (posts_sorted, {post_id: comments_sorted}, orphan_comments_sorted).
+
+    A comment is considered "orphan" when its ``parent_message_id`` does not
+    refer to a post present in the filtered ``messages`` list (e.g. because
+    the parent post falls outside the ``from_date`` / ``to_date`` range).
+    """
+    posts = sorted(
+        [m for m in messages if m.message_type == MessageType.POST],
+        key=lambda m: m.date,
+    )
+    post_ids = {p.id for p in posts}
+
+    comments_sorted = sorted(
+        [m for m in messages if m.message_type == MessageType.COMMENT],
+        key=lambda m: m.date,
+    )
+
+    grouped: dict[str, list[RawTelegramMessage]] = {}
+    orphans: list[RawTelegramMessage] = []
+    for comment in comments_sorted:
+        parent = comment.parent_message_id
+        if parent and parent in post_ids:
+            grouped.setdefault(parent, []).append(comment)
+        else:
+            orphans.append(comment)
+
+    return posts, grouped, orphans
+
+
+def _post_with_comments(
+    post: RawTelegramMessage,
+    comments: list[RawTelegramMessage],
+) -> dict[str, Any]:
+    payload = _message_payload(post)
+    payload["comments"] = [_message_payload(c) for c in comments]
+    return payload
+
+
+def _message_payload(msg: RawTelegramMessage) -> dict[str, Any]:
+    """Serialize a message without ``raw_payload`` (privacy + size invariant)."""
+    return msg.model_dump(mode="json", exclude={"raw_payload"})
+
+
+def _iso_or_none(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.isoformat()

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -56,6 +56,13 @@ _MCP_INSTRUCTIONS = (
     "Cross-channel Analytics: "
     "get_cross_channel_stats for topic counts, coverage and keyword overlaps, "
     "get_related_topics to find linked topics across channels.\n\n"
+    "Channel Export (F2 Parse-Only): "
+    "export_channel(channel_id, level=raw|processed|full, format=json|ndjson, "
+    "from_date?, to_date?) creates a background export job. Use level='raw' "
+    "for pure parse-only output of raw Telegram messages (no LLM); "
+    "'processed' for KnowledgeBaseEntry[]; 'full' (legacy) for processed + "
+    "topics. Poll get_export_status(job_id) until completed, then fetch via "
+    "download_url. raw_payload is never included (privacy invariant).\n\n"
     "LLM Configuration (runtime switching without restart): "
     "get_llm_config to view current provider/model per stage and available providers. "
     "set_llm_config to switch provider/model — scopes: global, processing, topicization, rag; "
@@ -433,6 +440,36 @@ class AddUserAuthResult(BaseModel):
 
 class RemoveUserAuthResult(BaseModel):
     success: bool
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# F2: Parse-Only Export — result models
+# ---------------------------------------------------------------------------
+
+
+class ExportChannelResult(BaseModel):
+    """Result of submitting an export job (F2: Parse-Only Export)."""
+
+    job_id: str
+    status: str
+    channel_id: str
+    level: str
+    format: str
+    download_url: str | None = None
+    message: str
+
+
+class ExportStatusResult(BaseModel):
+    """Status of an export job."""
+
+    job_id: str
+    status: str
+    channel_id: str | None = None
+    level: str
+    format: str
+    download_url: str | None = None
+    file_size: int | None = None
     message: str
 
 
@@ -1564,6 +1601,212 @@ async def reload_prompts(
     loader = get_prompt_loader()
     loader.reload(name)
     return {"reloaded": name or "all", "success": True}
+
+
+# ---------------------------------------------------------------------------
+# F2: Parse-Only Export — MCP tools
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso_datetime(value: str | None, *, field: str) -> Any:
+    """Parse an ISO-8601 datetime string (UTC). Accepts 'YYYY-MM-DD' too."""
+    from datetime import datetime as _dt
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be an ISO-8601 string, got {type(value).__name__}")
+    try:
+        return _dt.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} is not a valid ISO-8601 datetime: {value!r}") from exc
+
+
+@mcp.tool()
+async def export_channel(
+    channel_id: str,
+    level: str = "raw",
+    format: str = "json",
+    from_date: str | None = None,
+    to_date: str | None = None,
+    ctx: Context | None = None,
+) -> ExportChannelResult:
+    """Submit a channel export job (F2: Parse-Only Export).
+
+    Creates a background job that exports channel content at the requested
+    ``level``. Use ``get_export_status`` to poll for completion, then fetch
+    the file via ``download_url``.
+
+    Args:
+        channel_id: Telegram channel ID (required for level='raw').
+        level: 'raw' (parse-only, no LLM; default) | 'processed'
+            (KnowledgeBaseEntry[]) | 'full' (legacy: processed + topics).
+        format: 'json' | 'ndjson' — applies to level='raw'; for
+            processed/full the legacy convention (kb_entries.ndjson +
+            topics.json) is used.
+        from_date: Optional ISO-8601 UTC datetime filter (inclusive).
+        to_date: Optional ISO-8601 UTC datetime filter (inclusive).
+
+    Returns:
+        ``ExportChannelResult`` with ``job_id`` and ``status='pending'``.
+        Poll via ``get_export_status(job_id)`` until ``status='completed'``,
+        then download from ``download_url``.
+    """
+    import asyncio as _asyncio
+    import uuid as _uuid
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    from tg_parser.api.job_store import ensure_job_store_initialized
+    from tg_parser.api.routes.export import _run_export_job
+    from tg_parser.api.schemas import ExportFormat, ExportLevel, ExportRequest
+    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.storage.ports import Job, JobStatus, JobType
+
+    user = await resolve_mcp_user(ctx.client_id if ctx else None)
+
+    try:
+        level_enum = ExportLevel(level)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid level: {level!r}; expected one of "
+            f"{[lv.value for lv in ExportLevel]}"
+        ) from exc
+
+    try:
+        format_enum = ExportFormat(format)
+    except ValueError as exc:
+        raise ValueError(
+            f"invalid format: {format!r}; expected one of "
+            f"{[fm.value for fm in ExportFormat]}"
+        ) from exc
+
+    normalized = channel_id.lstrip("@") if channel_id else channel_id
+
+    if level_enum == ExportLevel.RAW and not normalized:
+        raise ValueError("level='raw' requires channel_id")
+
+    if normalized:
+        try:
+            await assert_channel_access(user, normalized)
+        except PermissionDenied as e:
+            return ExportChannelResult(
+                job_id="",
+                status="rejected",
+                channel_id=normalized,
+                level=level_enum.value,
+                format=format_enum.value,
+                download_url=None,
+                message=e.message,
+            )
+
+    parsed_from = _parse_iso_datetime(from_date, field="from_date")
+    parsed_to = _parse_iso_datetime(to_date, field="to_date")
+
+    request = ExportRequest(
+        channel_id=normalized,
+        level=level_enum,
+        format=format_enum,
+        from_date=parsed_from,
+        to_date=parsed_to,
+    )
+
+    job_store = await ensure_job_store_initialized()
+    job_id = str(_uuid.uuid4())
+    created_at = _dt.now(_UTC)
+
+    job = Job(
+        job_id=job_id,
+        job_type=JobType.EXPORT,
+        status=JobStatus.PENDING,
+        created_at=created_at,
+        channel_id=normalized,
+        client=user.name,
+        export_format=format_enum.value,
+        progress={"level": level_enum.value},
+    )
+    await job_store.create_job(job)
+
+    task = _asyncio.create_task(
+        _run_export_job(job_id, request),
+        name=f"mcp-export-{job_id}",
+    )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+    logger.info(
+        "mcp_export_channel_submitted",
+        job_id=job_id,
+        channel_id=normalized,
+        level=level_enum.value,
+        format=format_enum.value,
+    )
+
+    return ExportChannelResult(
+        job_id=job_id,
+        status=JobStatus.PENDING.value,
+        channel_id=normalized or "",
+        level=level_enum.value,
+        format=format_enum.value,
+        download_url=None,
+        message=(
+            f"Export job created for channel '{normalized}' "
+            f"(level={level_enum.value}, format={format_enum.value}). "
+            "Poll with get_export_status until status='completed'."
+        ),
+    )
+
+
+@mcp.tool()
+async def get_export_status(
+    job_id: str,
+    ctx: Context | None = None,
+) -> ExportStatusResult:
+    """Check the status of a previously submitted export job (F2).
+
+    Args:
+        job_id: Job identifier returned by ``export_channel``.
+    """
+    from tg_parser.api.job_store import ensure_job_store_initialized
+    from tg_parser.api.routes.export import _resolve_job_level
+    from tg_parser.api.schemas import ExportFormat
+
+    _user = await resolve_mcp_user(ctx.client_id if ctx else None)
+
+    job_store = await ensure_job_store_initialized()
+    job = await job_store.get_job(job_id)
+
+    if job is None:
+        return ExportStatusResult(
+            job_id=job_id,
+            status="unknown",
+            channel_id=None,
+            level="full",
+            format="ndjson",
+            download_url=None,
+            file_size=None,
+            message=f"Export job {job_id} not found.",
+        )
+
+    export_format = ExportFormat(job.export_format) if job.export_format else ExportFormat.NDJSON
+    export_level = _resolve_job_level(job)
+
+    file_size: int | None = None
+    if job.result and isinstance(job.result, dict):
+        size = job.result.get("file_size")
+        if isinstance(size, int):
+            file_size = size
+
+    return ExportStatusResult(
+        job_id=job.job_id,
+        status=job.status.value,
+        channel_id=job.channel_id,
+        level=export_level.value,
+        format=export_format.value,
+        download_url=job.download_url,
+        file_size=file_size,
+        message=job.error or f"Status: {job.status.value}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -1669,16 +1669,14 @@ async def export_channel(
         level_enum = ExportLevel(level)
     except ValueError as exc:
         raise ValueError(
-            f"invalid level: {level!r}; expected one of "
-            f"{[lv.value for lv in ExportLevel]}"
+            f"invalid level: {level!r}; expected one of {[lv.value for lv in ExportLevel]}"
         ) from exc
 
     try:
         format_enum = ExportFormat(format)
     except ValueError as exc:
         raise ValueError(
-            f"invalid format: {format!r}; expected one of "
-            f"{[fm.value for fm in ExportFormat]}"
+            f"invalid format: {format!r}; expected one of {[fm.value for fm in ExportFormat]}"
         ) from exc
 
     normalized = channel_id.lstrip("@") if channel_id else channel_id

--- a/tg_parser/services/db_context.py
+++ b/tg_parser/services/db_context.py
@@ -172,23 +172,31 @@ async def topic_embedding_repos() -> (
 
 @asynccontextmanager
 async def export_repos() -> (
-    "AsyncIterator[tuple[SAProcessedDocumentRepo, SATopicCardRepo, SATopicBundleRepo, SAIngestionStateRepo, Database]]"
+    "AsyncIterator[tuple[SAProcessedDocumentRepo, SATopicCardRepo, SATopicBundleRepo, SAIngestionStateRepo, SARawMessageRepo, Database]]"
 ):
-    """Context manager for export (processing + ingestion state in single Database)."""
+    """Context manager for export (processing + ingestion state + raw in single Database).
+
+    Includes ``SARawMessageRepo`` so that ``run_export(level='raw')``
+    (F2 Parse-Only Export) can read raw messages without opening a
+    separate session stack.
+    """
     db = await _get_db()
     proc_session = db.processing_storage_session()
     state_session = db.ingestion_state_session()
+    raw_session = db.raw_storage_session()
     try:
         yield (
             SAProcessedDocumentRepo(proc_session),
             SATopicCardRepo(proc_session),
             SATopicBundleRepo(proc_session),
             SAIngestionStateRepo(state_session),
+            SARawMessageRepo(raw_session),
             db,
         )
     finally:
         await proc_session.close()
         await state_session.close()
+        await raw_session.close()
 
 
 @asynccontextmanager

--- a/tg_parser/services/export_service.py
+++ b/tg_parser/services/export_service.py
@@ -3,6 +3,10 @@ Export service.
 
 Extracted from cli/export_cmd.py — owns the business logic for
 exporting topics and KB entries to JSON/NDJSON files.
+
+F2 (Parse-Only Export): extended with ``level`` branching so that callers
+can export raw Telegram messages (``level=ExportLevel.RAW``) in addition
+to the legacy processed/full flows.
 """
 
 import contextlib
@@ -12,14 +16,20 @@ from pathlib import Path
 import structlog
 from sqlalchemy.exc import SQLAlchemyError
 
+from tg_parser.domain.export import ExportFormat, ExportLevel
 from tg_parser.export.kb_export import export_kb_entries_ndjson, filter_kb_entries
 from tg_parser.export.kb_mapping import map_message_to_kb_entry
+from tg_parser.export.raw_export import (
+    export_raw_channel_json,
+    export_raw_channel_ndjson,
+)
 from tg_parser.export.telegram_url import resolve_telegram_url
 from tg_parser.export.topics_export import export_topic_detail_json, export_topics_json
 from tg_parser.services.db_context import export_repos
 from tg_parser.storage.ports import (
     IngestionStateRepo,
     ProcessedDocumentRepo,
+    RawMessageRepo,
     TopicBundleRepo,
     TopicCardRepo,
 )
@@ -34,30 +44,50 @@ async def run_export(
     from_date: datetime | None = None,
     to_date: datetime | None = None,
     pretty: bool = False,
+    level: ExportLevel = ExportLevel.FULL,
+    format: ExportFormat = ExportFormat.NDJSON,
     *,
     processed_repo: ProcessedDocumentRepo | None = None,
     topic_card_repo: TopicCardRepo | None = None,
     topic_bundle_repo: TopicBundleRepo | None = None,
     ingestion_repo: IngestionStateRepo | None = None,
+    raw_repo: RawMessageRepo | None = None,
 ) -> dict[str, int]:
     """
     Run artifact export.
 
     Args:
         output_dir: Output directory for files
-        channel_id: Channel filter (optional)
-        topic_id: Topic filter (optional)
+        channel_id: Channel filter (optional; required for level='raw')
+        topic_id: Topic filter (optional; applies to full/processed only)
         from_date: Date filter "from" (optional)
         to_date: Date filter "to" (optional)
         pretty: Pretty-print JSON
+        level: Export level (F2): RAW | PROCESSED | FULL (default — legacy behaviour).
+        format: Export format (applies to level=RAW). Processed/full levels
+            always write ``kb_entries.ndjson`` + optional ``topics.json``.
         processed_repo: Optional DI for ProcessedDocumentRepo
         topic_card_repo: Optional DI for TopicCardRepo
         topic_bundle_repo: Optional DI for TopicBundleRepo
         ingestion_repo: Optional DI for IngestionStateRepo
+        raw_repo: Optional DI for RawMessageRepo (F2: required for level='raw')
 
     Returns:
-        Statistics (kb_entries_count, topics_count, channels_count)
+        Statistics dict:
+
+        - For ``level=RAW``:
+          ``{"raw_posts_count": N, "raw_comments_count": N,
+          "raw_orphan_comments_count": N, "channels_count": 0|1}``.
+        - For ``level=PROCESSED`` / ``level=FULL``:
+          ``{"kb_entries_count": N, "topics_count": N, "channels_count": N}``
+          (topics_count is always 0 for PROCESSED).
+
+    Raises:
+        ValueError: when ``level=ExportLevel.RAW`` is used without ``channel_id``.
     """
+    if level == ExportLevel.RAW and not channel_id:
+        raise ValueError("level='raw' requires channel_id")
+
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
@@ -67,14 +97,38 @@ async def run_export(
             or topic_card_repo is None
             or topic_bundle_repo is None
             or ingestion_repo is None
+            or raw_repo is None
         ):
             (
-                processed_repo,
-                topic_card_repo,
-                topic_bundle_repo,
-                ingestion_repo,
+                ctx_processed_repo,
+                ctx_topic_card_repo,
+                ctx_topic_bundle_repo,
+                ctx_ingestion_repo,
+                ctx_raw_repo,
                 _db,
             ) = await stack.enter_async_context(export_repos())
+            if processed_repo is None:
+                processed_repo = ctx_processed_repo
+            if topic_card_repo is None:
+                topic_card_repo = ctx_topic_card_repo
+            if topic_bundle_repo is None:
+                topic_bundle_repo = ctx_topic_bundle_repo
+            if ingestion_repo is None:
+                ingestion_repo = ctx_ingestion_repo
+            if raw_repo is None:
+                raw_repo = ctx_raw_repo
+
+        if level == ExportLevel.RAW:
+            return await _run_raw_export(
+                output_path=output_path,
+                channel_id=channel_id,  # type: ignore[arg-type]
+                from_date=from_date,
+                to_date=to_date,
+                pretty=pretty,
+                format=format,
+                raw_repo=raw_repo,
+                ingestion_repo=ingestion_repo,
+            )
 
         return await _run_export_impl(
             output_path=output_path,
@@ -83,11 +137,81 @@ async def run_export(
             from_date=from_date,
             to_date=to_date,
             pretty=pretty,
+            level=level,
             processed_repo=processed_repo,
             topic_card_repo=topic_card_repo,
             topic_bundle_repo=topic_bundle_repo,
             ingestion_repo=ingestion_repo,
         )
+
+
+async def _run_raw_export(
+    *,
+    output_path: Path,
+    channel_id: str,
+    from_date: datetime | None,
+    to_date: datetime | None,
+    pretty: bool,
+    format: ExportFormat,
+    raw_repo: RawMessageRepo,
+    ingestion_repo: IngestionStateRepo,
+) -> dict[str, int]:
+    """Run level='raw' export (F2 Parse-Only).
+
+    Fail-open: unknown/empty channel still produces a valid (empty) envelope.
+    """
+    logger.info(
+        "Loading raw messages for channel: %s (format=%s)",
+        channel_id,
+        format.value,
+    )
+    raw_messages = await raw_repo.list_by_channel(
+        channel_id=channel_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
+    logger.info(
+        "Loaded %s raw messages for channel %s",
+        len(raw_messages),
+        channel_id,
+    )
+
+    channel_username_map = await ingestion_repo.get_channel_usernames()
+    channel_username = channel_username_map.get(channel_id)
+
+    if format == ExportFormat.NDJSON:
+        output_file = output_path / "raw_messages.ndjson"
+        stats = export_raw_channel_ndjson(
+            messages=raw_messages,
+            output_path=output_file,
+        )
+    else:
+        output_file = output_path / "raw_messages.json"
+        stats = export_raw_channel_json(
+            messages=raw_messages,
+            channel_id=channel_id,
+            channel_username=channel_username,
+            from_date=from_date,
+            to_date=to_date,
+            output_path=output_file,
+            pretty=pretty,
+        )
+
+    logger.info(
+        "Exported raw channel %s to %s (posts=%s, comments=%s, orphan=%s)",
+        channel_id,
+        output_file,
+        stats["posts"],
+        stats["comments"],
+        stats["orphan_comments"],
+    )
+
+    return {
+        "raw_posts_count": stats["posts"],
+        "raw_comments_count": stats["comments"],
+        "raw_orphan_comments_count": stats["orphan_comments"],
+        "channels_count": 1 if stats["posts"] or stats["comments"] else 0,
+    }
 
 
 async def _run_export_impl(
@@ -98,6 +222,7 @@ async def _run_export_impl(
     from_date: datetime | None,
     to_date: datetime | None,
     pretty: bool,
+    level: ExportLevel,
     processed_repo: ProcessedDocumentRepo,
     topic_card_repo: TopicCardRepo,
     topic_bundle_repo: TopicBundleRepo,
@@ -165,7 +290,8 @@ async def _run_export_impl(
 
     topics_count = 0
 
-    if channel_id:
+    # level=PROCESSED intentionally skips topics — they belong to FULL semantics.
+    if level == ExportLevel.FULL and channel_id:
         logger.info("Loading topic cards for channel: %s", channel_id)
         topic_cards = await topic_card_repo.list_by_channel(channel_id)
 
@@ -208,8 +334,10 @@ async def _run_export_impl(
             topics_count = len(topic_cards)
         else:
             logger.info("No topic cards found for export")
-    else:
+    elif level == ExportLevel.FULL:
         logger.info("Topics export requires channel_id filter")
+    else:
+        logger.info("level=processed: skipping topics export by design")
 
     return {
         "kb_entries_count": len(kb_entries),


### PR DESCRIPTION
## Summary

Implements **F2: Channel Content Export (Parse-Only Mode)** per [`docs/plans/F2_PARSE_ONLY_EXPORT_PLAN.md`](docs/plans/F2_PARSE_ONLY_EXPORT_PLAN.md).

Adds a new `level` dimension (`raw` | `processed` | `full`) to the export pipeline, exposing raw Telegram messages (`raw_messages`) as JSON envelope or NDJSON stream across `ExportService`, REST API (`/api/v1/export`), CLI (`tg_parser export`), MCP tool (`export_channel` + `get_export_status`), and Telegram bot tool. Default behaviour (`level=full`) is byte-identical to pre-F2 — full backward compatibility with existing API/CLI callers.

### Two commits

1. `9456b4f feat(f2): add raw channel export (level=raw|processed|full) to service/CLI/API`
   - `tg_parser/domain/export.py` — `ExportLevel` + `ExportFormat` enums (extracted to break `services` ↔ `api` circular import).
   - `tg_parser/export/raw_export.py` — pure writer: JSON envelope `raw_channel_export.v1` with comment grouping under posts + orphan-comments bucket; NDJSON stream (one message per line, posts first then comments by date). `raw_payload` excluded by default for privacy.
   - `tg_parser/services/export_service.py` — `run_export` branches on `level`; `RAW` requires `channel_id`; `PROCESSED` skips topics; `FULL` keeps legacy behaviour.
   - `tg_parser/services/db_context.py` — `export_repos()` extended with `RawMessageRepo`.
   - `tg_parser/cli/app.py` — `--level`, `--format` flags + validation + per-level stats output.
   - `tg_parser/api/routes/export.py` — proxies `level` / `from_date` / `to_date` to `_run_export_job`; resolves correct download file by level; stores level in `Job.progress`/`Job.result` (no DB migration).
   - `tg_parser/api/schemas.py` — `ExportRequest.level`/`from_date`/`to_date`, `ExportResponse.level`.

2. `6ab68d4 feat(f2): add export_channel MCP and bot tools with documentation`
   - `tg_parser/mcp_server.py` — `export_channel` and `get_export_status` MCP tools with `assert_channel_access` ownership checks; reuses HTTP-route `_run_export_job`.
   - `tg_parser/bot/tools.py` — `export_channel` bot tool with **50 MB Telegram `send_document` size gate**: small files → `FSInputFile`, large files → download URL. `_TOOLS_NEEDING_BOT_CONTEXT` mechanism passes `bot`/`chat_id` only to tools that need it without polluting other executor signatures.
   - `tg_parser/bot/agent.py`, `tg_parser/bot/handlers.py` — thread `bot` + `chat_id` from aiogram into tool execution.
   - Docs: `docs/USER_GUIDE.md` §"Parse-Only Export (F2)" with CLI/API/MCP/Bot examples + envelope structure + privacy note; `docs/MCP_AGENT_GUIDE.md` schemas + workflow submit→poll→download (24 → 26 tools, v4.3 → v4.4); `ENV_VARIABLES_GUIDE.md` `RATE_LIMIT_EXPORT` note; `docs/notes/FUTURE_FEATURES.md` F2 marked DONE.

## Test plan

- [x] `tests/test_f2_parse_only_export.py` — **49 new tests**: `TestRawExportWriter`, `TestGroupMessages`, `TestExportServiceRaw`, `TestExportServiceBackwardCompat`, `TestCLIExportLevel`, `TestAPIExportLevel`, `TestMCPExportChannel`, `TestBotExportChannel` (covers raw_payload exclusion, orphan comments, date filters, ownership, 50 MB size-gate, progress messages, NDJSON line-per-message invariant).
- [x] Local: `.venv/bin/pytest tests/test_f2_parse_only_export.py -x -q` → **49 passed**.
- [x] Full regression: `TEST_POSTGRES=1 pytest tests/ -x -q` → **1536 passed** in 137s (baseline 1487, +49 net new).
- [x] Self-review checklist (per plan §"Порядок работы" steps 5 & 10): backward-compat, raw writer edge cases, date filter semantics, NDJSON validity, `raw_payload` leak audit, CLI/API 400 validation, ownership enforcement, MCP/Bot signatures, docs consistency — all covered.
- [ ] CI green on PR.

## Out of scope (per plan §"Что НЕ входит в scope F2")

- `level=raw` for **all** channels (no `channel_id`) — requires `RawMessageRepo.list_all()` + paging; deferred.
- YAML / CSV formats; streaming NDJSON over HTTP response; `include_raw_payload` flag; F2-level `raw_plus_processed` hybrid; incremental export.

## Roadmap context

Step 2 of [post-F5-A Phase 3 sequence](docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md). Next: **F6: Scheduled Digests**.

Made with [Cursor](https://cursor.com)