### PR TITLE
feat(F6): Scheduled Digests — cron-driven channel summaries via Telegram bot

### DIFF
--- a/ENV_VARIABLES_GUIDE.md
+++ b/ENV_VARIABLES_GUIDE.md
@@ -812,8 +812,9 @@ Override default host port mappings when they conflict with other services on th
 - **Default**: `50`
 - **Description**: Per-channel cap on `ProcessedDocument`s included in one
   digest tick. Prevents an outlier-noisy channel from blowing the LLM
-  budget. The remainder is queued for the next tick (cursor advances only
-  past delivered docs).
+  budget. When `len(filtered) > cap`, the **oldest** slice is delivered and
+  the cursor advances to the last delivered doc — leftover newer docs are
+  picked up on the next tick (no message loss).
 
 #### `DIGEST_FIRST_RUN_LOOKBACK_HOURS`
 - **Type**: integer
@@ -836,10 +837,10 @@ Override default host port mappings when they conflict with other services on th
 
 #### `DIGEST_MAX_MESSAGE_PARTS`
 - **Type**: integer
-- **Default**: `4`
-- **Description**: Max number of split parts before falling back to
-  `FSInputFile` (sending the full digest as a `.md` attachment, F2-style
-  size-gate).
+- **Default**: `10`
+- **Description**: Max number of split parts before falling back to a
+  `BufferedInputFile` (the full digest is sent as a `.md` attachment built
+  in memory — no temp file on disk).
 
 #### `DIGEST_LLM_PROVIDER`
 - **Type**: string (`openai` | `anthropic` | `gemini` | `ollama`)

--- a/ENV_VARIABLES_GUIDE.md
+++ b/ENV_VARIABLES_GUIDE.md
@@ -793,6 +793,67 @@ Override default host port mappings when they conflict with other services on th
 - **Default**: `true`
 - **Description**: Enable agent state persistence
 
+### Scheduled Digests (F6)
+
+#### `DIGEST_SCHEDULER_ENABLED`
+- **Type**: boolean
+- **Default**: `true`
+- **Description**: Run digest cron jobs in the bot process (only the bot
+  delivers digests; API/CLI daemon never send to avoid duplicates).
+
+#### `DIGEST_DEFAULT_TIMEZONE`
+- **Type**: string (`zoneinfo` key)
+- **Default**: `Europe/Moscow`
+- **Description**: Fallback timezone for new subscriptions when the user
+  did not specify one.
+
+#### `DIGEST_MAX_DOCS_PER_RUN`
+- **Type**: integer
+- **Default**: `50`
+- **Description**: Per-channel cap on `ProcessedDocument`s included in one
+  digest tick. Prevents an outlier-noisy channel from blowing the LLM
+  budget. The remainder is queued for the next tick (cursor advances only
+  past delivered docs).
+
+#### `DIGEST_FIRST_RUN_LOOKBACK_HOURS`
+- **Type**: integer
+- **Default**: `24`
+- **Description**: Lookback window used when a subscription has no
+  `last_digest_cursor` yet (first ever run).
+
+#### `DIGEST_REFRESH_INTERVAL`
+- **Type**: integer (seconds)
+- **Default**: `60`
+- **Description**: How often the bot reconciles its in-memory scheduler
+  jobs against `digest_subscriptions` rows. Picks up subscriptions
+  created/deleted via MCP (in another process) without restart.
+
+#### `DIGEST_MESSAGE_MAX_CHARS`
+- **Type**: integer
+- **Default**: `4096`
+- **Description**: Max characters per Telegram message before splitting.
+  Telegram's hard limit is 4096; lower values create more parts.
+
+#### `DIGEST_MAX_MESSAGE_PARTS`
+- **Type**: integer
+- **Default**: `4`
+- **Description**: Max number of split parts before falling back to
+  `FSInputFile` (sending the full digest as a `.md` attachment, F2-style
+  size-gate).
+
+#### `DIGEST_LLM_PROVIDER`
+- **Type**: string (`openai` | `anthropic` | `gemini` | `ollama`)
+- **Default**: empty (falls back to `LLM_PROVIDER`)
+- **Description**: Per-stage override for the digest summarization LLM.
+  Can also be switched at runtime via
+  `set_llm_config(scope="digest", provider=...)`.
+
+#### `DIGEST_LLM_MODEL`
+- **Type**: string
+- **Default**: empty (falls back to `LLM_MODEL`)
+- **Description**: Per-stage model override paired with
+  `DIGEST_LLM_PROVIDER`.
+
 ---
 
 ## 🔍 How to Use Logs

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -64,6 +64,14 @@ Auth: Bearer <MCP_AUTH_TOKEN>
 | `export_channel` | owner/admin | Submit export job for a channel (level=raw/processed/full) |
 | `get_export_status` | owner/admin | Poll job status + download URL when completed |
 
+### Digests (F6)
+
+| Tool | Auth | Description |
+|------|------|-------------|
+| `subscribe_digest` | owner/admin | Create a cron-driven digest subscription delivering to a Telegram chat |
+| `list_digests` | any | List subscriptions (admin: all; user: own only) |
+| `unsubscribe_digest` | owner/admin | Delete a subscription and unregister its scheduler job |
+
 ### LLM Configuration
 
 | Tool | Auth | Description |
@@ -326,6 +334,65 @@ Returns: ExportStatusResult
   error: str | null              # populated when status == "failed"
 ```
 
+### `subscribe_digest`
+
+```
+Parameters:
+  name: str                      # Human label, e.g. "morning brief"
+  channel_ids: list[str]         # Non-empty; each must pass assert_channel_access
+  chat_id: int                   # Telegram chat to deliver into (private/group/supergroup/channel)
+  cron_expression: str = "0 9 * * *"
+  timezone: str = "Europe/Moscow"  # any zoneinfo key (UTC, Europe/Moscow, ...)
+  format: str = "summary"        # "summary" | "bullets" | "detailed"
+  language: str = "ru"           # ISO-639-1 hint forwarded to the LLM
+
+Returns: SubscribeDigestResult
+  success: bool
+  message: str
+  subscription: DigestSubscriptionInfo | null
+```
+
+- Cron is validated via `CronTrigger.from_crontab(...)`; invalid expressions
+  produce `success=false` with a human-readable message (no 500).
+- Timezone is validated via `zoneinfo.ZoneInfo(...)`; bad zones return a
+  similar 4xx-style error.
+- For each `channel_id`, ownership is enforced through
+  `assert_channel_access(user, channel_id)`; non-owners get rejected.
+- The subscription is persisted to `digest_subscriptions` and immediately
+  registered with the bot-process scheduler (or picked up via the next
+  reconciliation tick, every `DIGEST_REFRESH_INTERVAL` seconds).
+
+### `list_digests`
+
+```
+Parameters: (none)
+
+Returns: ListDigestsResult
+  count: int
+  subscriptions: list[DigestSubscriptionInfo]
+```
+
+- Admin sees all subscriptions across users (active + paused).
+- Non-admin sees only subscriptions whose `owner_id == current_user.id`.
+
+### `unsubscribe_digest`
+
+```
+Parameters:
+  subscription_id: str           # UUID
+
+Returns: UnsubscribeDigestResult
+  success: bool
+  message: str
+  subscription_id: str | null
+```
+
+- Returns `success=false, message="not found"` if the subscription does not
+  exist.
+- Non-admin can only unsubscribe their own subscriptions; cross-owner
+  attempts are rejected with `success=false`.
+- On success the scheduler job is unregistered and the row is deleted.
+
 ### `get_llm_config`
 
 ```
@@ -508,6 +575,30 @@ Notes:
 3. trigger_pipeline(channel_id="mychannel") # uses new provider
 4. reset_llm_config()                       # revert to .env defaults
 ```
+
+### 7. Subscribe and manage digests (F6)
+
+```
+1. result = subscribe_digest(
+     name="morning brief",
+     channel_ids=["@durov", "@telegram"],
+     chat_id=12345,                       # personal chat or group/channel id
+     cron_expression="0 9 * * 1-5",       # weekday mornings
+     timezone="Europe/Moscow",
+     format="summary",                    # or "bullets" / "detailed"
+   )
+   # returns {success: True, subscription: {...}}
+
+2. list_digests()                         # admin: all; user: own only
+
+3. unsubscribe_digest(subscription_id=result.subscription.id)
+```
+
+Notes:
+- LLM stage `digest` can be tuned via env (`DIGEST_LLM_PROVIDER`/`_MODEL`)
+  or runtime (`set_llm_config(scope="digest", ...)`).
+- The bot-process scheduler picks up new MCP-created subscriptions within
+  `DIGEST_REFRESH_INTERVAL` seconds (default 60s) without restart.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -22,7 +22,8 @@
 1. [Установка и настройка](#установка-и-настройка)
 2. [Database Setup (PostgreSQL)](#database-setup)
 3. [Конфигурация](#конфигурация)
-4. [CLI команды](#cli-команды)
+4. [Scheduled Digests (F6)](#scheduled-digests-f6)
+5. [CLI команды](#cli-команды)
 5. [Multi-Tenancy и управление пользователями](#multi-tenancy-и-управление-пользователями)
 6. [HTTP API](#http-api)
 7. [Logging](#logging)
@@ -491,6 +492,124 @@ tg_parser backfill-content-hash --channel-id my_channel --dry-run
 Backfill использует cursor-пагинацию (`WHERE content_hash IS NULL LIMIT N`
 в цикле), безопасно для больших таблиц. Идемпотентен: повторный запуск
 пропустит уже-хэшированные строки.
+
+---
+
+## Scheduled Digests (F6)
+
+Подписки на автоматические сводки (digests) по выбранным каналам с доставкой
+в Telegram-чат по cron-расписанию. На каждом тике планировщик берёт
+`ProcessedDocument`-ы, появившиеся **после** `last_digest_cursor` подписки,
+прогоняет их через LLM с промптом `prompts/digest.yaml` и отправляет
+итоговый Markdown в указанный `chat_id`.
+
+### Как это работает
+
+1. Пользователь создаёт подписку через Telegram-бот ("подпишись на дайджест по
+   @durov каждое утро в 9") или через MCP (`subscribe_digest`).
+2. Подписка сохраняется в таблице `digest_subscriptions` (БД `ingestion`) и
+   регистрируется в `BackgroundScheduler` через `CronTrigger`.
+3. По cron-тику запускается `run_scheduled_digests_task(subscription_id)`:
+   - `DigestService.generate(...)` загружает новые документы (фильтр
+     `processed_at > last_digest_cursor`, кап `DIGEST_MAX_DOCS_PER_RUN`),
+     группирует их по каналам, вызывает LLM в стейдже `digest`.
+   - `DigestService.deliver(...)` экранирует MarkdownV2, при необходимости
+     режет сообщение на куски ≤4096 символов; если кусков больше
+     `DIGEST_MAX_MESSAGE_PARTS` — отправляет полный текст файлом
+     (`FSInputFile`, паттерн F2 size-gate).
+   - При успешной доставке `last_digest_cursor` сдвигается до максимального
+     `processed_at` среди отправленных документов; `last_sent_at = now()`.
+4. Раз в `DIGEST_REFRESH_INTERVAL` секунд бот реконсилирует список jobs со
+   снимком `repo.list_active()` — так подписки, созданные через MCP в другом
+   процессе, подхватываются без рестарта бота.
+
+### Cron cheat-sheet
+
+| Cron        | Когда срабатывает                  |
+| ----------- | ----------------------------------- |
+| `0 9 * * *` | Каждый день в 09:00 (timezone подписки) |
+| `0 */4 * * *` | Каждые 4 часа                     |
+| `0 9 * * 1-5` | Будни в 09:00                     |
+| `0 18 * * 5` | Каждую пятницу в 18:00              |
+| `0 9 1 * *` | Первое число каждого месяца в 09:00 |
+
+Таймзона валидируется через `zoneinfo.ZoneInfo(...)` при создании подписки —
+неверное значение возвращает понятную ошибку, не 500.
+
+### Поддерживаемые форматы
+
+- `summary` (default) — связный краткий пересказ (3–6 абзацев).
+- `bullets` — компактные пункты по каналам.
+- `detailed` — расширенный обзор с подзаголовками per-channel.
+
+Формат прокидывается в шаблон `prompts/digest.yaml` через переменную
+`{format}`; LLM сам подгоняет стиль ответа.
+
+### Настройка LLM
+
+Стейдж `digest` поддерживает per-stage переопределение провайдера и модели:
+
+```bash
+# В .env
+DIGEST_LLM_PROVIDER=anthropic
+DIGEST_LLM_MODEL=claude-sonnet-4-5-20250929
+```
+
+Runtime-переключение без рестарта (через MCP):
+
+```text
+set_llm_config(scope="digest", provider="openai", model="gpt-4o-mini")
+```
+
+При отсутствии stage-override — fallback на `global` → дефолт из `.env`.
+
+### Управление подписками
+
+**Через бота (естественным языком):**
+
+```text
+Пользователь: подпишись на дайджест по @durov и @meduza каждое утро в 9
+Bot: 📰 Подписка morning создана. Расписание: 0 9 * * * (Europe/Moscow). Каналов: 2.
+
+Пользователь: покажи мои подписки
+Bot: <list_digests output>
+
+Пользователь: отпиши меня от дайджеста <id>
+Bot: ✅ Подписка отменена.
+```
+
+**Через MCP:**
+
+```text
+subscribe_digest(name="morning", channel_ids=["@durov"], chat_id=12345,
+                 cron_expression="0 9 * * *", timezone="Europe/Moscow")
+list_digests()             # admin: все подписки; user: только свои
+unsubscribe_digest(subscription_id="...")
+```
+
+### Ownership и лимиты
+
+- `digest_subscriptions.owner_id` ссылается на `users.id` (FK с
+  `ON DELETE CASCADE`).
+- Не-админ видит/редактирует только свои подписки; админ — все.
+- Каналы в `channel_ids[]` обязаны проходить `assert_channel_access(user, cid)`
+  — для restricted user'а попытка подписаться на чужой канал отклоняется
+  ошибкой "no access to channel ...".
+- `DIGEST_MAX_DOCS_PER_RUN` (default 50) — кап документов per channel per
+  тик (исключает out-of-budget runs на шумных каналах).
+
+### Включение
+
+```bash
+# В .env
+SCHEDULER_ENABLED=true       # общий switch для BackgroundScheduler
+DIGEST_SCHEDULER_ENABLED=true # запускать digest-jobs в bot-процессе
+DIGEST_DEFAULT_TIMEZONE=Europe/Moscow
+DIGEST_REFRESH_INTERVAL=60    # секунд между реконсиляциями DB ↔ scheduler
+```
+
+Доставка происходит **только в bot-процессе** — API/CLI daemon дайджесты не
+шлют, чтобы исключить дубль.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -24,13 +24,13 @@
 3. [Конфигурация](#конфигурация)
 4. [Scheduled Digests (F6)](#scheduled-digests-f6)
 5. [CLI команды](#cli-команды)
-5. [Multi-Tenancy и управление пользователями](#multi-tenancy-и-управление-пользователями)
-6. [HTTP API](#http-api)
-7. [Logging](#logging)
-8. [Мониторинг](#мониторинг)
-9. [Примеры использования](#примеры-использования)
-10. [Production Deployment](#production-deployment)
-11. [Troubleshooting](#troubleshooting)
+6. [Multi-Tenancy и управление пользователями](#multi-tenancy-и-управление-пользователями)
+7. [HTTP API](#http-api)
+8. [Logging](#logging)
+9. [Мониторинг](#мониторинг)
+10. [Примеры использования](#примеры-использования)
+11. [Production Deployment](#production-deployment)
+12. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -515,8 +515,8 @@ Backfill использует cursor-пагинацию (`WHERE content_hash IS 
      группирует их по каналам, вызывает LLM в стейдже `digest`.
    - `DigestService.deliver(...)` экранирует MarkdownV2, при необходимости
      режет сообщение на куски ≤4096 символов; если кусков больше
-     `DIGEST_MAX_MESSAGE_PARTS` — отправляет полный текст файлом
-     (`FSInputFile`, паттерн F2 size-gate).
+     `DIGEST_MAX_MESSAGE_PARTS` — отправляет полный текст вложением
+     (`BufferedInputFile`, .md в памяти — без записи на диск).
    - При успешной доставке `last_digest_cursor` сдвигается до максимального
      `processed_at` среди отправленных документов; `last_sent_at = now()`.
 4. Раз в `DIGEST_REFRESH_INTERVAL` секунд бот реконсилирует список jobs со

--- a/docs/notes/FUTURE_FEATURES.md
+++ b/docs/notes/FUTURE_FEATURES.md
@@ -17,7 +17,7 @@
 | **F3** | Multi-Source Connectors (WA, Discord) | ~2–3 сессии | Низкий | Архитектура |
 | **F4** | Multi-Tenancy (Users + Workspaces) | A: ~3–4, B: ~2 сессии | Низкий | Архитектура |
 | **F5** | Living Knowledge Base | A–D: ~1.5–6+ сессий | Высокий | Core |
-| **F6** | Scheduled Digests | ~1.5–2 сессии | Средний-высокий | Функционал |
+| **F6** | Scheduled Digests ✅ DONE | ~1.5–2 сессии | Средний-высокий | Функционал |
 | **F7** | Monetization (Billing) | ~3–4 сессии | Средний | Бизнес |
 | **F8** | Scalability & Resilience | A–C: ~1–3+ сессий | Высокий | Инфраструктура |
 | **F9** | Security Hardening | Quick: ~0.5, Full: ~2–3 сессии | **ВЫСШИЙ** | Безопасность |
@@ -800,8 +800,11 @@ Level A даёт немедленное улучшение RAG качества.
 
 ## F6: Scheduled Digests — автоматические сводки по расписанию
 
+**Статус:** ✅ DONE (см. `docs/plans/F6_SCHEDULED_DIGESTS_PLAN.md`,
+`docs/USER_GUIDE.md` § "Scheduled Digests (F6)",
+`docs/MCP_AGENT_GUIDE.md` § "Digests (F6)").
 **Приоритет:** Средний-высокий
-**Сложность:** ~1.5–2 сессии (низкая-средняя)
+**Сложность:** ~1.5–2 сессии (низкая-средняя) — фактически 2 коммита.
 **Зависимости:** F4-B (Workspaces) — для per-group digests; без неё работает на уровне каналов
 
 ### Мотивация

--- a/migrations/versions/ingestion/20260418_add_digest_subscriptions.py
+++ b/migrations/versions/ingestion/20260418_add_digest_subscriptions.py
@@ -1,6 +1,6 @@
 """add digest_subscriptions table
 
-Revision ID: c3d4e5f6a7b8
+Revision ID: f6a1b2c3d4e5
 Revises: b2c3d4e5f6a7
 Create Date: 2026-04-18
 

--- a/migrations/versions/ingestion/20260418_add_digest_subscriptions.py
+++ b/migrations/versions/ingestion/20260418_add_digest_subscriptions.py
@@ -1,0 +1,71 @@
+"""add digest_subscriptions table
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-18
+
+F6 Scheduled Digests: per-user subscriptions for cron-driven digests.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f6a1b2c3d4e5"
+down_revision: str | None = "b2c3d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text("""
+        CREATE TABLE IF NOT EXISTS digest_subscriptions (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            chat_id BIGINT NOT NULL,
+            name VARCHAR(200) NOT NULL,
+            channel_ids TEXT[] NOT NULL,
+            cron_expression VARCHAR(100) NOT NULL DEFAULT '0 9 * * *',
+            timezone VARCHAR(50) NOT NULL DEFAULT 'UTC',
+            format VARCHAR(20) NOT NULL DEFAULT 'summary',
+            language VARCHAR(10) NOT NULL DEFAULT 'ru',
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            last_sent_at TIMESTAMPTZ,
+            last_digest_cursor TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT digest_subscriptions_channel_ids_nonempty
+                CHECK (array_length(channel_ids, 1) >= 1)
+        )
+    """)
+    )
+
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_digest_subscriptions_owner_active "
+            "ON digest_subscriptions(owner_id, is_active)"
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_digest_subscriptions_active_cron "
+            "ON digest_subscriptions(is_active) WHERE is_active = TRUE"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_digest_subscriptions_active_cron",
+        table_name="digest_subscriptions",
+    )
+    op.drop_index(
+        "idx_digest_subscriptions_owner_active",
+        table_name="digest_subscriptions",
+    )
+    op.drop_table("digest_subscriptions")

--- a/prompts/digest.yaml
+++ b/prompts/digest.yaml
@@ -1,0 +1,61 @@
+# TG_parser Scheduled Digest Prompt
+# Version: 1.0.0
+#
+# Prompt for summarising new ProcessedDocument-s collected since the previous
+# digest run for a single subscription. Rendered through PromptLoader and
+# Python str.format — placeholders use {name} syntax (NOT Jinja).
+#
+# Placeholders:
+#   system.prompt:  {language}, {format}
+#   user.template:  {language}, {format}, {from_iso}, {to_iso}, {channels_block}
+#
+# `channels_block` is pre-rendered by DigestService as a Markdown chunk grouping
+# documents by channel, e.g.:
+#
+#   ## @durov (12 new)
+#   - [2026-04-18 09:01] Summary text...
+#   - [2026-04-18 09:42] Summary text... (truncated)
+#
+# Edit this file and call MCP/bot tool `reload_prompts` to apply without restart.
+#
+# Documentation: docs/LLM_PROMPTS.md
+
+metadata:
+  version: "1.0.0"
+  description: "Scheduled-digest summarisation prompt (F6)"
+
+system:
+  prompt: |
+    Ты ассистент-аналитик. Твоя задача — собрать краткий дайджест новых сообщений
+    из Telegram-каналов за указанный период.
+
+    Правила:
+    - Группируй пункты по каналам, сохраняя заголовок канала из входных данных.
+    - Не выдумывай факты, которых нет во входных сообщениях.
+    - Не цитируй дословно длинные блоки — пересказывай суть.
+    - Если в канале новых сообщений нет, не упоминай его.
+    - Сохраняй ссылки и упоминания в исходном виде.
+
+    Стиль вывода зависит от формата:
+    - 'summary'  — 1–2 параграфа на канал, обзорно.
+    - 'bullets'  — список маркеров, по одной короткой строке на пункт.
+    - 'detailed' — параграф на канал плюс 1–3 ключевые цитаты или фактоиды.
+
+    Формат запрошен: {format}.
+    Язык вывода: {language}.
+
+user:
+  template: |
+    Сформируй дайджест в формате '{format}' за период {from_iso} — {to_iso}.
+    Язык вывода: {language}.
+
+    Вот новые сообщения, сгруппированные по каналам:
+
+    {channels_block}
+
+    Выведи только сам дайджест в Markdown без вступлений и заключений.
+  variables: [format, language, from_iso, to_iso, channels_block]
+
+model:
+  temperature: 0.3
+  max_tokens: 1500

--- a/tests/test_bot_tools_v11.py
+++ b/tests/test_bot_tools_v11.py
@@ -95,7 +95,7 @@ class TestBotToolDeclarations:
         assert "get_pipeline_status" in names
         assert "pause_channel" in names
         assert "resume_channel" in names
-        assert len(TOOL_DECLARATIONS) == 25
+        assert len(TOOL_DECLARATIONS) == 28
 
 
 class TestExecuteToolTriggerPipeline:

--- a/tests/test_bot_tools_v12.py
+++ b/tests/test_bot_tools_v12.py
@@ -147,7 +147,7 @@ class TestBotToolDeclarationsV12:
             assert name in names, f"{name} not in TOOL_DECLARATIONS"
 
     def test_total_tool_count(self):
-        assert len(TOOL_DECLARATIONS) == 25
+        assert len(TOOL_DECLARATIONS) == 28
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f6_scheduled_digests.py
+++ b/tests/test_f6_scheduled_digests.py
@@ -38,7 +38,6 @@ from tg_parser.storage.sqlalchemy.digest_subscription_repo import (
 )
 from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
 
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PROMPTS_DIR = PROJECT_ROOT / "prompts"
 
@@ -270,9 +269,7 @@ class TestDigestSubscriptionRepo:
         assert fetched is not None
         assert fetched.name == sub.name
 
-    async def test_create_generates_uuid_when_id_omitted(
-        self, digest_repo, user_repo_for_digest
-    ):
+    async def test_create_generates_uuid_when_id_omitted(self, digest_repo, user_repo_for_digest):
         """When ``sub.id`` is empty, the DB default (gen_random_uuid) kicks in."""
         owner = await user_repo_for_digest.create_user("alice_auto_id")
         sub = _make_subscription(
@@ -290,9 +287,7 @@ class TestDigestSubscriptionRepo:
         result = await digest_repo.get("00000000-0000-0000-0000-000000000000")
         assert result is None
 
-    async def test_update_partial_fields_preserves_others(
-        self, digest_repo, user_repo_for_digest
-    ):
+    async def test_update_partial_fields_preserves_others(self, digest_repo, user_repo_for_digest):
         owner = await user_repo_for_digest.create_user("bob")
         sub = await digest_repo.create(_make_subscription(owner_id=owner.id))
         ts = datetime(2026, 4, 18, 12, 0, 0, tzinfo=UTC)
@@ -317,9 +312,7 @@ class TestDigestSubscriptionRepo:
         assert await digest_repo.delete(sub.id) is False
         assert await digest_repo.get(sub.id) is None
 
-    async def test_list_by_owner_filters_correctly(
-        self, digest_repo, user_repo_for_digest
-    ):
+    async def test_list_by_owner_filters_correctly(self, digest_repo, user_repo_for_digest):
         alice = await user_repo_for_digest.create_user("alice2")
         bob = await user_repo_for_digest.create_user("bob2")
         await digest_repo.create(_make_subscription(owner_id=alice.id, name="alice 1"))
@@ -333,16 +326,10 @@ class TestDigestSubscriptionRepo:
         assert len(bob_subs) == 1
         assert bob_subs[0].name == "bob 1"
 
-    async def test_list_active_excludes_paused(
-        self, digest_repo, user_repo_for_digest
-    ):
+    async def test_list_active_excludes_paused(self, digest_repo, user_repo_for_digest):
         owner = await user_repo_for_digest.create_user("dora")
-        active = await digest_repo.create(
-            _make_subscription(owner_id=owner.id, name="active")
-        )
-        paused = await digest_repo.create(
-            _make_subscription(owner_id=owner.id, name="paused")
-        )
+        active = await digest_repo.create(_make_subscription(owner_id=owner.id, name="active"))
+        paused = await digest_repo.create(_make_subscription(owner_id=owner.id, name="paused"))
         await digest_repo.update(paused.id, is_active=False)
 
         active_list = await digest_repo.list_active()
@@ -399,8 +386,7 @@ class TestDigestService:
             _make_processed_doc(
                 channel_id="ch1",
                 msg_id=str(i),
-                processed_at=datetime(2026, 4, 18, 10, i % 60, tzinfo=UTC)
-                + timedelta(minutes=i),
+                processed_at=datetime(2026, 4, 18, 10, i % 60, tzinfo=UTC) + timedelta(minutes=i),
             )
             for i in range(100)
         ]
@@ -430,9 +416,7 @@ class TestDigestService:
             msg_id="2",
             processed_at=datetime(2026, 4, 18, 12, 0, tzinfo=UTC),
         )
-        service, _processed, _llm, _update = _make_service(
-            docs_by_channel={"ch1": [doc1, doc2]}
-        )
+        service, _processed, _llm, _update = _make_service(docs_by_channel={"ch1": [doc1, doc2]})
         sub = _make_subscription(
             channel_ids=["ch1"],
             last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
@@ -482,9 +466,7 @@ class TestDigestService:
         service, _processed, llm, _update = _make_service(
             docs_by_channel={"ch1": [doc_at_cursor, doc_after]},
         )
-        sub = _make_subscription(
-            channel_ids=["ch1"], last_digest_cursor=cursor_time
-        )
+        sub = _make_subscription(channel_ids=["ch1"], last_digest_cursor=cursor_time)
         result = await service.generate(sub)
         assert result.docs_count == 1, "doc with processed_at == cursor must be skipped"
         rendered = llm.calls[0]["prompt"]
@@ -497,9 +479,7 @@ class TestDigestService:
             docs_by_channel={"ch1": []},
             sub_repo_update=update_mock,
         )
-        sub = _make_subscription(
-            channel_ids=["ch1"], last_digest_cursor=None
-        )
+        sub = _make_subscription(channel_ids=["ch1"], last_digest_cursor=None)
         bot = AsyncMock()
         bot.send_message = AsyncMock()
 
@@ -811,7 +791,7 @@ class TestDigestDelivery:
             message_max_chars=1000,
             max_message_parts=10,
         )
-        long_body = ("paragraph text\n" * 200)
+        long_body = "paragraph text\n" * 200
         result = DigestResult(
             subscription_id="x",
             chat_id=1,
@@ -832,7 +812,7 @@ class TestDigestDelivery:
             message_max_chars=200,
             max_message_parts=2,
         )
-        huge_body = ("paragraph text\n" * 500)
+        huge_body = "paragraph text\n" * 500
         result = DigestResult(
             subscription_id="x",
             chat_id=1,
@@ -1004,7 +984,10 @@ class TestBotDigestTools:
             chat_id=10,
         )
         assert "error" in result
-        assert "forbidden" in (result.get("channel_id") or "") or "no access" in result["error"].lower()
+        assert (
+            "forbidden" in (result.get("channel_id") or "")
+            or "no access" in result["error"].lower()
+        )
 
     async def test_list_digests_non_admin_sees_only_owned(
         self,
@@ -1018,9 +1001,7 @@ class TestBotDigestTools:
         await digest_repo.create(_make_subscription(owner_id=alice.id, name="a"))
         await digest_repo.create(_make_subscription(owner_id=bob.id, name="b"))
 
-        bob_user = _make_current_user(
-            bob.id, name=bob.name, role="user", allowed_channel_ids=set()
-        )
+        bob_user = _make_current_user(bob.id, name=bob.name, role="user", allowed_channel_ids=set())
         result = await _exec_list_digests({}, current_user=bob_user)
         names = {s["name"] for s in result["subscriptions"]}
         assert names == {"b"}
@@ -1055,9 +1036,7 @@ class TestBotDigestTools:
         bob = await user_repo_for_digest.create_user("bob_un")
         sub = await digest_repo.create(_make_subscription(owner_id=alice.id))
 
-        bob_user = _make_current_user(
-            bob.id, name=bob.name, role="user", allowed_channel_ids=set()
-        )
+        bob_user = _make_current_user(bob.id, name=bob.name, role="user", allowed_channel_ids=set())
         result = await _exec_unsubscribe_digest(
             {"subscription_id": sub.id},
             current_user=bob_user,
@@ -1213,9 +1192,7 @@ class TestSchedulerReconciliation:
 
         before = set(get_registered_digest_subscription_ids())
         owner = await user_repo_for_digest.create_user("alice_recon")
-        sub = await digest_repo.create(
-            _make_subscription(owner_id=owner.id, name="recon-add")
-        )
+        sub = await digest_repo.create(_make_subscription(owner_id=owner.id, name="recon-add"))
         try:
             stats = await reconcile_digest_subscriptions()
             assert sub.id in stats["added"] or sub.id in get_registered_digest_subscription_ids()
@@ -1240,9 +1217,7 @@ class TestSchedulerReconciliation:
         from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
 
         owner = await user_repo_for_digest.create_user("bob_recon")
-        sub = await digest_repo.create(
-            _make_subscription(owner_id=owner.id, name="recon-rm")
-        )
+        sub = await digest_repo.create(_make_subscription(owner_id=owner.id, name="recon-rm"))
         register_digest_subscription(sub)
         assert sub.id in get_registered_digest_subscription_ids()
 
@@ -1250,7 +1225,9 @@ class TestSchedulerReconciliation:
         await digest_repo.delete(sub.id)
         try:
             stats = await reconcile_digest_subscriptions()
-            assert sub.id in stats["removed"] or sub.id not in get_registered_digest_subscription_ids()
+            assert (
+                sub.id in stats["removed"] or sub.id not in get_registered_digest_subscription_ids()
+            )
             assert sub.id not in get_registered_digest_subscription_ids()
         finally:
             unregister_digest_subscription(sub.id)
@@ -1266,9 +1243,7 @@ class TestRunScheduledDigestsTask:
     async def test_run_returns_not_found_for_missing_subscription(self):
         from tg_parser.services.scheduler_service import run_scheduled_digests_task
 
-        result = await run_scheduled_digests_task(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        result = await run_scheduled_digests_task("00000000-0000-0000-0000-000000000000")
         assert result["status"] == "not_found"
 
     async def test_run_returns_inactive_for_paused_subscription(

--- a/tests/test_f6_scheduled_digests.py
+++ b/tests/test_f6_scheduled_digests.py
@@ -1,0 +1,633 @@
+"""
+F6 — Scheduled Digests test suite.
+
+Commit 1 scope: schema, repo, DigestService, prompt loader, LLM-stage extension.
+Commit 2 scope (added later): scheduler integration, bot delivery, bot/MCP tools,
+reconciliation.
+
+Postgres-backed tests are gated by ``TEST_POSTGRES=1`` (matches existing F4
+storage tests). Pure-logic tests (service mock-only, prompt loader, LLM scope)
+run unconditionally.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tg_parser.config.settings import LLM_SCOPES, LLMConfigManager, Settings
+from tg_parser.domain.models import (
+    DigestFormat,
+    DigestSubscription,
+    ProcessedDocument,
+)
+from tg_parser.processing.prompt_loader import PromptLoader
+from tg_parser.services.digest_service import (
+    DigestResult,
+    DigestService,
+    escape_markdown_v2,
+)
+from tg_parser.storage.sqlalchemy import init_ingestion_state_schema
+from tg_parser.storage.sqlalchemy.digest_subscription_repo import (
+    SADigestSubscriptionRepo,
+)
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = PROJECT_ROOT / "prompts"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_processed_doc(
+    channel_id: str = "ch1",
+    msg_id: str = "1",
+    processed_at: datetime | None = None,
+    summary: str | None = None,
+    text_clean: str | None = None,
+) -> ProcessedDocument:
+    return ProcessedDocument(
+        id=f"doc:tg:{channel_id}:post:{msg_id}",
+        source_ref=f"tg:{channel_id}:post:{msg_id}",
+        source_message_id=msg_id,
+        channel_id=channel_id,
+        processed_at=processed_at or datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC),
+        text_clean=text_clean or f"clean text {msg_id}",
+        summary=summary or f"summary {msg_id}",
+        topics=[],
+        entities=[],
+    )
+
+
+def _make_subscription(
+    *,
+    sub_id: str = "00000000-0000-0000-0000-0000000000aa",
+    owner_id: str = "00000000-0000-0000-0000-0000000000bb",
+    chat_id: int = 123,
+    name: str = "morning brief",
+    channel_ids: list[str] | None = None,
+    cron_expression: str = "0 9 * * *",
+    timezone: str = "UTC",
+    format: DigestFormat = DigestFormat.SUMMARY,
+    language: str = "ru",
+    is_active: bool = True,
+    last_sent_at: datetime | None = None,
+    last_digest_cursor: datetime | None = None,
+) -> DigestSubscription:
+    return DigestSubscription(
+        id=sub_id,
+        owner_id=owner_id,
+        chat_id=chat_id,
+        name=name,
+        channel_ids=channel_ids or ["ch1"],
+        cron_expression=cron_expression,
+        timezone=timezone,
+        format=format,
+        language=language,
+        is_active=is_active,
+        last_sent_at=last_sent_at,
+        last_digest_cursor=last_digest_cursor,
+    )
+
+
+class _FakeProcessedRepo:
+    """Tiny stub of ``ProcessedDocumentRepo.list_by_channel`` used by service tests."""
+
+    def __init__(self, docs_by_channel: dict[str, list[ProcessedDocument]]):
+        self._docs = docs_by_channel
+        self.calls: list[tuple[str, datetime | None, datetime | None]] = []
+
+    async def list_by_channel(
+        self,
+        channel_id: str,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> list[ProcessedDocument]:
+        self.calls.append((channel_id, from_date, to_date))
+        docs = list(self._docs.get(channel_id, []))
+        if from_date is not None:
+            docs = [d for d in docs if d.processed_at >= from_date]
+        if to_date is not None:
+            docs = [d for d in docs if d.processed_at <= to_date]
+        return docs
+
+
+class _FakeLLM:
+    """Captures (system, user, kwargs) and returns a canned response."""
+
+    def __init__(self, response: str = "## Канал ch1\n- факт 1"):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def generate(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        response_format: dict | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "system_prompt": system_prompt,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "response_format": response_format,
+            }
+        )
+        return self.response
+
+
+def _make_service(
+    *,
+    docs_by_channel: dict[str, list[ProcessedDocument]] | None = None,
+    llm_response: str = "## ch1\n- bullet",
+    max_docs_per_run: int = 50,
+    first_run_lookback_hours: int = 24,
+    sub_repo_update: AsyncMock | None = None,
+    message_max_chars: int = 4096,
+    max_message_parts: int = 10,
+) -> tuple[DigestService, _FakeProcessedRepo, _FakeLLM, AsyncMock]:
+    processed = _FakeProcessedRepo(docs_by_channel or {})
+    llm = _FakeLLM(llm_response)
+    sub_repo = MagicMock()
+    sub_repo.update = sub_repo_update or AsyncMock()
+    ingestion_repo = MagicMock()
+    loader = PromptLoader(prompts_dir=PROMPTS_DIR)
+    factory: Callable = lambda: llm  # noqa: E731
+    service = DigestService(
+        processed_repo=processed,
+        ingestion_repo=ingestion_repo,
+        subscription_repo=sub_repo,
+        prompt_loader=loader,
+        llm_client_factory=factory,
+        max_docs_per_run=max_docs_per_run,
+        first_run_lookback_hours=first_run_lookback_hours,
+        message_max_chars=message_max_chars,
+        max_message_parts=max_message_parts,
+    )
+    return service, processed, llm, sub_repo.update
+
+
+# ============================================================================
+# TestDigestSubscriptionRepo (Postgres)
+# ============================================================================
+
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+@pytest.fixture
+async def _digest_db(test_db):
+    """Ensure F4 + F6 schema present, then truncate digest_subscriptions."""
+    await init_ingestion_state_schema(test_db.ingestion_state_engine)
+    session = test_db.ingestion_state_session()
+    try:
+        from sqlalchemy import text
+
+        await session.execute(text("DELETE FROM digest_subscriptions"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db
+
+
+@pytest.fixture
+async def digest_repo(_digest_db):
+    session = _digest_db.ingestion_state_session()
+    try:
+        yield SADigestSubscriptionRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def user_repo_for_digest(_digest_db):
+    session = _digest_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+@pg_only
+class TestDigestSubscriptionRepo:
+    async def test_create_returns_uuid_and_persists(self, digest_repo, user_repo_for_digest):
+        owner = await user_repo_for_digest.create_user("alice")
+        sub = _make_subscription(
+            sub_id="00000000-0000-0000-0000-000000000000",  # ignored by INSERT
+            owner_id=owner.id,
+            channel_ids=["@durov", "@telegram"],
+        )
+        created = await digest_repo.create(sub)
+        assert created.id and created.id != sub.id  # server-assigned UUID
+        assert created.owner_id == owner.id
+        assert created.channel_ids == ["@durov", "@telegram"]
+        assert created.is_active is True
+        # idempotent get
+        fetched = await digest_repo.get(created.id)
+        assert fetched is not None
+        assert fetched.name == sub.name
+
+    async def test_get_returns_none_for_unknown_id(self, digest_repo):
+        result = await digest_repo.get("00000000-0000-0000-0000-000000000000")
+        assert result is None
+
+    async def test_update_partial_fields_preserves_others(
+        self, digest_repo, user_repo_for_digest
+    ):
+        owner = await user_repo_for_digest.create_user("bob")
+        sub = await digest_repo.create(_make_subscription(owner_id=owner.id))
+        ts = datetime(2026, 4, 18, 12, 0, 0, tzinfo=UTC)
+        updated = await digest_repo.update(
+            sub.id,
+            last_sent_at=ts,
+            last_digest_cursor=ts,
+            is_active=False,
+        )
+        assert updated is not None
+        assert updated.is_active is False
+        assert updated.last_sent_at == ts
+        assert updated.last_digest_cursor == ts
+        assert updated.name == sub.name
+        assert updated.cron_expression == sub.cron_expression
+        assert updated.channel_ids == sub.channel_ids
+
+    async def test_delete_returns_true_then_false(self, digest_repo, user_repo_for_digest):
+        owner = await user_repo_for_digest.create_user("charlie")
+        sub = await digest_repo.create(_make_subscription(owner_id=owner.id))
+        assert await digest_repo.delete(sub.id) is True
+        assert await digest_repo.delete(sub.id) is False
+        assert await digest_repo.get(sub.id) is None
+
+    async def test_list_by_owner_filters_correctly(
+        self, digest_repo, user_repo_for_digest
+    ):
+        alice = await user_repo_for_digest.create_user("alice2")
+        bob = await user_repo_for_digest.create_user("bob2")
+        await digest_repo.create(_make_subscription(owner_id=alice.id, name="alice 1"))
+        await digest_repo.create(_make_subscription(owner_id=alice.id, name="alice 2"))
+        await digest_repo.create(_make_subscription(owner_id=bob.id, name="bob 1"))
+
+        alice_subs = await digest_repo.list_by_owner(alice.id)
+        bob_subs = await digest_repo.list_by_owner(bob.id)
+        assert len(alice_subs) == 2
+        assert {s.name for s in alice_subs} == {"alice 1", "alice 2"}
+        assert len(bob_subs) == 1
+        assert bob_subs[0].name == "bob 1"
+
+    async def test_list_active_excludes_paused(
+        self, digest_repo, user_repo_for_digest
+    ):
+        owner = await user_repo_for_digest.create_user("dora")
+        active = await digest_repo.create(
+            _make_subscription(owner_id=owner.id, name="active")
+        )
+        paused = await digest_repo.create(
+            _make_subscription(owner_id=owner.id, name="paused")
+        )
+        await digest_repo.update(paused.id, is_active=False)
+
+        active_list = await digest_repo.list_active()
+        ids = {s.id for s in active_list}
+        assert active.id in ids
+        assert paused.id not in ids
+
+
+# ============================================================================
+# TestDigestService (pure logic with fakes)
+# ============================================================================
+
+
+class TestDigestService:
+    async def test_generate_empty_when_no_new_docs_returns_skipped(self):
+        service, _processed, llm, _update = _make_service(docs_by_channel={"ch1": []})
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        result = await service.generate(sub)
+        assert result.skipped is True
+        assert result.docs_count == 0
+        assert result.body_markdown == ""
+        assert llm.calls == [], "LLM must not be called on empty result"
+
+    async def test_generate_first_run_uses_lookback_window(self):
+        recent = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            processed_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+        old = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="2",
+            processed_at=datetime.now(UTC) - timedelta(days=5),
+        )
+        service, processed, llm, _update = _make_service(
+            docs_by_channel={"ch1": [recent, old]},
+            first_run_lookback_hours=24,
+        )
+        sub = _make_subscription(channel_ids=["ch1"], last_digest_cursor=None)
+        result = await service.generate(sub)
+        assert result.skipped is False
+        assert result.docs_count == 1, "Only the recent doc falls inside lookback window"
+        # confirm fake repo was queried with from_date ~ 24h ago
+        _, from_date, _ = processed.calls[0]
+        assert from_date is not None
+        assert from_date <= datetime.now(UTC) - timedelta(hours=23, minutes=30)
+        assert llm.calls, "LLM must be invoked for non-empty digest"
+
+    async def test_generate_caps_docs_at_max_per_run(self):
+        docs = [
+            _make_processed_doc(
+                channel_id="ch1",
+                msg_id=str(i),
+                processed_at=datetime(2026, 4, 18, 10, i % 60, tzinfo=UTC)
+                + timedelta(minutes=i),
+            )
+            for i in range(100)
+        ]
+        service, _processed, llm, _update = _make_service(
+            docs_by_channel={"ch1": docs},
+            max_docs_per_run=10,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        result = await service.generate(sub)
+        assert result.docs_count == 10
+        assert result.per_channel_counts == {"ch1": 10}
+        # LLM prompt should mention the per-channel total (100) AND the kept count (10)
+        rendered_user_prompt = llm.calls[0]["prompt"]
+        assert "10 of 100 new" in rendered_user_prompt
+
+    async def test_generate_updates_cursor_to_max_processed_at(self):
+        doc1 = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            processed_at=datetime(2026, 4, 18, 10, 0, tzinfo=UTC),
+        )
+        doc2 = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="2",
+            processed_at=datetime(2026, 4, 18, 12, 0, tzinfo=UTC),
+        )
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": [doc1, doc2]}
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        result = await service.generate(sub)
+        assert result.new_cursor == datetime(2026, 4, 18, 12, 0, tzinfo=UTC)
+
+    async def test_generate_groups_by_channel_in_prompt(self):
+        d1 = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            summary="alpha",
+            processed_at=datetime(2026, 4, 18, 10, tzinfo=UTC),
+        )
+        d2 = _make_processed_doc(
+            channel_id="ch2",
+            msg_id="2",
+            summary="beta",
+            processed_at=datetime(2026, 4, 18, 11, tzinfo=UTC),
+        )
+        service, _processed, llm, _update = _make_service(
+            docs_by_channel={"ch1": [d1], "ch2": [d2]},
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1", "ch2"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        await service.generate(sub)
+        rendered = llm.calls[0]["prompt"]
+        assert "## ch1" in rendered
+        assert "## ch2" in rendered
+        idx_ch1 = rendered.index("## ch1")
+        idx_ch2 = rendered.index("## ch2")
+        assert idx_ch1 < idx_ch2  # order matches subscription channel_ids
+
+    async def test_generate_strict_greater_than_cursor(self):
+        """processed_at == cursor must be excluded — strict-`>` filter."""
+        cursor_time = datetime(2026, 4, 18, 10, 0, 0, tzinfo=UTC)
+        doc_at_cursor = _make_processed_doc(
+            channel_id="ch1", msg_id="boundary", processed_at=cursor_time
+        )
+        doc_after = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="after",
+            processed_at=cursor_time + timedelta(seconds=1),
+        )
+        service, _processed, llm, _update = _make_service(
+            docs_by_channel={"ch1": [doc_at_cursor, doc_after]},
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"], last_digest_cursor=cursor_time
+        )
+        result = await service.generate(sub)
+        assert result.docs_count == 1, "doc with processed_at == cursor must be skipped"
+        rendered = llm.calls[0]["prompt"]
+        assert "after" in rendered
+        assert "boundary" not in rendered
+
+    async def test_run_for_subscription_skipped_advances_cursor_no_send(self):
+        update_mock = AsyncMock()
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": []},
+            sub_repo_update=update_mock,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"], last_digest_cursor=None
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock()
+
+        result = await service.run_for_subscription(sub, bot)
+        assert result.skipped is True
+        update_mock.assert_awaited()
+        # Skipped digests must NOT call send_message
+        bot.send_message.assert_not_called()
+        # cursor must have advanced (first-run safety)
+        kwargs = update_mock.await_args.kwargs
+        assert kwargs.get("last_digest_cursor") is not None
+        assert kwargs.get("last_sent_at") is not None
+
+    async def test_run_for_subscription_no_bot_skips_cursor_update(self):
+        update_mock = AsyncMock()
+        doc = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            processed_at=datetime(2026, 4, 18, 10, tzinfo=UTC),
+        )
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": [doc]},
+            sub_repo_update=update_mock,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        result = await service.run_for_subscription(sub, bot=None)
+        assert result.delivery_failed is True
+        assert result.delivery_error == "bot_unavailable"
+        update_mock.assert_not_called()
+
+    async def test_run_for_subscription_send_failure_skips_cursor(self):
+        update_mock = AsyncMock()
+        doc = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            processed_at=datetime(2026, 4, 18, 10, tzinfo=UTC),
+        )
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": [doc]},
+            sub_repo_update=update_mock,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock(side_effect=RuntimeError("network down"))
+
+        result = await service.run_for_subscription(sub, bot)
+        assert result.delivery_failed is True
+        assert "network down" in (result.delivery_error or "")
+        update_mock.assert_not_called()
+
+
+# ============================================================================
+# TestDigestPromptLoader
+# ============================================================================
+
+
+class TestDigestPromptLoader:
+    def test_digest_prompt_loads_successfully(self):
+        loader = PromptLoader(prompts_dir=PROMPTS_DIR)
+        cfg = loader.load("digest")
+        assert isinstance(cfg, dict)
+        assert "system" in cfg
+        assert "user" in cfg
+        assert "model" in cfg
+        assert isinstance(cfg["system"].get("prompt"), str)
+        assert isinstance(cfg["user"].get("template"), str)
+
+    def test_digest_prompt_includes_required_template_vars(self):
+        loader = PromptLoader(prompts_dir=PROMPTS_DIR)
+        cfg = loader.load("digest")
+        user_template = cfg["user"]["template"]
+        for var in ("{format}", "{language}", "{from_iso}", "{to_iso}", "{channels_block}"):
+            assert var in user_template, f"missing placeholder {var} in digest user template"
+
+
+# ============================================================================
+# TestDigestLLMScope
+# ============================================================================
+
+
+class TestDigestLLMScope:
+    def test_llm_scopes_includes_digest(self):
+        assert "digest" in LLM_SCOPES
+
+    def test_resolve_digest_falls_back_to_global(self):
+        LLMConfigManager.reset()
+        s = Settings(
+            llm_provider="openai",
+            llm_model="gpt-4o-mini",
+            openai_api_key="sk-test",
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
+        )
+        mgr = LLMConfigManager.get_instance(s)
+        try:
+            provider, _api_key, model = mgr.resolve("digest")
+            assert provider == "openai"
+            assert model == "gpt-4o-mini"
+        finally:
+            LLMConfigManager.reset()
+
+    def test_resolve_digest_uses_override_when_set(self):
+        LLMConfigManager.reset()
+        s = Settings(
+            llm_provider="openai",
+            llm_model="gpt-4o-mini",
+            openai_api_key="sk-test",
+            anthropic_api_key="ant-test",
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
+        )
+        mgr = LLMConfigManager.get_instance(s)
+        try:
+            mgr.set("digest", provider="anthropic", model="claude-haiku")
+            provider, _api_key, model = mgr.resolve("digest")
+            assert provider == "anthropic"
+            assert model == "claude-haiku"
+        finally:
+            LLMConfigManager.reset()
+
+    def test_resolve_digest_uses_static_stage_setting(self):
+        LLMConfigManager.reset()
+        s = Settings(
+            llm_provider="openai",
+            llm_model="gpt-4o-mini",
+            openai_api_key="sk-test",
+            gemini_api_key="g-test",
+            digest_llm_provider="gemini",
+            digest_llm_model="gemini-2.0-flash-exp",
+            telegram_api_id=1,
+            telegram_api_hash="h",
+            telegram_phone="+1",
+        )
+        mgr = LLMConfigManager.get_instance(s)
+        try:
+            provider, _api_key, model = mgr.resolve("digest")
+            assert provider == "gemini"
+            assert model == "gemini-2.0-flash-exp"
+        finally:
+            LLMConfigManager.reset()
+
+
+# ============================================================================
+# escape_markdown_v2 helper
+# ============================================================================
+
+
+class TestEscapeMarkdownV2:
+    @pytest.mark.parametrize(
+        "raw,expected_substring",
+        [
+            ("@my_channel", "@my\\_channel"),
+            ("hello.world", "hello\\.world"),
+            ("[link](url)", "\\[link\\]\\(url\\)"),
+            ("a*b_c", "a\\*b\\_c"),
+            ("price = 5+3-1!", "price \\= 5\\+3\\-1\\!"),
+        ],
+    )
+    def test_escape_special_chars(self, raw: str, expected_substring: str):
+        out = escape_markdown_v2(raw)
+        assert expected_substring in out
+
+    def test_empty_string(self):
+        assert escape_markdown_v2("") == ""

--- a/tests/test_f6_scheduled_digests.py
+++ b/tests/test_f6_scheduled_digests.py
@@ -70,7 +70,7 @@ def _make_processed_doc(
 
 def _make_subscription(
     *,
-    sub_id: str = "00000000-0000-0000-0000-0000000000aa",
+    sub_id: str | None = None,
     owner_id: str = "00000000-0000-0000-0000-0000000000bb",
     chat_id: int = 123,
     name: str = "morning brief",
@@ -83,8 +83,10 @@ def _make_subscription(
     last_sent_at: datetime | None = None,
     last_digest_cursor: datetime | None = None,
 ) -> DigestSubscription:
+    import uuid as _uuid
+
     return DigestSubscription(
-        id=sub_id,
+        id=sub_id if sub_id is not None else str(_uuid.uuid4()),
         owner_id=owner_id,
         chat_id=chat_id,
         name=name,
@@ -146,6 +148,28 @@ class _FakeLLM:
             }
         )
         return self.response
+
+
+def _make_current_user(
+    user_id: str,
+    *,
+    name: str = "test",
+    role: str = "admin",
+    allowed_channel_ids: set[str] | None = None,
+    max_channels: int = 999,
+):
+    """Wrapper around ``CurrentUser`` that defaults the F4-required fields."""
+    from tg_parser.auth.models import CurrentUser
+
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=(
+            None if allowed_channel_ids is None and role == "admin" else allowed_channel_ids
+        ),
+        max_channels=max_channels,
+    )
 
 
 def _make_service(
@@ -230,13 +254,14 @@ async def user_repo_for_digest(_digest_db):
 class TestDigestSubscriptionRepo:
     async def test_create_returns_uuid_and_persists(self, digest_repo, user_repo_for_digest):
         owner = await user_repo_for_digest.create_user("alice")
+        # Caller-supplied id is preserved so the scheduler and DB stay in sync.
         sub = _make_subscription(
-            sub_id="00000000-0000-0000-0000-000000000000",  # ignored by INSERT
+            sub_id="11111111-2222-3333-4444-555555555555",
             owner_id=owner.id,
             channel_ids=["@durov", "@telegram"],
         )
         created = await digest_repo.create(sub)
-        assert created.id and created.id != sub.id  # server-assigned UUID
+        assert created.id == sub.id
         assert created.owner_id == owner.id
         assert created.channel_ids == ["@durov", "@telegram"]
         assert created.is_active is True
@@ -244,6 +269,22 @@ class TestDigestSubscriptionRepo:
         fetched = await digest_repo.get(created.id)
         assert fetched is not None
         assert fetched.name == sub.name
+
+    async def test_create_generates_uuid_when_id_omitted(
+        self, digest_repo, user_repo_for_digest
+    ):
+        """When ``sub.id`` is empty, the DB default (gen_random_uuid) kicks in."""
+        owner = await user_repo_for_digest.create_user("alice_auto_id")
+        sub = _make_subscription(
+            sub_id="",
+            owner_id=owner.id,
+            channel_ids=["@durov"],
+        )
+        created = await digest_repo.create(sub)
+        assert created.id and created.id != ""
+        assert created.id != sub.id  # server-assigned UUID
+        fetched = await digest_repo.get(created.id)
+        assert fetched is not None
 
     async def test_get_returns_none_for_unknown_id(self, digest_repo):
         result = await digest_repo.get("00000000-0000-0000-0000-000000000000")
@@ -631,3 +672,614 @@ class TestEscapeMarkdownV2:
 
     def test_empty_string(self):
         assert escape_markdown_v2("") == ""
+
+
+# ============================================================================
+# Commit 2 — Scheduler integration, delivery, bot/MCP tools, reconciliation
+# ============================================================================
+
+
+# ----------------------------------------------------------------------------
+# TestSchedulerCronIntegration
+# ----------------------------------------------------------------------------
+
+
+class TestSchedulerCronIntegration:
+    """Cron-trigger plumbing on top of ``BackgroundScheduler``."""
+
+    def test_add_cron_task_registers_with_correct_trigger(self):
+        from tg_parser.services.background_scheduler import BackgroundScheduler
+
+        scheduler = BackgroundScheduler()
+
+        async def _noop():
+            return None
+
+        job = scheduler.add_cron_task(
+            task_id="test_cron",
+            func=_noop,
+            cron_expression="0 9 * * *",
+            timezone="Europe/Moscow",
+        )
+        assert job is not None
+        from apscheduler.triggers.cron import CronTrigger
+
+        assert isinstance(job.trigger, CronTrigger)
+        # Trigger must be configured with the requested IANA timezone
+        assert "Moscow" in str(job.trigger.timezone)
+
+    def test_add_cron_task_invalid_expression_raises(self):
+        from tg_parser.services.background_scheduler import BackgroundScheduler
+
+        scheduler = BackgroundScheduler()
+        with pytest.raises(ValueError, match="invalid cron"):
+            scheduler.add_cron_task(
+                task_id="bad",
+                func=lambda: None,
+                cron_expression="not a cron",
+                timezone="UTC",
+            )
+
+    def test_add_cron_task_invalid_timezone_raises(self):
+        from tg_parser.services.background_scheduler import BackgroundScheduler
+
+        scheduler = BackgroundScheduler()
+        with pytest.raises(ValueError, match="invalid cron"):
+            scheduler.add_cron_task(
+                task_id="badtz",
+                func=lambda: None,
+                cron_expression="0 9 * * *",
+                timezone="Mars/Olympus",
+            )
+
+    def test_register_digest_subscription_creates_job(self):
+        from tg_parser.services.background_scheduler import (
+            BackgroundScheduler,
+            register_digest_subscription,
+        )
+
+        sub = _make_subscription(sub_id="11111111-1111-1111-1111-111111111111")
+        scheduler = BackgroundScheduler()
+        job = register_digest_subscription(sub, scheduler)
+        assert job is not None
+        assert job.id == f"digest:{sub.id}"
+
+    def test_register_inactive_subscription_skipped(self):
+        from tg_parser.services.background_scheduler import (
+            BackgroundScheduler,
+            register_digest_subscription,
+        )
+
+        sub = _make_subscription(
+            sub_id="22222222-2222-2222-2222-222222222222",
+            is_active=False,
+        )
+        scheduler = BackgroundScheduler()
+        job = register_digest_subscription(sub, scheduler)
+        assert job is None
+
+    def test_unregister_removes_job(self):
+        from tg_parser.services.background_scheduler import (
+            BackgroundScheduler,
+            register_digest_subscription,
+            unregister_digest_subscription,
+        )
+
+        sub = _make_subscription(sub_id="33333333-3333-3333-3333-333333333333")
+        scheduler = BackgroundScheduler()
+        register_digest_subscription(sub, scheduler)
+        assert unregister_digest_subscription(sub.id, scheduler) is True
+        # idempotent: second call returns False
+        assert unregister_digest_subscription(sub.id, scheduler) is False
+
+
+# ----------------------------------------------------------------------------
+# TestDigestDelivery
+# ----------------------------------------------------------------------------
+
+
+class TestDigestDelivery:
+    """``DigestService.deliver`` → aiogram Bot interaction."""
+
+    async def test_deliver_calls_send_message_with_markdown_v2(self):
+        from aiogram.enums import ParseMode
+
+        service, _processed, _llm, _update = _make_service()
+        result = DigestResult(
+            subscription_id="x",
+            chat_id=42,
+            title="My Digest",
+            body_markdown="**Hello** _world_",
+            docs_count=3,
+            new_cursor=datetime(2026, 4, 18, tzinfo=UTC),
+            skipped=False,
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock()
+
+        await service.deliver(bot, result)
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["chat_id"] == 42
+        assert kwargs["parse_mode"] == ParseMode.MARKDOWN_V2
+        # Body must be MarkdownV2-escaped
+        assert "\\*" in kwargs["text"]
+        assert "\\_" in kwargs["text"]
+
+    async def test_deliver_splits_long_messages(self):
+        service, _processed, _llm, _update = _make_service(
+            message_max_chars=1000,
+            max_message_parts=10,
+        )
+        long_body = ("paragraph text\n" * 200)
+        result = DigestResult(
+            subscription_id="x",
+            chat_id=1,
+            title="t",
+            body_markdown=long_body,
+            docs_count=1,
+            new_cursor=None,
+            skipped=False,
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock()
+
+        await service.deliver(bot, result)
+        assert bot.send_message.await_count >= 2
+
+    async def test_deliver_falls_back_to_document_when_too_many_parts(self):
+        service, _processed, _llm, _update = _make_service(
+            message_max_chars=200,
+            max_message_parts=2,
+        )
+        huge_body = ("paragraph text\n" * 500)
+        result = DigestResult(
+            subscription_id="x",
+            chat_id=1,
+            title="huge",
+            body_markdown=huge_body,
+            docs_count=99,
+            new_cursor=None,
+            skipped=False,
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock()
+        bot.send_document = AsyncMock()
+
+        await service.deliver(bot, result)
+        bot.send_message.assert_not_called()
+        bot.send_document.assert_awaited_once()
+
+    async def test_deliver_advances_cursor_only_after_success(self):
+        update_mock = AsyncMock()
+        doc = _make_processed_doc(
+            channel_id="ch1",
+            msg_id="1",
+            processed_at=datetime(2026, 4, 18, 12, tzinfo=UTC),
+        )
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": [doc]},
+            sub_repo_update=update_mock,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 17, tzinfo=UTC),
+        )
+        bot = AsyncMock()
+        bot.send_message = AsyncMock()
+
+        await service.run_for_subscription(sub, bot)
+        update_mock.assert_awaited()
+        kwargs = update_mock.await_args.kwargs
+        assert kwargs.get("last_digest_cursor") == datetime(2026, 4, 18, 12, tzinfo=UTC)
+
+
+# ----------------------------------------------------------------------------
+# TestBotRuntime
+# ----------------------------------------------------------------------------
+
+
+class TestBotRuntime:
+    """Process-local Bot singleton used by background tasks."""
+
+    def setup_method(self):
+        from tg_parser.bot.runtime import clear_bot
+
+        clear_bot()
+
+    def teardown_method(self):
+        from tg_parser.bot.runtime import clear_bot
+
+        clear_bot()
+
+    def test_get_bot_returns_none_when_not_set(self):
+        from tg_parser.bot.runtime import get_bot
+
+        assert get_bot() is None
+
+    def test_set_and_get_bot_round_trip(self):
+        from tg_parser.bot.runtime import get_bot, set_bot
+
+        sentinel = object()
+        set_bot(sentinel)  # type: ignore[arg-type]
+        assert get_bot() is sentinel
+
+    def test_clear_bot_drops_reference(self):
+        from tg_parser.bot.runtime import clear_bot, get_bot, set_bot
+
+        set_bot(object())  # type: ignore[arg-type]
+        clear_bot()
+        assert get_bot() is None
+
+
+# ----------------------------------------------------------------------------
+# TestBotDigestTools
+# ----------------------------------------------------------------------------
+
+
+@pg_only
+class TestBotDigestTools:
+    """End-to-end exercise of the bot-tool executors against PostgreSQL."""
+
+    async def test_subscribe_digest_persists_and_registers(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_subscribe_digest
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            unregister_digest_subscription,
+        )
+
+        owner = await user_repo_for_digest.create_user("alice_bot")
+        user = _make_current_user(owner.id, name=owner.name, role="admin")
+
+        result = await _exec_subscribe_digest(
+            {
+                "name": "morning",
+                "channel_ids": ["@durov"],
+                "cron_expression": "0 9 * * *",
+                "timezone": "Europe/Moscow",
+                "format": "summary",
+            },
+            current_user=user,
+            bot=None,
+            chat_id=12345,
+        )
+        assert "subscription_id" in result, result
+        sub_id = result["subscription_id"]
+
+        # Persisted in DB (use existing repo fixture)
+        persisted = await digest_repo.get(sub_id)
+        assert persisted is not None
+        assert persisted.name == "morning"
+        assert persisted.channel_ids == ["durov"]
+
+        assert sub_id in get_registered_digest_subscription_ids()
+        unregister_digest_subscription(sub_id)
+
+    async def test_subscribe_digest_validates_cron_expression(
+        self,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_subscribe_digest
+
+        owner = await user_repo_for_digest.create_user("bob_bot")
+        user = _make_current_user(owner.id, name=owner.name, role="admin")
+        result = await _exec_subscribe_digest(
+            {
+                "name": "bad-cron",
+                "channel_ids": ["@x"],
+                "cron_expression": "this is not cron",
+            },
+            current_user=user,
+            bot=None,
+            chat_id=10,
+        )
+        assert "error" in result
+        assert "cron" in result["error"].lower()
+
+    async def test_subscribe_digest_rejects_unauthorized_channel(
+        self,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_subscribe_digest
+
+        owner = await user_repo_for_digest.create_user("carol_bot")
+        # Restricted user — only allowed to access "owned"
+        user = _make_current_user(
+            owner.id,
+            name=owner.name,
+            role="user",
+            allowed_channel_ids={"owned"},
+        )
+        result = await _exec_subscribe_digest(
+            {
+                "name": "denied",
+                "channel_ids": ["@forbidden"],
+            },
+            current_user=user,
+            bot=None,
+            chat_id=10,
+        )
+        assert "error" in result
+        assert "forbidden" in (result.get("channel_id") or "") or "no access" in result["error"].lower()
+
+    async def test_list_digests_non_admin_sees_only_owned(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_list_digests
+
+        alice = await user_repo_for_digest.create_user("alice_list")
+        bob = await user_repo_for_digest.create_user("bob_list")
+        await digest_repo.create(_make_subscription(owner_id=alice.id, name="a"))
+        await digest_repo.create(_make_subscription(owner_id=bob.id, name="b"))
+
+        bob_user = _make_current_user(
+            bob.id, name=bob.name, role="user", allowed_channel_ids=set()
+        )
+        result = await _exec_list_digests({}, current_user=bob_user)
+        names = {s["name"] for s in result["subscriptions"]}
+        assert names == {"b"}
+
+    async def test_list_digests_admin_sees_all(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_list_digests
+
+        alice = await user_repo_for_digest.create_user("alice_listall")
+        bob = await user_repo_for_digest.create_user("bob_listall")
+        await digest_repo.create(_make_subscription(owner_id=alice.id, name="a"))
+        b_sub = await digest_repo.create(_make_subscription(owner_id=bob.id, name="b"))
+        await digest_repo.update(b_sub.id, is_active=False)
+
+        admin = _make_current_user(alice.id, name="admin", role="admin")
+        result = await _exec_list_digests({}, current_user=admin)
+        assert result["count"] == 2
+        names = {s["name"] for s in result["subscriptions"]}
+        assert names == {"a", "b"}
+
+    async def test_unsubscribe_digest_ownership_enforced(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.bot.tools import _exec_unsubscribe_digest
+
+        alice = await user_repo_for_digest.create_user("alice_un")
+        bob = await user_repo_for_digest.create_user("bob_un")
+        sub = await digest_repo.create(_make_subscription(owner_id=alice.id))
+
+        bob_user = _make_current_user(
+            bob.id, name=bob.name, role="user", allowed_channel_ids=set()
+        )
+        result = await _exec_unsubscribe_digest(
+            {"subscription_id": sub.id},
+            current_user=bob_user,
+        )
+        assert "error" in result
+        # Owner can delete
+        alice_user = _make_current_user(
+            alice.id, name=alice.name, role="user", allowed_channel_ids=set()
+        )
+        ok = await _exec_unsubscribe_digest(
+            {"subscription_id": sub.id},
+            current_user=alice_user,
+        )
+        assert ok.get("deleted") is True
+
+
+# ----------------------------------------------------------------------------
+# TestMCPDigestTools
+# ----------------------------------------------------------------------------
+
+
+@pg_only
+class TestMCPDigestTools:
+    async def test_mcp_subscribe_digest_returns_subscription(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from unittest.mock import patch
+
+        from tg_parser.mcp_server import subscribe_digest
+        from tg_parser.services.background_scheduler import unregister_digest_subscription
+
+        owner = await user_repo_for_digest.create_user("alice_mcp")
+        user = _make_current_user(owner.id, name=owner.name, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await subscribe_digest(
+                name="weekday",
+                channel_ids=["@durov"],
+                chat_id=99,
+                cron_expression="0 9 * * 1-5",
+                timezone="UTC",
+            )
+        assert result.success is True
+        assert result.subscription is not None
+        assert result.subscription.cron_expression == "0 9 * * 1-5"
+        # Cleanup scheduler job to keep singleton clean
+        unregister_digest_subscription(result.subscription.id)
+
+    async def test_mcp_subscribe_digest_validates_cron(
+        self,
+        user_repo_for_digest,
+    ):
+        from unittest.mock import patch
+
+        from tg_parser.mcp_server import subscribe_digest
+
+        owner = await user_repo_for_digest.create_user("bob_mcp")
+        user = _make_current_user(owner.id, name=owner.name, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await subscribe_digest(
+                name="bad",
+                channel_ids=["@x"],
+                chat_id=1,
+                cron_expression="garbage",
+            )
+        assert result.success is False
+        assert "cron" in result.message.lower()
+
+    async def test_mcp_subscribe_digest_channel_ownership_enforced(
+        self,
+        user_repo_for_digest,
+    ):
+        from unittest.mock import patch
+
+        from tg_parser.mcp_server import subscribe_digest
+
+        owner = await user_repo_for_digest.create_user("carol_mcp")
+        user = _make_current_user(
+            owner.id,
+            name=owner.name,
+            role="user",
+            allowed_channel_ids={"only_this"},
+        )
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await subscribe_digest(
+                name="denied",
+                channel_ids=["@forbidden"],
+                chat_id=1,
+            )
+        assert result.success is False
+        assert "forbidden" in result.message.lower() or "no access" in result.message.lower()
+
+    async def test_mcp_list_digests_admin_sees_all(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from unittest.mock import patch
+
+        from tg_parser.mcp_server import list_digests
+
+        alice = await user_repo_for_digest.create_user("alice_mcp_list")
+        bob = await user_repo_for_digest.create_user("bob_mcp_list")
+        await digest_repo.create(_make_subscription(owner_id=alice.id, name="ml-a"))
+        b_sub = await digest_repo.create(_make_subscription(owner_id=bob.id, name="ml-b"))
+        await digest_repo.update(b_sub.id, is_active=False)
+
+        admin = _make_current_user(alice.id, name="admin", role="admin")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=admin)):
+            result = await list_digests()
+        names = {s.name for s in result.subscriptions}
+        assert {"ml-a", "ml-b"} <= names
+
+    async def test_mcp_unsubscribe_digest_returns_404_for_unknown_id(
+        self,
+        user_repo_for_digest,
+    ):
+        from unittest.mock import patch
+
+        from tg_parser.mcp_server import unsubscribe_digest
+
+        owner = await user_repo_for_digest.create_user("dora_mcp")
+        user = _make_current_user(owner.id, name=owner.name, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await unsubscribe_digest(
+                subscription_id="00000000-0000-0000-0000-000000000000",
+            )
+        assert result.success is False
+        assert "not found" in result.message.lower()
+
+
+# ----------------------------------------------------------------------------
+# TestSchedulerReconciliation
+# ----------------------------------------------------------------------------
+
+
+@pg_only
+class TestSchedulerReconciliation:
+    async def test_reconciliation_adds_new_subscriptions_without_restart(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            unregister_digest_subscription,
+        )
+        from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
+
+        before = set(get_registered_digest_subscription_ids())
+        owner = await user_repo_for_digest.create_user("alice_recon")
+        sub = await digest_repo.create(
+            _make_subscription(owner_id=owner.id, name="recon-add")
+        )
+        try:
+            stats = await reconcile_digest_subscriptions()
+            assert sub.id in stats["added"] or sub.id in get_registered_digest_subscription_ids()
+            registered = get_registered_digest_subscription_ids()
+            assert sub.id in registered
+        finally:
+            unregister_digest_subscription(sub.id)
+            # Restore baseline (best-effort)
+            for sid in get_registered_digest_subscription_ids() - before:
+                unregister_digest_subscription(sid)
+
+    async def test_reconciliation_removes_deleted_subscriptions(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            register_digest_subscription,
+            unregister_digest_subscription,
+        )
+        from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
+
+        owner = await user_repo_for_digest.create_user("bob_recon")
+        sub = await digest_repo.create(
+            _make_subscription(owner_id=owner.id, name="recon-rm")
+        )
+        register_digest_subscription(sub)
+        assert sub.id in get_registered_digest_subscription_ids()
+
+        # Drop from DB without unregistering scheduler job
+        await digest_repo.delete(sub.id)
+        try:
+            stats = await reconcile_digest_subscriptions()
+            assert sub.id in stats["removed"] or sub.id not in get_registered_digest_subscription_ids()
+            assert sub.id not in get_registered_digest_subscription_ids()
+        finally:
+            unregister_digest_subscription(sub.id)
+
+
+# ----------------------------------------------------------------------------
+# TestRunScheduledDigestsTask (PG, integration)
+# ----------------------------------------------------------------------------
+
+
+@pg_only
+class TestRunScheduledDigestsTask:
+    async def test_run_returns_not_found_for_missing_subscription(self):
+        from tg_parser.services.scheduler_service import run_scheduled_digests_task
+
+        result = await run_scheduled_digests_task(
+            "00000000-0000-0000-0000-000000000000"
+        )
+        assert result["status"] == "not_found"
+
+    async def test_run_returns_inactive_for_paused_subscription(
+        self,
+        digest_repo,
+        user_repo_for_digest,
+    ):
+        from tg_parser.services.scheduler_service import run_scheduled_digests_task
+
+        owner = await user_repo_for_digest.create_user("alice_run")
+        sub = await digest_repo.create(_make_subscription(owner_id=owner.id))
+        await digest_repo.update(sub.id, is_active=False)
+        result = await run_scheduled_digests_task(sub.id)
+        assert result["status"] == "inactive"

--- a/tests/test_f6_scheduled_digests.py
+++ b/tests/test_f6_scheduled_digests.py
@@ -185,12 +185,10 @@ def _make_service(
     llm = _FakeLLM(llm_response)
     sub_repo = MagicMock()
     sub_repo.update = sub_repo_update or AsyncMock()
-    ingestion_repo = MagicMock()
     loader = PromptLoader(prompts_dir=PROMPTS_DIR)
     factory: Callable = lambda: llm  # noqa: E731
     service = DigestService(
         processed_repo=processed,
-        ingestion_repo=ingestion_repo,
         subscription_repo=sub_repo,
         prompt_loader=loader,
         llm_client_factory=factory,
@@ -404,6 +402,39 @@ class TestDigestService:
         # LLM prompt should mention the per-channel total (100) AND the kept count (10)
         rendered_user_prompt = llm.calls[0]["prompt"]
         assert "10 of 100 new" in rendered_user_prompt
+
+    async def test_generate_cap_keeps_oldest_so_backlog_resumes_next_tick(self):
+        """Regression: with > max_docs new docs, cursor must advance only past
+        the oldest slice we actually delivered — leftover newer docs must be
+        picked up on the next tick, not silently skipped.
+        """
+        docs = [
+            _make_processed_doc(
+                channel_id="ch1",
+                msg_id=str(i),
+                processed_at=datetime(2026, 4, 18, 10, 0, tzinfo=UTC) + timedelta(minutes=i),
+            )
+            for i in range(5)
+        ]
+        service, _processed, _llm, _update = _make_service(
+            docs_by_channel={"ch1": docs},
+            max_docs_per_run=2,
+        )
+        sub = _make_subscription(
+            channel_ids=["ch1"],
+            last_digest_cursor=datetime(2026, 4, 18, 9, 0, tzinfo=UTC),
+        )
+        result = await service.generate(sub)
+
+        assert result.docs_count == 2, "kept slice must equal max_docs_per_run"
+        # Cursor must equal the timestamp of the LAST kept (oldest-slice) doc
+        # so the next tick fetches the remaining three with strict `>`.
+        assert result.new_cursor == docs[1].processed_at, (
+            f"cursor must land on doc[1] (last kept), got {result.new_cursor}"
+        )
+        assert docs[2].processed_at > result.new_cursor, (
+            "leftover docs must be strictly newer than the new cursor"
+        )
 
     async def test_generate_updates_cursor_to_max_processed_at(self):
         doc1 = _make_processed_doc(

--- a/tg_parser/bot/main.py
+++ b/tg_parser/bot/main.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import sys
 from asyncio import StreamReader, StreamWriter
+from typing import Any
 
 import structlog
 from aiogram import Bot, Dispatcher
@@ -153,6 +154,10 @@ async def run_bot() -> None:
         default=DefaultBotProperties(parse_mode="HTML"),
     )
 
+    from tg_parser.bot.runtime import set_bot
+
+    set_bot(bot)
+
     dp = Dispatcher()
 
     # Register middleware (order matters: logging first, then auth, then rate limit)
@@ -171,6 +176,11 @@ async def run_bot() -> None:
 
     health_server = await _start_health_server()
 
+    digest_scheduler = None
+    digest_reconcile_task: asyncio.Task[None] | None = None
+    if settings.digest_scheduler_enabled:
+        digest_scheduler, digest_reconcile_task = await _start_digest_scheduler()
+
     try:
         await dp.start_polling(
             bot,
@@ -179,12 +189,84 @@ async def run_bot() -> None:
         )
     finally:
         logger.info("bot_shutting_down")
+        if digest_reconcile_task is not None:
+            digest_reconcile_task.cancel()
+            try:
+                await digest_reconcile_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if digest_scheduler is not None:
+            try:
+                digest_scheduler.shutdown(wait=False)
+            except Exception:
+                logger.warning("digest_scheduler_shutdown_failed", exc_info=True)
+        from tg_parser.bot.runtime import clear_bot
+
+        clear_bot()
         if health_server:
             health_server.close()
             await health_server.wait_closed()
         await agent.close()
         await Database.close_instance()
         logger.info("bot_stopped")
+
+
+async def _start_digest_scheduler() -> tuple[Any, asyncio.Task[None] | None]:
+    """Initialize the F6 digest scheduler inside the bot process.
+
+    Returns ``(scheduler, reconciliation_task)``. Scheduler is started and the
+    initial set of active subscriptions registered before the polling loop
+    begins. The reconciliation task wakes up every
+    ``digest_refresh_interval`` seconds and diffs DB ↔ scheduler so MCP-side
+    create/delete (or another bot replica) propagate without a restart.
+    """
+    from tg_parser.config import settings
+    from tg_parser.services.background_scheduler import (
+        get_scheduler,
+        register_digest_subscription,
+    )
+    from tg_parser.services.db_context import digest_subscription_repo
+    from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
+
+    scheduler = get_scheduler()
+    if not scheduler.is_running:
+        scheduler.start()
+
+    try:
+        async with digest_subscription_repo() as (repo, _db):
+            active = await repo.list_active()
+    except Exception:
+        logger.exception("digest_scheduler_initial_load_failed")
+        active = []
+
+    for sub in active:
+        try:
+            register_digest_subscription(sub, scheduler)
+        except ValueError as exc:
+            logger.warning(
+                "digest_subscription_invalid_skip",
+                subscription_id=sub.id,
+                error=str(exc),
+            )
+
+    logger.info(
+        "digest_scheduler_started",
+        active_subscriptions=len(active),
+        refresh_interval=settings.digest_refresh_interval,
+    )
+
+    async def _reconcile_loop() -> None:
+        while True:
+            try:
+                await asyncio.sleep(settings.digest_refresh_interval)
+                await reconcile_digest_subscriptions()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("digest_reconcile_tick_failed")
+
+    task = asyncio.create_task(_reconcile_loop(), name="digest-reconcile-loop")
+    return scheduler, task
 
 
 def run_bot_sync() -> None:

--- a/tg_parser/bot/runtime.py
+++ b/tg_parser/bot/runtime.py
@@ -20,10 +20,10 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-_bot: "Bot | None" = None
+_bot: Bot | None = None
 
 
-def set_bot(bot: "Bot") -> None:
+def set_bot(bot: Bot) -> None:
     """Register the current ``Bot`` instance for background tasks.
 
     Idempotent: replacing an existing reference logs a debug message but does
@@ -35,7 +35,7 @@ def set_bot(bot: "Bot") -> None:
     _bot = bot
 
 
-def get_bot() -> "Bot | None":
+def get_bot() -> Bot | None:
     """Return the registered ``Bot`` instance, or ``None`` when not started."""
     return _bot
 

--- a/tg_parser/bot/runtime.py
+++ b/tg_parser/bot/runtime.py
@@ -1,0 +1,49 @@
+"""
+Process-local Bot singleton (F6).
+
+Background tasks (e.g. scheduled-digest delivery) need access to the running
+``aiogram.Bot`` instance to push messages to chats outside the polling loop.
+The bot stores itself here on startup; background tasks fetch the reference
+on demand. If no bot is registered, ``get_bot`` returns ``None`` and the
+caller is expected to skip delivery (and *not* advance the digest cursor).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+
+
+logger = structlog.get_logger(__name__)
+
+_bot: "Bot | None" = None
+
+
+def set_bot(bot: "Bot") -> None:
+    """Register the current ``Bot`` instance for background tasks.
+
+    Idempotent: replacing an existing reference logs a debug message but does
+    not raise. Useful for test fixtures that swap the runtime bot.
+    """
+    global _bot
+    if _bot is not None and _bot is not bot:
+        logger.debug("bot_runtime_replacing_existing_bot")
+    _bot = bot
+
+
+def get_bot() -> "Bot | None":
+    """Return the registered ``Bot`` instance, or ``None`` when not started."""
+    return _bot
+
+
+def clear_bot() -> None:
+    """Drop the registered ``Bot`` reference (call on shutdown)."""
+    global _bot
+    _bot = None
+
+
+__all__ = ["clear_bot", "get_bot", "set_bot"]

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -24,7 +24,7 @@ logger = structlog.get_logger(__name__)
 TG_BOT_DOCUMENT_LIMIT_BYTES: int = 50 * 1024 * 1024
 
 # Tools that need access to the bot instance / chat_id (e.g. to upload files).
-_TOOLS_NEEDING_BOT_CONTEXT: set[str] = {"export_channel"}
+_TOOLS_NEEDING_BOT_CONTEXT: set[str] = {"export_channel", "subscribe_digest"}
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -568,6 +568,79 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
                 },
             },
             "required": ["channel_id"],
+        },
+    },
+    {
+        "name": "subscribe_digest",
+        "description": (
+            "Create a recurring digest subscription (F6). The bot will summarize "
+            "new processed documents from the selected channels and deliver them "
+            "to the current chat on the cron schedule. Cron expression is the "
+            "standard 5-field format (minute hour day month weekday). Default "
+            "schedule is '0 9 * * *' (daily at 09:00 in the chosen timezone). "
+            "format controls style: 'summary' (1-2 paragraphs per channel), "
+            "'bullets' (one-line bullets), 'detailed' (paragraph + key quotes)."
+        ),
+        "parameters": {
+            "type": "OBJECT",
+            "properties": {
+                "name": {
+                    "type": "STRING",
+                    "description": "Subscription name (used by list/unsubscribe)",
+                },
+                "channel_ids": {
+                    "type": "ARRAY",
+                    "items": {"type": "STRING"},
+                    "description": "Channel IDs (or @usernames) to include in the digest",
+                },
+                "cron_expression": {
+                    "type": "STRING",
+                    "description": "5-field cron expression (default '0 9 * * *')",
+                },
+                "timezone": {
+                    "type": "STRING",
+                    "description": "IANA timezone such as 'Europe/Moscow' (default 'UTC')",
+                },
+                "format": {
+                    "type": "STRING",
+                    "enum": ["summary", "bullets", "detailed"],
+                    "description": "Digest formatting style (default 'summary')",
+                },
+                "language": {
+                    "type": "STRING",
+                    "description": "Output language code (default 'ru')",
+                },
+            },
+            "required": ["name", "channel_ids"],
+        },
+    },
+    {
+        "name": "list_digests",
+        "description": (
+            "List the caller's digest subscriptions (F6). Admins see every "
+            "subscription, regular users see only their own."
+        ),
+        "parameters": {
+            "type": "OBJECT",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "unsubscribe_digest",
+        "description": (
+            "Delete a digest subscription by id (F6). Owner-only for non-admins; "
+            "admins can delete any subscription."
+        ),
+        "parameters": {
+            "type": "OBJECT",
+            "properties": {
+                "subscription_id": {
+                    "type": "STRING",
+                    "description": "Subscription UUID returned by subscribe_digest / list_digests",
+                },
+            },
+            "required": ["subscription_id"],
         },
     },
 ]
@@ -1847,6 +1920,198 @@ async def _exec_export_channel(
     return summary
 
 
+async def _exec_subscribe_digest(
+    args: dict[str, Any],
+    current_user: CurrentUser | None = None,
+    bot: Bot | None = None,
+    chat_id: int | None = None,
+) -> dict[str, Any]:
+    """Create a new digest subscription and register it with the scheduler.
+
+    The subscription is owned by ``current_user`` and delivered to the
+    current chat (``chat_id`` from the message context). Each ``channel_id``
+    must be accessible by the user (``assert_channel_access``). Cron
+    expression and timezone are validated by the scheduler before persisting
+    so an invalid spec yields a clean error rather than a half-saved row.
+    """
+    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.auth.resolvers import get_default_admin
+    from tg_parser.config import settings
+    from tg_parser.domain.models import DigestFormat, DigestSubscription
+    from tg_parser.services.background_scheduler import (
+        get_scheduler,
+        register_digest_subscription,
+    )
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = current_user or await get_default_admin()
+
+    if chat_id is None:
+        return {"error": "chat_id is required (call from a chat context)"}
+
+    name = (args.get("name") or "").strip()
+    if not name:
+        return {"error": "name is required"}
+
+    raw_channels = args.get("channel_ids") or []
+    if not isinstance(raw_channels, list) or not raw_channels:
+        return {"error": "channel_ids must be a non-empty list"}
+    channel_ids = [str(c).lstrip("@").strip() for c in raw_channels if str(c).strip()]
+    if not channel_ids:
+        return {"error": "channel_ids must contain at least one channel"}
+
+    for cid in channel_ids:
+        try:
+            await assert_channel_access(user, cid)
+        except PermissionDenied as exc:
+            return {"error": exc.message, "channel_id": cid}
+
+    cron_expression = (args.get("cron_expression") or "0 9 * * *").strip()
+    timezone = (args.get("timezone") or settings.digest_default_timezone or "UTC").strip()
+    format_raw = (args.get("format") or "summary").strip()
+    language = (args.get("language") or "ru").strip()
+
+    try:
+        format_enum = DigestFormat(format_raw)
+    except ValueError:
+        return {
+            "error": (
+                f"invalid format: {format_raw!r}; expected one of "
+                f"{[fm.value for fm in DigestFormat]}"
+            )
+        }
+
+    import uuid as _uuid
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    subscription = DigestSubscription(
+        id=str(_uuid.uuid4()),
+        owner_id=user.id,
+        chat_id=chat_id,
+        name=name,
+        channel_ids=channel_ids,
+        cron_expression=cron_expression,
+        timezone=timezone,
+        format=format_enum,
+        language=language,
+        is_active=True,
+        last_sent_at=None,
+        last_digest_cursor=None,
+        created_at=_dt.now(_UTC),
+        updated_at=_dt.now(_UTC),
+    )
+
+    try:
+        register_digest_subscription(subscription, get_scheduler())
+    except ValueError as exc:
+        return {"error": f"cron/timezone validation failed: {exc}"}
+
+    try:
+        async with digest_subscription_repo() as (repo, _db):
+            created = await repo.create(subscription)
+    except Exception as exc:
+        from tg_parser.services.background_scheduler import unregister_digest_subscription
+
+        unregister_digest_subscription(subscription.id)
+        logger.exception("subscribe_digest_persist_failed")
+        return {"error": f"failed to persist subscription: {exc}"}
+
+    if bot is not None:
+        try:
+            await bot.send_message(
+                chat_id=chat_id,
+                text=(
+                    f"📰 Подписка <b>{created.name}</b> создана. "
+                    f"Расписание: <code>{created.cron_expression}</code> ({created.timezone}). "
+                    f"Каналов: {len(created.channel_ids)}."
+                ),
+                parse_mode="HTML",
+            )
+        except Exception:
+            logger.debug("subscribe_digest_confirmation_failed", exc_info=True)
+
+    return {
+        "subscription_id": created.id,
+        "name": created.name,
+        "chat_id": created.chat_id,
+        "channel_ids": created.channel_ids,
+        "cron_expression": created.cron_expression,
+        "timezone": created.timezone,
+        "format": created.format.value,
+        "language": created.language,
+        "is_active": created.is_active,
+    }
+
+
+async def _exec_list_digests(
+    args: dict[str, Any],
+    current_user: CurrentUser | None = None,
+) -> dict[str, Any]:
+    """Return the caller's subscriptions (admins see all)."""
+    from tg_parser.auth.resolvers import get_default_admin
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = current_user or await get_default_admin()
+
+    async with digest_subscription_repo() as (repo, _db):
+        if user.is_admin:
+            subs = await repo.list_all()
+        else:
+            subs = await repo.list_by_owner(user.id)
+
+    return {
+        "count": len(subs),
+        "subscriptions": [
+            {
+                "id": s.id,
+                "owner_id": s.owner_id,
+                "chat_id": s.chat_id,
+                "name": s.name,
+                "channel_ids": s.channel_ids,
+                "cron_expression": s.cron_expression,
+                "timezone": s.timezone,
+                "format": s.format.value,
+                "language": s.language,
+                "is_active": s.is_active,
+                "last_sent_at": s.last_sent_at.isoformat() if s.last_sent_at else None,
+                "last_digest_cursor": (
+                    s.last_digest_cursor.isoformat() if s.last_digest_cursor else None
+                ),
+            }
+            for s in subs
+        ],
+    }
+
+
+async def _exec_unsubscribe_digest(
+    args: dict[str, Any],
+    current_user: CurrentUser | None = None,
+) -> dict[str, Any]:
+    """Delete a subscription by id (owner-only for non-admins)."""
+    from tg_parser.auth.resolvers import get_default_admin
+    from tg_parser.services.background_scheduler import unregister_digest_subscription
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = current_user or await get_default_admin()
+    sub_id = (args.get("subscription_id") or "").strip()
+    if not sub_id:
+        return {"error": "subscription_id is required"}
+
+    async with digest_subscription_repo() as (repo, _db):
+        existing = await repo.get(sub_id)
+        if existing is None:
+            return {"error": f"subscription {sub_id!r} not found", "subscription_id": sub_id}
+        if not user.is_admin and existing.owner_id != user.id:
+            return {"error": "permission denied", "subscription_id": sub_id}
+        deleted = await repo.delete(sub_id)
+
+    if deleted:
+        unregister_digest_subscription(sub_id)
+        return {"subscription_id": sub_id, "deleted": True}
+    return {"subscription_id": sub_id, "deleted": False, "error": "delete failed"}
+
+
 async def _exec_remove_user_auth(
     args: dict[str, Any],
     current_user: CurrentUser | None = None,
@@ -1895,4 +2160,7 @@ _TOOL_EXECUTORS: dict[str, Any] = {
     "add_user_auth": _exec_add_user_auth,
     "remove_user_auth": _exec_remove_user_auth,
     "export_channel": _exec_export_channel,
+    "subscribe_digest": _exec_subscribe_digest,
+    "list_digests": _exec_list_digests,
+    "unsubscribe_digest": _exec_unsubscribe_digest,
 }

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -459,8 +459,8 @@ class Settings(BaseSettings):
         ),
     )
     digest_default_timezone: str = Field(
-        default="UTC",
-        description="Fallback IANA timezone applied when subscription does not specify one",
+        default="Europe/Moscow",
+        description=("Fallback IANA timezone applied when subscription does not specify one"),
     )
     digest_max_docs_per_run: int = Field(
         default=50,
@@ -717,10 +717,10 @@ LLM_SCOPES = ("global", "processing", "topicization", "rag", "digest")
 class LLMConfigManager:
     """Runtime LLM configuration overlay.
 
-    Holds per-scope (global / processing / topicization) overrides that
-    take effect immediately for new LLM client creation. Thread-safe via a
-    reentrant lock so concurrent pipeline workers can read safely while an
-    MCP/API call writes.
+    Holds per-scope (global / processing / topicization / rag / digest)
+    overrides that take effect immediately for new LLM client creation.
+    Thread-safe via a reentrant lock so concurrent pipeline workers can
+    read safely while an MCP/API call writes.
 
     Static settings from ``.env`` are used as defaults; runtime overrides
     are lost on restart (safe fallback by design).

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -142,6 +142,8 @@ class Settings(BaseSettings):
     topicization_llm_model: str | None = None
     rag_llm_provider: str | None = None
     rag_llm_model: str | None = None
+    digest_llm_provider: str | None = None
+    digest_llm_model: str | None = None
 
     # API keys (должны быть в ENV)
     openai_api_key: str | None = None
@@ -446,6 +448,61 @@ class Settings(BaseSettings):
     )
 
     # ==========================================================================
+    # Scheduled Digests (F6)
+    # ==========================================================================
+
+    digest_scheduler_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable digest scheduler in the bot process. Set to False in API/CLI "
+            "schedulers to avoid double delivery."
+        ),
+    )
+    digest_default_timezone: str = Field(
+        default="UTC",
+        description="Fallback IANA timezone applied when subscription does not specify one",
+    )
+    digest_max_docs_per_run: int = Field(
+        default=50,
+        description="Maximum number of processed documents per channel included in one digest",
+        ge=1,
+        le=500,
+    )
+    digest_first_run_lookback_hours: int = Field(
+        default=24,
+        description=(
+            "When `last_digest_cursor` is None, fetch documents from the past N hours; "
+            "after the first run the cursor advances to `now` even on empty result."
+        ),
+        ge=1,
+        le=24 * 30,
+    )
+    digest_refresh_interval: int = Field(
+        default=60,
+        description=(
+            "Seconds between scheduler reconciliation ticks (picks up subscriptions "
+            "created/deleted in another process)."
+        ),
+        ge=10,
+        le=3600,
+    )
+    digest_message_max_chars: int = Field(
+        default=4096,
+        description="Telegram MARKDOWN_V2 send_message character limit per part",
+        ge=512,
+        le=4096,
+    )
+    digest_max_message_parts: int = Field(
+        default=10,
+        description=(
+            "Maximum number of split message parts before the digest is sent as a "
+            ".md attachment instead."
+        ),
+        ge=1,
+        le=50,
+    )
+
+    # ==========================================================================
     # Embedding / RAG Configuration (P5)
     # ==========================================================================
 
@@ -654,7 +711,7 @@ class RetrySettings(BaseSettings):
 
 
 SUPPORTED_LLM_PROVIDERS = ("openai", "anthropic", "gemini", "ollama")
-LLM_SCOPES = ("global", "processing", "topicization", "rag")
+LLM_SCOPES = ("global", "processing", "topicization", "rag", "digest")
 
 
 class LLMConfigManager:
@@ -847,6 +904,7 @@ class LLMConfigManager:
                 "processing": _stage_config("processing"),
                 "topicization": _stage_config("topicization"),
                 "rag": _stage_config("rag"),
+                "digest": _stage_config("digest"),
             },
             "available_providers": available_providers,
             "runtime_overrides": overrides,

--- a/tg_parser/domain/models.py
+++ b/tg_parser/domain/models.py
@@ -475,3 +475,80 @@ class KnowledgeBaseEntry(BaseModel):
             ]
         }
     )
+
+
+# ============================================================================
+# DigestSubscription (F6 Scheduled Digests)
+# ============================================================================
+
+
+class DigestFormat(StrEnum):
+    """Output style for a scheduled digest."""
+
+    SUMMARY = "summary"
+    BULLETS = "bullets"
+    DETAILED = "detailed"
+
+
+class DigestSubscription(BaseModel):
+    """
+    User subscription to a scheduled digest of new ProcessedDocument-s.
+
+    Persisted in `digest_subscriptions` (ingestion DB). The scheduler picks up
+    active subscriptions and triggers `DigestService.run_for_subscription` per
+    subscription on the configured cron. Owner of the subscription must own
+    every channel in `channel_ids` (admins exempt).
+    """
+
+    id: str = Field(description="Subscription UUID")
+    owner_id: str = Field(description="User UUID owning the subscription")
+    chat_id: int = Field(description="Telegram chat_id where the digest is delivered")
+    name: str = Field(min_length=1, max_length=200, description="Human label")
+    channel_ids: list[str] = Field(
+        min_length=1, description="Channels included in the digest"
+    )
+    cron_expression: str = Field(
+        default="0 9 * * *",
+        max_length=100,
+        description="Cron expression evaluated in `timezone`",
+    )
+    timezone: str = Field(default="UTC", max_length=50, description="IANA timezone name")
+    format: DigestFormat = Field(default=DigestFormat.SUMMARY)
+    language: str = Field(default="ru", max_length=10)
+    is_active: bool = Field(default=True)
+    last_sent_at: datetime | None = Field(
+        default=None,
+        description="Last delivery attempt (also set on suppressed empty digests)",
+    )
+    last_digest_cursor: datetime | None = Field(
+        default=None,
+        description="processed_at of the last document included; strict-`>` filter on next run",
+    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now())
+    updated_at: datetime = Field(default_factory=lambda: datetime.now())
+
+    @field_validator("channel_ids")
+    @classmethod
+    def _channel_ids_nonempty(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("channel_ids must contain at least one channel")
+        return value
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "owner_id": "00000000-0000-0000-0000-000000000002",
+                    "chat_id": 12345,
+                    "name": "Daily morning brief",
+                    "channel_ids": ["durov", "telegram"],
+                    "cron_expression": "0 9 * * *",
+                    "timezone": "Europe/Moscow",
+                    "format": "summary",
+                    "language": "ru",
+                    "is_active": True,
+                }
+            ]
+        }
+    )

--- a/tg_parser/domain/models.py
+++ b/tg_parser/domain/models.py
@@ -504,9 +504,7 @@ class DigestSubscription(BaseModel):
     owner_id: str = Field(description="User UUID owning the subscription")
     chat_id: int = Field(description="Telegram chat_id where the digest is delivered")
     name: str = Field(min_length=1, max_length=200, description="Human label")
-    channel_ids: list[str] = Field(
-        min_length=1, description="Channels included in the digest"
-    )
+    channel_ids: list[str] = Field(min_length=1, description="Channels included in the digest")
     cron_expression: str = Field(
         default="0 9 * * *",
         max_length=100,

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -1938,7 +1938,9 @@ async def subscribe_digest(
     normalized = [str(c).lstrip("@").strip() for c in channel_ids if str(c).strip()]
     if not normalized:
         return SubscribeDigestResult(
-            success=False, subscription=None, message="channel_ids must contain at least one channel"
+            success=False,
+            subscription=None,
+            message="channel_ids must contain at least one channel",
         )
 
     for cid in normalized:
@@ -1958,8 +1960,7 @@ async def subscribe_digest(
             success=False,
             subscription=None,
             message=(
-                f"invalid format: {format!r}; expected one of "
-                f"{[fm.value for fm in DigestFormat]}"
+                f"invalid format: {format!r}; expected one of {[fm.value for fm in DigestFormat]}"
             ),
         )
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -77,6 +77,17 @@ _MCP_INSTRUCTIONS = (
     "list_users to see all users with channel counts. "
     "whoami (any user) to see own profile. "
     "add_user_auth / remove_user_auth to manage auth credentials.\n\n"
+    "Scheduled Digests (F6): "
+    "subscribe_digest(name, channel_ids, chat_id, cron_expression?, timezone?, "
+    "format?, language?) creates a recurring digest delivered to chat_id by "
+    "the bot scheduler. cron_expression is the standard 5-field syntax "
+    "(default '0 9 * * *'), timezone is an IANA name (default 'UTC'), "
+    "format is 'summary'|'bullets'|'detailed' (default 'summary'). "
+    "list_digests returns the caller's subscriptions (admins see all). "
+    "unsubscribe_digest(subscription_id) deletes a subscription (owner-only "
+    "for non-admins). Channels in channel_ids must be accessible to the "
+    "caller. The 'digest' LLM stage is configurable via DIGEST_LLM_PROVIDER "
+    "/ DIGEST_LLM_MODEL or set_llm_config(scope='digest', ...).\n\n"
     "Prompt Management: reload_prompts to reload YAML prompt files without restart. "
     "Prompts live in prompts/ directory (processing, topicization, rag, bot, merge, "
     "incremental_discover). Each YAML has system.prompt, user.template, and model "
@@ -470,6 +481,51 @@ class ExportStatusResult(BaseModel):
     format: str
     download_url: str | None = None
     file_size: int | None = None
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# F6: Scheduled Digests — result models
+# ---------------------------------------------------------------------------
+
+
+class DigestSubscriptionInfo(BaseModel):
+    """Public projection of a ``DigestSubscription``."""
+
+    id: str
+    owner_id: str
+    chat_id: int
+    name: str
+    channel_ids: list[str]
+    cron_expression: str
+    timezone: str
+    format: str
+    language: str
+    is_active: bool
+    last_sent_at: str | None = None
+    last_digest_cursor: str | None = None
+
+
+class SubscribeDigestResult(BaseModel):
+    """Result of ``subscribe_digest``."""
+
+    success: bool
+    subscription: DigestSubscriptionInfo | None = None
+    message: str
+
+
+class ListDigestsResult(BaseModel):
+    """Result of ``list_digests``."""
+
+    count: int
+    subscriptions: list[DigestSubscriptionInfo]
+
+
+class UnsubscribeDigestResult(BaseModel):
+    """Result of ``unsubscribe_digest``."""
+
+    success: bool
+    subscription_id: str
     message: str
 
 
@@ -1804,6 +1860,240 @@ async def get_export_status(
         download_url=job.download_url,
         file_size=file_size,
         message=job.error or f"Status: {job.status.value}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# F6: Scheduled Digests — MCP tools
+# ---------------------------------------------------------------------------
+
+
+def _digest_to_info(sub: Any) -> DigestSubscriptionInfo:
+    return DigestSubscriptionInfo(
+        id=sub.id,
+        owner_id=sub.owner_id,
+        chat_id=sub.chat_id,
+        name=sub.name,
+        channel_ids=list(sub.channel_ids),
+        cron_expression=sub.cron_expression,
+        timezone=sub.timezone,
+        format=sub.format.value,
+        language=sub.language,
+        is_active=sub.is_active,
+        last_sent_at=sub.last_sent_at.isoformat() if sub.last_sent_at else None,
+        last_digest_cursor=sub.last_digest_cursor.isoformat() if sub.last_digest_cursor else None,
+    )
+
+
+@mcp.tool()
+async def subscribe_digest(
+    name: str,
+    channel_ids: list[str],
+    chat_id: int,
+    cron_expression: str = "0 9 * * *",
+    timezone: str = "UTC",
+    format: str = "summary",
+    language: str = "ru",
+    ctx: Context | None = None,
+) -> SubscribeDigestResult:
+    """Create a recurring digest subscription (F6).
+
+    The subscription is owned by the calling user and delivered to ``chat_id``
+    on the cron schedule. For private chats ``chat_id`` equals the user's
+    Telegram id; for groups/supergroups it is a negative integer (Telegram
+    convention). Each ``channel_id`` must be accessible by the caller
+    (admin sees all, regular user sees only owned channels).
+
+    Args:
+        name: Human-readable subscription name (used by list/unsubscribe).
+        channel_ids: One or more channel ids (or @usernames) to digest.
+        chat_id: Telegram chat id to deliver into.
+        cron_expression: Standard 5-field cron (default '0 9 * * *' = 09:00 daily).
+        timezone: IANA timezone for the cron (default 'UTC').
+        format: 'summary' | 'bullets' | 'detailed' (default 'summary').
+        language: Output language code (default 'ru').
+    """
+    import uuid as _uuid
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.domain.models import DigestFormat, DigestSubscription
+    from tg_parser.services.background_scheduler import (
+        get_scheduler,
+        register_digest_subscription,
+        unregister_digest_subscription,
+    )
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = await resolve_mcp_user(ctx.client_id if ctx else None)
+
+    if not name or not name.strip():
+        return SubscribeDigestResult(success=False, subscription=None, message="name is required")
+    if not channel_ids:
+        return SubscribeDigestResult(
+            success=False, subscription=None, message="channel_ids must be non-empty"
+        )
+
+    normalized = [str(c).lstrip("@").strip() for c in channel_ids if str(c).strip()]
+    if not normalized:
+        return SubscribeDigestResult(
+            success=False, subscription=None, message="channel_ids must contain at least one channel"
+        )
+
+    for cid in normalized:
+        try:
+            await assert_channel_access(user, cid)
+        except PermissionDenied as exc:
+            return SubscribeDigestResult(
+                success=False,
+                subscription=None,
+                message=f"{exc.message} (channel_id={cid})",
+            )
+
+    try:
+        format_enum = DigestFormat(format)
+    except ValueError:
+        return SubscribeDigestResult(
+            success=False,
+            subscription=None,
+            message=(
+                f"invalid format: {format!r}; expected one of "
+                f"{[fm.value for fm in DigestFormat]}"
+            ),
+        )
+
+    subscription = DigestSubscription(
+        id=str(_uuid.uuid4()),
+        owner_id=user.id,
+        chat_id=chat_id,
+        name=name.strip(),
+        channel_ids=normalized,
+        cron_expression=cron_expression.strip(),
+        timezone=timezone.strip(),
+        format=format_enum,
+        language=language.strip(),
+        is_active=True,
+        last_sent_at=None,
+        last_digest_cursor=None,
+        created_at=_dt.now(_UTC),
+        updated_at=_dt.now(_UTC),
+    )
+
+    try:
+        register_digest_subscription(subscription, get_scheduler())
+    except ValueError as exc:
+        return SubscribeDigestResult(
+            success=False,
+            subscription=None,
+            message=f"cron/timezone validation failed: {exc}",
+        )
+
+    try:
+        async with digest_subscription_repo() as (repo, _db):
+            created = await repo.create(subscription)
+    except SQLAlchemyError as exc:
+        unregister_digest_subscription(subscription.id)
+        logger.exception("mcp_subscribe_digest_persist_failed")
+        return SubscribeDigestResult(
+            success=False,
+            subscription=None,
+            message=f"failed to persist subscription: {exc}",
+        )
+
+    logger.info(
+        "mcp_subscribe_digest_created",
+        subscription_id=created.id,
+        owner_id=created.owner_id,
+        channel_count=len(created.channel_ids),
+    )
+    return SubscribeDigestResult(
+        success=True,
+        subscription=_digest_to_info(created),
+        message=(
+            f"Subscription '{created.name}' created. "
+            f"Schedule: {created.cron_expression} ({created.timezone}). "
+            f"Channels: {len(created.channel_ids)}."
+        ),
+    )
+
+
+@mcp.tool()
+async def list_digests(ctx: Context | None = None) -> ListDigestsResult:
+    """List digest subscriptions (F6).
+
+    Admins see every subscription in the system; regular users see only their
+    own. Inactive (paused) subscriptions are included so the caller can
+    inspect / re-create them.
+    """
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = await resolve_mcp_user(ctx.client_id if ctx else None)
+
+    async with digest_subscription_repo() as (repo, _db):
+        if user.is_admin:
+            subs = await repo.list_all()
+        else:
+            subs = await repo.list_by_owner(user.id)
+
+    return ListDigestsResult(
+        count=len(subs),
+        subscriptions=[_digest_to_info(s) for s in subs],
+    )
+
+
+@mcp.tool()
+async def unsubscribe_digest(
+    subscription_id: str,
+    ctx: Context | None = None,
+) -> UnsubscribeDigestResult:
+    """Delete a digest subscription by id (F6).
+
+    Owner-only for non-admins; admins can delete any subscription. The
+    matching scheduler job is removed atomically — the next reconciliation
+    tick is *not* required for the deletion to take effect inside the bot
+    process.
+    """
+    from tg_parser.services.background_scheduler import unregister_digest_subscription
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    user = await resolve_mcp_user(ctx.client_id if ctx else None)
+
+    sub_id = subscription_id.strip()
+    if not sub_id:
+        return UnsubscribeDigestResult(
+            success=False,
+            subscription_id=subscription_id,
+            message="subscription_id is required",
+        )
+
+    async with digest_subscription_repo() as (repo, _db):
+        existing = await repo.get(sub_id)
+        if existing is None:
+            return UnsubscribeDigestResult(
+                success=False,
+                subscription_id=sub_id,
+                message=f"Subscription {sub_id!r} not found.",
+            )
+        if not user.is_admin and existing.owner_id != user.id:
+            return UnsubscribeDigestResult(
+                success=False,
+                subscription_id=sub_id,
+                message="Permission denied (owner-only).",
+            )
+        deleted = await repo.delete(sub_id)
+
+    if deleted:
+        unregister_digest_subscription(sub_id)
+        return UnsubscribeDigestResult(
+            success=True,
+            subscription_id=sub_id,
+            message=f"Subscription {sub_id!r} deleted.",
+        )
+    return UnsubscribeDigestResult(
+        success=False,
+        subscription_id=sub_id,
+        message=f"Subscription {sub_id!r} delete failed.",
     )
 
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -65,7 +65,7 @@ _MCP_INSTRUCTIONS = (
     "download_url. raw_payload is never included (privacy invariant).\n\n"
     "LLM Configuration (runtime switching without restart): "
     "get_llm_config to view current provider/model per stage and available providers. "
-    "set_llm_config to switch provider/model — scopes: global, processing, topicization, rag; "
+    "set_llm_config to switch provider/model — scopes: global, processing, topicization, rag, digest; "
     "providers: openai, anthropic, gemini, ollama. "
     "reset_llm_config to revert runtime overrides to .env defaults. "
     "Resolution priority: stage override → global override → stage .env → global .env. "
@@ -1363,7 +1363,7 @@ async def set_llm_config(
     Changes are NOT persisted to .env — a restart reverts to defaults.
 
     Args:
-        scope: Which config to change: 'global', 'processing', 'topicization', or 'rag'.
+        scope: Which config to change: 'global', 'processing', 'topicization', 'rag', or 'digest'.
         provider: LLM provider name: 'openai', 'anthropic', 'gemini', or 'ollama'.
         model: Optional model name override (e.g. 'gpt-4o', 'claude-sonnet-4-20250514').
                If omitted, the provider's default model is used.
@@ -1409,7 +1409,7 @@ async def reset_llm_config(
     """Reset runtime LLM overrides, reverting to .env defaults.
 
     Args:
-        scope: Scope to reset ('global', 'processing', 'topicization').
+        scope: Scope to reset ('global', 'processing', 'topicization', 'rag', or 'digest').
                If omitted, resets ALL runtime overrides."""
     from tg_parser.auth.ownership import PermissionDenied, assert_admin
     from tg_parser.config import llm_config

--- a/tg_parser/services/background_scheduler.py
+++ b/tg_parser/services/background_scheduler.py
@@ -7,11 +7,18 @@ Lives in services/ to avoid circular dependency: services → api → services.
 
 from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import structlog
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
+
+if TYPE_CHECKING:
+    from apscheduler.job import Job
+
+    from tg_parser.domain.models import DigestSubscription
 
 logger = structlog.get_logger(__name__)
 
@@ -97,6 +104,71 @@ class BackgroundScheduler:
         # Run immediately if requested
         if start_immediately and self._is_running:
             self._scheduler.modify_job(task_id, next_run_time=datetime.now(UTC))
+
+    def add_cron_task(
+        self,
+        task_id: str,
+        func: Callable,
+        cron_expression: str,
+        *,
+        timezone: str = "UTC",
+        args: tuple = (),
+        kwargs: dict[str, Any] | None = None,
+    ) -> "Job":
+        """Add a task driven by a 5-field cron expression.
+
+        Wraps APScheduler's ``CronTrigger.from_crontab(...)`` and reuses the
+        same metric-recording wrapper as ``add_task``. ``timezone`` must be a
+        valid IANA name (validated via :class:`zoneinfo.ZoneInfo`); the call
+        raises ``ValueError`` on bad input so callers (bot/MCP tools) can
+        surface a clean error to the user instead of crashing the scheduler.
+
+        Replaces an existing task with the same ``task_id`` (mirrors
+        ``add_task`` semantics).
+        """
+        try:
+            trigger = CronTrigger.from_crontab(cron_expression, timezone=ZoneInfo(timezone))
+        except (ValueError, ZoneInfoNotFoundError) as exc:
+            raise ValueError(
+                f"invalid cron task spec ({cron_expression!r} / tz={timezone!r}): {exc}"
+            ) from exc
+
+        if task_id in self._tasks:
+            logger.debug("cron_task_replacing_existing", task_id=task_id)
+            self.remove_task(task_id)
+
+        call_args = args
+        call_kwargs = dict(kwargs or {})
+
+        async def wrapped_func() -> None:
+            from tg_parser.api.metrics import record_scheduler_task
+
+            start_time = datetime.now(UTC)
+            try:
+                await func(*call_args, **call_kwargs)
+                record_scheduler_task(task_id, success=True)
+                duration = (datetime.now(UTC) - start_time).total_seconds()
+                logger.debug("cron_task_completed", task_id=task_id, duration=duration)
+            except Exception as exc:  # noqa: BLE001
+                record_scheduler_task(task_id, success=False)
+                logger.exception("cron_task_failed", task_id=task_id, error=str(exc))
+
+        job = self._scheduler.add_job(
+            wrapped_func,
+            trigger=trigger,
+            id=task_id,
+            name=task_id,
+            replace_existing=True,
+        )
+
+        self._tasks[task_id] = func
+        logger.info(
+            "added_cron_task",
+            task_id=task_id,
+            cron_expression=cron_expression,
+            timezone=timezone,
+        )
+        return job
 
     def remove_task(self, task_id: str) -> bool:
         """
@@ -316,6 +388,82 @@ def setup_default_tasks(
         "Default background tasks configured (incl. incremental pipeline + embedding, interval=%ds)",
         interval,
     )
+
+
+# ============================================================================
+# F6 — Scheduled Digests: subscription job lifecycle helpers
+# ============================================================================
+
+
+def _digest_job_id(subscription_id: str) -> str:
+    """Stable per-subscription scheduler job id used for register/remove/diff."""
+    return f"digest:{subscription_id}"
+
+
+def register_digest_subscription(
+    subscription: "DigestSubscription",
+    scheduler: BackgroundScheduler | None = None,
+) -> "Job | None":
+    """Add (or replace) the cron job for ``subscription`` on the singleton scheduler.
+
+    Returns the new ``Job`` on success and ``None`` if the subscription is
+    inactive. Invalid cron expression / timezone propagate as ``ValueError`` so
+    bot/MCP tools surface a clean error to the user.
+    """
+    if not subscription.is_active:
+        logger.debug(
+            "digest_skip_register_inactive",
+            subscription_id=subscription.id,
+        )
+        return None
+
+    sched = scheduler or get_scheduler()
+    from tg_parser.services.scheduler_service import run_scheduled_digests_task
+
+    return sched.add_cron_task(
+        task_id=_digest_job_id(subscription.id),
+        func=run_scheduled_digests_task,
+        cron_expression=subscription.cron_expression,
+        timezone=subscription.timezone,
+        args=(subscription.id,),
+    )
+
+
+def unregister_digest_subscription(
+    subscription_id: str,
+    scheduler: BackgroundScheduler | None = None,
+) -> bool:
+    """Remove the cron job for ``subscription_id`` if present. Idempotent."""
+    sched = scheduler or get_scheduler()
+    return sched.remove_task(_digest_job_id(subscription_id))
+
+
+def reschedule_digest_subscription(
+    subscription: "DigestSubscription",
+    scheduler: BackgroundScheduler | None = None,
+) -> "Job | None":
+    """Re-register a subscription job to pick up cron / timezone / activity changes.
+
+    Inactive subscriptions are removed instead of re-registered.
+    """
+    sched = scheduler or get_scheduler()
+    if not subscription.is_active:
+        unregister_digest_subscription(subscription.id, sched)
+        return None
+    return register_digest_subscription(subscription, sched)
+
+
+def get_registered_digest_subscription_ids(
+    scheduler: BackgroundScheduler | None = None,
+) -> set[str]:
+    """Return the set of subscription IDs that currently have a scheduler job."""
+    sched = scheduler or get_scheduler()
+    prefix = "digest:"
+    out: set[str] = set()
+    for task_id in sched._tasks:  # noqa: SLF001 — minimal helper, no public iter
+        if task_id.startswith(prefix):
+            out.add(task_id[len(prefix) :])
+    return out
 
 
 async def _incremental_embedding_task() -> None:

--- a/tg_parser/services/db_context.py
+++ b/tg_parser/services/db_context.py
@@ -11,6 +11,9 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from tg_parser.storage.sqlalchemy import Database
+from tg_parser.storage.sqlalchemy.digest_subscription_repo import (
+    SADigestSubscriptionRepo,
+)
 from tg_parser.storage.sqlalchemy.embedding_repo import SAEmbeddingRepo
 from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
 from tg_parser.storage.sqlalchemy.job_repo import SAJobRepo
@@ -113,6 +116,19 @@ async def user_repo() -> "AsyncIterator[tuple[SAUserRepo, Database]]":
     session = db.ingestion_state_session()
     try:
         yield SAUserRepo(session), db
+    finally:
+        await session.close()
+
+
+@asynccontextmanager
+async def digest_subscription_repo() -> (
+    "AsyncIterator[tuple[SADigestSubscriptionRepo, Database]]"
+):
+    """Context manager for DigestSubscriptionRepo (F6 scheduled digests)."""
+    db = await _get_db()
+    session = db.ingestion_state_session()
+    try:
+        yield SADigestSubscriptionRepo(session), db
     finally:
         await session.close()
 

--- a/tg_parser/services/db_context.py
+++ b/tg_parser/services/db_context.py
@@ -121,9 +121,7 @@ async def user_repo() -> "AsyncIterator[tuple[SAUserRepo, Database]]":
 
 
 @asynccontextmanager
-async def digest_subscription_repo() -> (
-    "AsyncIterator[tuple[SADigestSubscriptionRepo, Database]]"
-):
+async def digest_subscription_repo() -> "AsyncIterator[tuple[SADigestSubscriptionRepo, Database]]":
     """Context manager for DigestSubscriptionRepo (F6 scheduled digests)."""
     db = await _get_db()
     session = db.ingestion_state_session()

--- a/tg_parser/services/digest_service.py
+++ b/tg_parser/services/digest_service.py
@@ -195,7 +195,7 @@ class DigestService:
                 docs_count=0,
                 new_cursor=new_cursor,
                 skipped=True,
-                per_channel_counts={cid: 0 for cid in sub.channel_ids},
+                per_channel_counts=dict.fromkeys(sub.channel_ids, 0),
             )
 
         channels_block = self._render_channels_block(
@@ -221,7 +221,7 @@ class DigestService:
             per_channel_counts={cid: len(per_channel_docs.get(cid, [])) for cid in sub.channel_ids},
         )
 
-    async def deliver(self, bot: "Bot", result: DigestResult) -> None:
+    async def deliver(self, bot: Bot, result: DigestResult) -> None:
         """Send ``result`` to ``chat_id`` over Telegram.
 
         Raises whatever ``bot.send_message`` / ``bot.send_document`` raises so the
@@ -246,7 +246,7 @@ class DigestService:
     async def run_for_subscription(
         self,
         sub: DigestSubscription,
-        bot: "Bot | None",
+        bot: Bot | None,
     ) -> DigestResult:
         """Generate + (optionally) deliver + advance the cursor.
 
@@ -420,7 +420,7 @@ class DigestService:
 
     async def _deliver_as_document(
         self,
-        bot: "Bot",
+        bot: Bot,
         result: DigestResult,
         full_message: str,
     ) -> None:
@@ -430,9 +430,7 @@ class DigestService:
         filename = f"digest_{date_str}.md"
         raw_body = f"# {result.title}\n\n{result.body_markdown}"
         file = BufferedInputFile(raw_body.encode("utf-8"), filename=filename)
-        caption = escape_markdown_v2(
-            f"{result.title} ({result.docs_count} new)"
-        )
+        caption = escape_markdown_v2(f"{result.title} ({result.docs_count} new)")
         from aiogram.enums import ParseMode
 
         await bot.send_document(

--- a/tg_parser/services/digest_service.py
+++ b/tg_parser/services/digest_service.py
@@ -38,7 +38,6 @@ from tg_parser.domain.models import (
 from tg_parser.processing.prompt_loader import PromptLoader
 from tg_parser.storage.ports import (
     DigestSubscriptionRepo,
-    IngestionStateRepo,
     ProcessedDocumentRepo,
 )
 
@@ -108,7 +107,6 @@ class DigestService:
     def __init__(
         self,
         processed_repo: ProcessedDocumentRepo,
-        ingestion_repo: IngestionStateRepo,
         subscription_repo: DigestSubscriptionRepo,
         prompt_loader: PromptLoader,
         llm_client_factory: LLMClientFactory,
@@ -120,7 +118,6 @@ class DigestService:
         prompt_name: str = "digest",
     ):
         self._processed_repo = processed_repo
-        self._ingestion_repo = ingestion_repo
         self._subscription_repo = subscription_repo
         self._prompt_loader = prompt_loader
         self._llm_client_factory = llm_client_factory
@@ -171,7 +168,12 @@ class DigestService:
                 if d.processed_at is not None
                 and (cursor is None or _to_utc(d.processed_at) > _to_utc(cursor))
             ]
-            filtered.sort(key=lambda d: d.processed_at, reverse=True)
+            # Oldest-first: when len(filtered) > max_docs_per_run we keep the
+            # oldest slice. The cursor then advances to the *last kept* doc, so
+            # the leftover newer docs are picked up on the next tick instead of
+            # being silently skipped (which would happen if we kept the newest
+            # slice and advanced cursor to the newest of the kept).
+            filtered.sort(key=lambda d: _to_utc(d.processed_at))
             per_channel_total[channel_id] = len(filtered)
             kept = filtered[: self._max_docs_per_run]
             per_channel_docs[channel_id] = kept

--- a/tg_parser/services/digest_service.py
+++ b/tg_parser/services/digest_service.py
@@ -1,0 +1,463 @@
+"""
+Scheduled-Digest service (F6).
+
+Generates and delivers a Markdown digest of new ProcessedDocument-s for a single
+``DigestSubscription``. Designed to be invoked from APScheduler tasks running
+inside the bot process.
+
+Key invariants:
+
+- Strict ``processed_at > last_digest_cursor`` filter — equality would re-include
+  the most recent document on the next tick. ``ProcessedDocumentRepo.list_by_channel``
+  uses ``>=`` semantics, so the service filters again in Python.
+- ``digest_max_docs_per_run`` is a per-channel cap, not a global one — a noisy
+  channel cannot starve quieter channels.
+- On the first run (``last_digest_cursor is None``) we look back
+  ``first_run_lookback_hours`` hours, then advance the cursor to ``now`` even if
+  the result is empty so we don't repeat the lookback every tick.
+- Cursor + ``last_sent_at`` are persisted ONLY after successful delivery (or
+  successful skip-because-empty); a failed ``Bot.send_message`` leaves the
+  subscription untouched so the next tick retries.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from tg_parser.domain.models import (
+    DigestFormat,
+    DigestSubscription,
+    ProcessedDocument,
+)
+from tg_parser.processing.prompt_loader import PromptLoader
+from tg_parser.storage.ports import (
+    DigestSubscriptionRepo,
+    IngestionStateRepo,
+    ProcessedDocumentRepo,
+)
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+
+    from tg_parser.processing.ports import LLMClient
+
+
+logger = structlog.get_logger(__name__)
+
+
+# ----------------------------------------------------------------------------
+# Markdown V2 helpers
+# ----------------------------------------------------------------------------
+
+
+_MD_V2_SPECIAL = r"_*[]()~`>#+-=|{}.!\\"
+
+
+def escape_markdown_v2(text: str) -> str:
+    """Escape every Telegram MarkdownV2 special char in ``text``.
+
+    Used both for dynamic strings inserted into the title (channel names, dates)
+    and for the entire LLM-produced body — we cannot trust the LLM to produce
+    valid V2 markup, so escaping the body sacrifices intentional formatting in
+    exchange for guaranteed safe delivery.
+    """
+    if not text:
+        return ""
+    pattern = "[" + re.escape(_MD_V2_SPECIAL) + "]"
+    return re.sub(pattern, r"\\\g<0>", text)
+
+
+# ----------------------------------------------------------------------------
+# Result dataclass
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class DigestResult:
+    """Outcome of one digest generation run for a subscription."""
+
+    subscription_id: str
+    chat_id: int
+    title: str
+    body_markdown: str
+    docs_count: int
+    new_cursor: datetime | None
+    skipped: bool
+    delivery_failed: bool = False
+    delivery_error: str | None = None
+    per_channel_counts: dict[str, int] = field(default_factory=dict)
+
+
+# ----------------------------------------------------------------------------
+# Service
+# ----------------------------------------------------------------------------
+
+
+LLMClientFactory = Callable[[], "LLMClient"]
+
+
+class DigestService:
+    """Compose digest text and deliver it to Telegram for a subscription."""
+
+    def __init__(
+        self,
+        processed_repo: ProcessedDocumentRepo,
+        ingestion_repo: IngestionStateRepo,
+        subscription_repo: DigestSubscriptionRepo,
+        prompt_loader: PromptLoader,
+        llm_client_factory: LLMClientFactory,
+        *,
+        max_docs_per_run: int = 50,
+        first_run_lookback_hours: int = 24,
+        message_max_chars: int = 4096,
+        max_message_parts: int = 10,
+        prompt_name: str = "digest",
+    ):
+        self._processed_repo = processed_repo
+        self._ingestion_repo = ingestion_repo
+        self._subscription_repo = subscription_repo
+        self._prompt_loader = prompt_loader
+        self._llm_client_factory = llm_client_factory
+        self._max_docs_per_run = max(1, int(max_docs_per_run))
+        self._first_run_lookback_hours = max(1, int(first_run_lookback_hours))
+        self._message_max_chars = max(512, int(message_max_chars))
+        self._max_message_parts = max(1, int(max_message_parts))
+        self._prompt_name = prompt_name
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def generate(self, sub: DigestSubscription) -> DigestResult:
+        """Fetch new docs, summarise via LLM, return ``DigestResult``."""
+        now = datetime.now(UTC)
+        cursor = sub.last_digest_cursor
+        first_run = cursor is None
+        if first_run:
+            from_date = now - timedelta(hours=self._first_run_lookback_hours)
+        else:
+            from_date = cursor  # type: ignore[assignment]
+
+        per_channel_docs: dict[str, list[ProcessedDocument]] = {}
+        per_channel_total: dict[str, int] = {}
+        max_processed_at: datetime | None = None
+        all_docs: list[ProcessedDocument] = []
+
+        for channel_id in sub.channel_ids:
+            try:
+                fetched = await self._processed_repo.list_by_channel(
+                    channel_id,
+                    from_date=from_date,
+                    to_date=now,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "digest.fetch_failed",
+                    subscription_id=sub.id,
+                    channel_id=channel_id,
+                    error=str(exc),
+                )
+                continue
+
+            filtered = [
+                d
+                for d in fetched
+                if d.processed_at is not None
+                and (cursor is None or _to_utc(d.processed_at) > _to_utc(cursor))
+            ]
+            filtered.sort(key=lambda d: d.processed_at, reverse=True)
+            per_channel_total[channel_id] = len(filtered)
+            kept = filtered[: self._max_docs_per_run]
+            per_channel_docs[channel_id] = kept
+            for d in kept:
+                if d.processed_at is not None:
+                    cur_pa = _to_utc(d.processed_at)
+                    if max_processed_at is None or cur_pa > max_processed_at:
+                        max_processed_at = cur_pa
+                    all_docs.append(d)
+
+        docs_count = sum(len(v) for v in per_channel_docs.values())
+        title = self._build_title(sub, now)
+
+        if docs_count == 0:
+            new_cursor = now if first_run else cursor
+            return DigestResult(
+                subscription_id=sub.id,
+                chat_id=sub.chat_id,
+                title=title,
+                body_markdown="",
+                docs_count=0,
+                new_cursor=new_cursor,
+                skipped=True,
+                per_channel_counts={cid: 0 for cid in sub.channel_ids},
+            )
+
+        channels_block = self._render_channels_block(
+            sub,
+            per_channel_docs,
+            per_channel_total,
+        )
+        body_markdown = await self._call_llm(
+            sub=sub,
+            channels_block=channels_block,
+            from_iso=_iso(from_date),
+            to_iso=_iso(now),
+        )
+
+        return DigestResult(
+            subscription_id=sub.id,
+            chat_id=sub.chat_id,
+            title=title,
+            body_markdown=body_markdown,
+            docs_count=docs_count,
+            new_cursor=max_processed_at or now,
+            skipped=False,
+            per_channel_counts={cid: len(per_channel_docs.get(cid, [])) for cid in sub.channel_ids},
+        )
+
+    async def deliver(self, bot: "Bot", result: DigestResult) -> None:
+        """Send ``result`` to ``chat_id`` over Telegram.
+
+        Raises whatever ``bot.send_message`` / ``bot.send_document`` raises so the
+        caller can decide whether to advance the cursor.
+        """
+        from aiogram.enums import ParseMode
+
+        message = self._compose_message(result)
+        parts = self._split_for_telegram(message)
+
+        if len(parts) > self._max_message_parts:
+            await self._deliver_as_document(bot, result, message)
+            return
+
+        for part in parts:
+            await bot.send_message(
+                chat_id=result.chat_id,
+                text=part,
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
+
+    async def run_for_subscription(
+        self,
+        sub: DigestSubscription,
+        bot: "Bot | None",
+    ) -> DigestResult:
+        """Generate + (optionally) deliver + advance the cursor.
+
+        - Empty result → no delivery, but cursor + last_sent_at advance (so we
+          don't keep replaying the lookback window).
+        - Bot unavailable + non-empty result → log warning, mark
+          ``delivery_failed`` and DO NOT advance cursor.
+        - Delivery raises → mark ``delivery_failed`` and DO NOT advance cursor.
+        """
+        result = await self.generate(sub)
+
+        if result.skipped:
+            await self._advance_cursor(sub.id, result.new_cursor)
+            logger.info(
+                "digest.skipped_empty",
+                subscription_id=sub.id,
+                chat_id=sub.chat_id,
+                first_run=sub.last_digest_cursor is None,
+            )
+            return result
+
+        if bot is None:
+            logger.warning(
+                "digest.delivery_skipped_no_bot",
+                subscription_id=sub.id,
+                docs_count=result.docs_count,
+            )
+            result.delivery_failed = True
+            result.delivery_error = "bot_unavailable"
+            return result
+
+        try:
+            await self.deliver(bot, result)
+        except Exception as exc:  # noqa: BLE001 — surface as delivery failure
+            logger.warning(
+                "digest.delivery_failed",
+                subscription_id=sub.id,
+                chat_id=sub.chat_id,
+                error=str(exc),
+            )
+            result.delivery_failed = True
+            result.delivery_error = str(exc)
+            return result
+
+        await self._advance_cursor(sub.id, result.new_cursor)
+        logger.info(
+            "digest.delivered",
+            subscription_id=sub.id,
+            chat_id=sub.chat_id,
+            docs_count=result.docs_count,
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _advance_cursor(self, sub_id: str, new_cursor: datetime | None) -> None:
+        kwargs: dict[str, Any] = {"last_sent_at": datetime.now(UTC)}
+        if new_cursor is not None:
+            kwargs["last_digest_cursor"] = new_cursor
+        await self._subscription_repo.update(sub_id, **kwargs)
+
+    def _build_title(self, sub: DigestSubscription, now: datetime) -> str:
+        date_str = now.strftime("%Y-%m-%d")
+        return f"{sub.name} — {date_str}"
+
+    def _render_channels_block(
+        self,
+        sub: DigestSubscription,
+        per_channel: dict[str, list[ProcessedDocument]],
+        per_channel_total: dict[str, int],
+    ) -> str:
+        chunks: list[str] = []
+        channel_titles = self._channel_titles(sub.channel_ids)
+        for channel_id in sub.channel_ids:
+            docs = per_channel.get(channel_id, [])
+            if not docs:
+                continue
+            total = per_channel_total.get(channel_id, len(docs))
+            title = channel_titles.get(channel_id, channel_id)
+            header = f"## {title} ({len(docs)} of {total} new)"
+            lines = [header]
+            for d in docs:
+                stamp = (
+                    d.processed_at.astimezone(UTC).strftime("%Y-%m-%d %H:%M")
+                    if d.processed_at
+                    else "?"
+                )
+                snippet = (d.summary or d.text_clean or "").strip()
+                snippet = snippet.replace("\n", " ")
+                if len(snippet) > 400:
+                    snippet = snippet[:397] + "..."
+                lines.append(f"- [{stamp}] {snippet}")
+            chunks.append("\n".join(lines))
+        return "\n\n".join(chunks)
+
+    def _channel_titles(self, channel_ids: list[str]) -> dict[str, str]:
+        """Lightweight resolver — returns ``channel_id`` as title if no metadata.
+
+        Hook for future enrichment (e.g. ``Source.channel_username``).
+        """
+        return {cid: cid for cid in channel_ids}
+
+    async def _call_llm(
+        self,
+        *,
+        sub: DigestSubscription,
+        channels_block: str,
+        from_iso: str,
+        to_iso: str,
+    ) -> str:
+        config = self._prompt_loader.load(self._prompt_name)
+        system_template = (config.get("system") or {}).get("prompt") or ""
+        user_template = (config.get("user") or {}).get("template") or ""
+        model_cfg = config.get("model") or {}
+
+        format_value = sub.format.value if isinstance(sub.format, DigestFormat) else str(sub.format)
+        render_args: dict[str, Any] = {
+            "format": format_value,
+            "language": sub.language,
+            "from_iso": from_iso,
+            "to_iso": to_iso,
+            "channels_block": channels_block,
+        }
+
+        try:
+            system_prompt = system_template.format(**render_args)
+        except KeyError:
+            system_prompt = system_template
+        try:
+            user_prompt = user_template.format(**render_args)
+        except KeyError as exc:
+            raise ValueError(
+                f"digest prompt template missing required placeholder: {exc.args[0]!r}"
+            ) from exc
+
+        llm = self._llm_client_factory()
+        body = await llm.generate(
+            prompt=user_prompt,
+            system_prompt=system_prompt,
+            temperature=float(model_cfg.get("temperature", 0.3)),
+            max_tokens=int(model_cfg.get("max_tokens", 1500)),
+        )
+        return (body or "").strip()
+
+    def _compose_message(self, result: DigestResult) -> str:
+        title_md = f"*{escape_markdown_v2(result.title)}*"
+        body_md = escape_markdown_v2(result.body_markdown)
+        if not body_md:
+            return title_md
+        return f"{title_md}\n\n{body_md}"
+
+    def _split_for_telegram(self, text: str) -> list[str]:
+        if len(text) <= self._message_max_chars:
+            return [text]
+
+        parts: list[str] = []
+        remaining = text
+        limit = self._message_max_chars
+        while remaining:
+            if len(remaining) <= limit:
+                parts.append(remaining)
+                break
+            split_at = remaining.rfind("\n", 0, limit)
+            if split_at <= 0:
+                split_at = limit
+            parts.append(remaining[:split_at])
+            remaining = remaining[split_at:].lstrip("\n")
+        return parts
+
+    async def _deliver_as_document(
+        self,
+        bot: "Bot",
+        result: DigestResult,
+        full_message: str,
+    ) -> None:
+        from aiogram.types import BufferedInputFile
+
+        date_str = datetime.now(UTC).strftime("%Y%m%d_%H%M")
+        filename = f"digest_{date_str}.md"
+        raw_body = f"# {result.title}\n\n{result.body_markdown}"
+        file = BufferedInputFile(raw_body.encode("utf-8"), filename=filename)
+        caption = escape_markdown_v2(
+            f"{result.title} ({result.docs_count} new)"
+        )
+        from aiogram.enums import ParseMode
+
+        await bot.send_document(
+            chat_id=result.chat_id,
+            document=file,
+            caption=caption,
+            parse_mode=ParseMode.MARKDOWN_V2,
+        )
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _to_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return _to_utc(dt).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "DigestResult",
+    "DigestService",
+    "escape_markdown_v2",
+]

--- a/tg_parser/services/scheduler_service.py
+++ b/tg_parser/services/scheduler_service.py
@@ -365,30 +365,31 @@ async def run_scheduled_digests_task(subscription_id: str) -> dict[str, Any]:
 
     logger.info("digest_task_triggered", subscription_id=subscription_id)
 
-    async with digest_subscription_repo() as (sub_repo_lookup, _db1):
-        sub = await sub_repo_lookup.get(subscription_id)
-
-    if sub is None:
-        logger.warning("digest_subscription_not_found", subscription_id=subscription_id)
-        return {"subscription_id": subscription_id, "status": "not_found"}
-
-    if not sub.is_active:
-        logger.info("digest_subscription_inactive", subscription_id=subscription_id)
-        return {"subscription_id": subscription_id, "status": "inactive"}
-
     prompt_loader = PromptLoader(prompts_dir=str(settings.prompts_dir))
 
     def _llm_factory():
         provider, api_key, model = resolve_llm_config("digest")
         return create_llm_client(provider=provider, api_key=api_key, model=model)
 
+    # Resolve the subscription inside the same DB context that the service
+    # will use, so an MCP-side delete/pause that lands between fetch and run
+    # surfaces as "not_found" / "inactive" instead of a stale delivery.
     async with (
-        ingestion_and_processing_repos() as (state_repo, processed_repo, _db2),
+        ingestion_and_processing_repos() as (_state_repo, processed_repo, _db2),
         digest_subscription_repo() as (sub_repo, _db3),
     ):
+        sub = await sub_repo.get(subscription_id)
+
+        if sub is None:
+            logger.warning("digest_subscription_not_found", subscription_id=subscription_id)
+            return {"subscription_id": subscription_id, "status": "not_found"}
+
+        if not sub.is_active:
+            logger.info("digest_subscription_inactive", subscription_id=subscription_id)
+            return {"subscription_id": subscription_id, "status": "inactive"}
+
         service = DigestService(
             processed_repo=processed_repo,
-            ingestion_repo=state_repo,
             subscription_repo=sub_repo,
             prompt_loader=prompt_loader,
             llm_client_factory=_llm_factory,

--- a/tg_parser/services/scheduler_service.py
+++ b/tg_parser/services/scheduler_service.py
@@ -334,6 +334,141 @@ async def _run_scheduler_async(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# F6 — Scheduled Digests: scheduler entry point + reconciliation
+# ---------------------------------------------------------------------------
+
+
+async def run_scheduled_digests_task(subscription_id: str) -> dict[str, Any]:
+    """APScheduler entry point — generate and deliver one digest tick.
+
+    Looks up the subscription, builds a ``DigestService`` against the live
+    repos / prompt loader / LLM factory, and dispatches to
+    ``DigestService.run_for_subscription``. The cursor is advanced inside the
+    service (only on successful delivery / successful empty-skip).
+
+    Returns a small status dict for logging / metrics. Never raises — failures
+    are logged and surfaced via the return value so the scheduler wrapper does
+    not retry storms.
+    """
+    from tg_parser.bot.runtime import get_bot
+    from tg_parser.processing.llm.factory import (
+        create_llm_client,
+        resolve_llm_config,
+    )
+    from tg_parser.processing.prompt_loader import PromptLoader
+    from tg_parser.services.db_context import (
+        digest_subscription_repo,
+        ingestion_and_processing_repos,
+    )
+    from tg_parser.services.digest_service import DigestService
+
+    logger.info("digest_task_triggered", subscription_id=subscription_id)
+
+    async with digest_subscription_repo() as (sub_repo_lookup, _db1):
+        sub = await sub_repo_lookup.get(subscription_id)
+
+    if sub is None:
+        logger.warning("digest_subscription_not_found", subscription_id=subscription_id)
+        return {"subscription_id": subscription_id, "status": "not_found"}
+
+    if not sub.is_active:
+        logger.info("digest_subscription_inactive", subscription_id=subscription_id)
+        return {"subscription_id": subscription_id, "status": "inactive"}
+
+    prompt_loader = PromptLoader(prompts_dir=str(settings.prompts_dir))
+
+    def _llm_factory():
+        provider, api_key, model = resolve_llm_config("digest")
+        return create_llm_client(provider=provider, api_key=api_key, model=model)
+
+    async with (
+        ingestion_and_processing_repos() as (state_repo, processed_repo, _db2),
+        digest_subscription_repo() as (sub_repo, _db3),
+    ):
+        service = DigestService(
+            processed_repo=processed_repo,
+            ingestion_repo=state_repo,
+            subscription_repo=sub_repo,
+            prompt_loader=prompt_loader,
+            llm_client_factory=_llm_factory,
+            max_docs_per_run=settings.digest_max_docs_per_run,
+            first_run_lookback_hours=settings.digest_first_run_lookback_hours,
+            message_max_chars=settings.digest_message_max_chars,
+            max_message_parts=settings.digest_max_message_parts,
+        )
+        result = await service.run_for_subscription(sub, get_bot())
+
+    return {
+        "subscription_id": subscription_id,
+        "status": (
+            "delivery_failed"
+            if result.delivery_failed
+            else ("skipped" if result.skipped else "delivered")
+        ),
+        "docs_count": result.docs_count,
+        "delivery_error": result.delivery_error,
+    }
+
+
+async def reconcile_digest_subscriptions() -> dict[str, Any]:
+    """Diff active subscriptions in the DB against scheduler jobs.
+
+    Adds jobs for newly-created/activated subscriptions, removes jobs for
+    deleted/paused ones. Designed to be invoked periodically inside the bot
+    process so MCP-side mutations propagate without a restart.
+    """
+    from tg_parser.services.background_scheduler import (
+        get_registered_digest_subscription_ids,
+        register_digest_subscription,
+        unregister_digest_subscription,
+    )
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    async with digest_subscription_repo() as (sub_repo, _db):
+        active = await sub_repo.list_active()
+
+    desired_ids = {sub.id for sub in active}
+    registered_ids = get_registered_digest_subscription_ids()
+
+    added: list[str] = []
+    removed: list[str] = []
+    failed: list[str] = []
+
+    for sub in active:
+        if sub.id in registered_ids:
+            continue
+        try:
+            register_digest_subscription(sub)
+            added.append(sub.id)
+        except ValueError as exc:
+            logger.warning(
+                "digest_reconcile_register_failed",
+                subscription_id=sub.id,
+                error=str(exc),
+            )
+            failed.append(sub.id)
+
+    for sub_id in registered_ids - desired_ids:
+        if unregister_digest_subscription(sub_id):
+            removed.append(sub_id)
+
+    if added or removed or failed:
+        logger.info(
+            "digest_reconcile",
+            added=len(added),
+            removed=len(removed),
+            failed=len(failed),
+        )
+
+    return {
+        "active_count": len(desired_ids),
+        "added": added,
+        "removed": removed,
+        "failed": failed,
+    }
+
+
 async def incremental_pipeline_task() -> dict:
     """
     Periodic task: run incremental pipeline for all active sources.

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from tg_parser.domain.models import (
     BundleItem,
+    DigestFormat,
+    DigestSubscription,
     ProcessedDocument,
     RawTelegramMessage,
     TopicBundle,
@@ -1167,4 +1169,67 @@ class HandoffHistoryRepo(ABC):
         to_date: datetime | None = None,
     ) -> dict[str, Any]:
         """Get handoff statistics."""
+        pass
+
+
+# ============================================================================
+# Digest Subscriptions (F6 Scheduled Digests)
+# ============================================================================
+
+
+class DigestSubscriptionRepo(ABC):
+    """
+    Repository for scheduled-digest subscriptions (F6).
+
+    Storage: PostgreSQL (`digest_subscriptions` in ingestion DB).
+    """
+
+    @abstractmethod
+    async def create(self, sub: DigestSubscription) -> DigestSubscription:
+        """Persist a new subscription. Returns the row with server-side defaults populated."""
+        pass
+
+    @abstractmethod
+    async def get(self, subscription_id: str) -> DigestSubscription | None:
+        """Look up a subscription by id; returns None if absent."""
+        pass
+
+    @abstractmethod
+    async def update(
+        self,
+        subscription_id: str,
+        *,
+        is_active: bool | None = None,
+        last_sent_at: datetime | None = None,
+        last_digest_cursor: datetime | None = None,
+        cron_expression: str | None = None,
+        timezone: str | None = None,
+        format: DigestFormat | None = None,
+        language: str | None = None,
+        chat_id: int | None = None,
+        name: str | None = None,
+        channel_ids: list[str] | None = None,
+    ) -> DigestSubscription | None:
+        """
+        Partial update. Pass only fields that should change; omitted fields retain their value.
+
+        Note: ``last_sent_at`` and ``last_digest_cursor`` are nullable in the schema, but this
+        method does NOT support setting them back to NULL — pass non-None values to update or
+        omit to keep unchanged. (No use case for un-setting cursors today.)
+        """
+        pass
+
+    @abstractmethod
+    async def delete(self, subscription_id: str) -> bool:
+        """Delete a subscription. Returns True if a row was removed."""
+        pass
+
+    @abstractmethod
+    async def list_by_owner(self, owner_id: str) -> list[DigestSubscription]:
+        """All subscriptions owned by ``owner_id``, ordered by created_at."""
+        pass
+
+    @abstractmethod
+    async def list_active(self) -> list[DigestSubscription]:
+        """All ``is_active = true`` subscriptions (used by scheduler bootstrap + reconciliation)."""
         pass

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -1230,6 +1230,11 @@ class DigestSubscriptionRepo(ABC):
         pass
 
     @abstractmethod
+    async def list_all(self) -> list[DigestSubscription]:
+        """Every subscription regardless of active state (admin views)."""
+        pass
+
+    @abstractmethod
     async def list_active(self) -> list[DigestSubscription]:
         """All ``is_active = true`` subscriptions (used by scheduler bootstrap + reconciliation)."""
         pass

--- a/tg_parser/storage/sqlalchemy/__init__.py
+++ b/tg_parser/storage/sqlalchemy/__init__.py
@@ -7,6 +7,7 @@ PostgreSQL via SQLAlchemy 2.x async.
 from .agent_state_repo import SAAgentStateRepo
 from .agent_stats_repo import SAAgentStatsRepo
 from .database import Database
+from .digest_subscription_repo import SADigestSubscriptionRepo
 from .embedding_repo import SAEmbeddingRepo
 from .handoff_history_repo import SAHandoffHistoryRepo
 from .ingestion_state_repo import SAIngestionStateRepo
@@ -46,4 +47,6 @@ __all__ = [
     "SAHandoffHistoryRepo",
     # Multi-Tenancy (F4)
     "SAUserRepo",
+    # Scheduled Digests (F6)
+    "SADigestSubscriptionRepo",
 ]

--- a/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
+++ b/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
@@ -1,0 +1,176 @@
+"""
+SQLAlchemy implementation of DigestSubscriptionRepo (F6 Scheduled Digests).
+"""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tg_parser.domain.models import DigestFormat, DigestSubscription
+from tg_parser.storage.ports import DigestSubscriptionRepo
+
+
+_SELECT_COLUMNS = (
+    "id, owner_id, chat_id, name, channel_ids, cron_expression, timezone, "
+    "format, language, is_active, last_sent_at, last_digest_cursor, "
+    "created_at, updated_at"
+)
+
+
+class SADigestSubscriptionRepo(DigestSubscriptionRepo):
+    """PostgreSQL-backed digest-subscription repository (ingestion DB)."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, sub: DigestSubscription) -> DigestSubscription:
+        query = text(f"""
+            INSERT INTO digest_subscriptions
+                (owner_id, chat_id, name, channel_ids, cron_expression,
+                 timezone, format, language, is_active,
+                 last_sent_at, last_digest_cursor)
+            VALUES
+                (:owner_id, :chat_id, :name, :channel_ids, :cron_expression,
+                 :timezone, :format, :language, :is_active,
+                 :last_sent_at, :last_digest_cursor)
+            RETURNING {_SELECT_COLUMNS}
+        """)
+        result = await self.session.execute(
+            query,
+            {
+                "owner_id": sub.owner_id,
+                "chat_id": sub.chat_id,
+                "name": sub.name,
+                "channel_ids": list(sub.channel_ids),
+                "cron_expression": sub.cron_expression,
+                "timezone": sub.timezone,
+                "format": str(sub.format.value),
+                "language": sub.language,
+                "is_active": sub.is_active,
+                "last_sent_at": sub.last_sent_at,
+                "last_digest_cursor": sub.last_digest_cursor,
+            },
+        )
+        row = result.fetchone()
+        await self.session.commit()
+        return self._row_to_model(row)
+
+    async def get(self, subscription_id: str) -> DigestSubscription | None:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions WHERE id = :id"
+            ),
+            {"id": subscription_id},
+        )
+        row = result.fetchone()
+        return self._row_to_model(row) if row else None
+
+    async def update(
+        self,
+        subscription_id: str,
+        *,
+        is_active: bool | None = None,
+        last_sent_at: datetime | None = None,
+        last_digest_cursor: datetime | None = None,
+        cron_expression: str | None = None,
+        timezone: str | None = None,
+        format: DigestFormat | None = None,
+        language: str | None = None,
+        chat_id: int | None = None,
+        name: str | None = None,
+        channel_ids: list[str] | None = None,
+    ) -> DigestSubscription | None:
+        sets: list[str] = []
+        params: dict[str, Any] = {"id": subscription_id}
+
+        if is_active is not None:
+            sets.append("is_active = :is_active")
+            params["is_active"] = is_active
+        if last_sent_at is not None:
+            sets.append("last_sent_at = :last_sent_at")
+            params["last_sent_at"] = last_sent_at
+        if last_digest_cursor is not None:
+            sets.append("last_digest_cursor = :last_digest_cursor")
+            params["last_digest_cursor"] = last_digest_cursor
+        if cron_expression is not None:
+            sets.append("cron_expression = :cron_expression")
+            params["cron_expression"] = cron_expression
+        if timezone is not None:
+            sets.append("timezone = :timezone")
+            params["timezone"] = timezone
+        if format is not None:
+            sets.append("format = :format")
+            params["format"] = str(format.value)
+        if language is not None:
+            sets.append("language = :language")
+            params["language"] = language
+        if chat_id is not None:
+            sets.append("chat_id = :chat_id")
+            params["chat_id"] = chat_id
+        if name is not None:
+            sets.append("name = :name")
+            params["name"] = name
+        if channel_ids is not None:
+            sets.append("channel_ids = :channel_ids")
+            params["channel_ids"] = list(channel_ids)
+
+        if not sets:
+            return await self.get(subscription_id)
+
+        sets.append("updated_at = NOW()")
+        sql = (
+            f"UPDATE digest_subscriptions SET {', '.join(sets)} "
+            f"WHERE id = :id RETURNING {_SELECT_COLUMNS}"
+        )
+        result = await self.session.execute(text(sql), params)
+        row = result.fetchone()
+        await self.session.commit()
+        return self._row_to_model(row) if row else None
+
+    async def delete(self, subscription_id: str) -> bool:
+        result = await self.session.execute(
+            text("DELETE FROM digest_subscriptions WHERE id = :id"),
+            {"id": subscription_id},
+        )
+        await self.session.commit()
+        return (result.rowcount or 0) > 0
+
+    async def list_by_owner(self, owner_id: str) -> list[DigestSubscription]:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
+                f"WHERE owner_id = :owner_id ORDER BY created_at"
+            ),
+            {"owner_id": owner_id},
+        )
+        return [self._row_to_model(row) for row in result.fetchall()]
+
+    async def list_active(self) -> list[DigestSubscription]:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
+                f"WHERE is_active = TRUE ORDER BY created_at"
+            ),
+        )
+        return [self._row_to_model(row) for row in result.fetchall()]
+
+    @staticmethod
+    def _row_to_model(row: Any) -> DigestSubscription:
+        return DigestSubscription(
+            id=str(row.id),
+            owner_id=str(row.owner_id),
+            chat_id=int(row.chat_id),
+            name=row.name,
+            channel_ids=list(row.channel_ids or []),
+            cron_expression=row.cron_expression,
+            timezone=row.timezone,
+            format=DigestFormat(row.format),
+            language=row.language,
+            is_active=bool(row.is_active),
+            last_sent_at=row.last_sent_at,
+            last_digest_cursor=row.last_digest_cursor,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )

--- a/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
+++ b/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tg_parser.domain.models import DigestFormat, DigestSubscription
 from tg_parser.storage.ports import DigestSubscriptionRepo
 
-
 _SELECT_COLUMNS = (
     "id, owner_id, chat_id, name, channel_ids, cron_expression, timezone, "
     "format, language, is_active, last_sent_at, last_digest_cursor, "
@@ -78,9 +77,7 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
 
     async def get(self, subscription_id: str) -> DigestSubscription | None:
         result = await self.session.execute(
-            text(
-                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions WHERE id = :id"
-            ),
+            text(f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions WHERE id = :id"),
             {"id": subscription_id},
         )
         row = result.fetchone()
@@ -181,10 +178,7 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
         Sorted by ``created_at`` ascending.
         """
         result = await self.session.execute(
-            text(
-                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
-                f"ORDER BY created_at"
-            ),
+            text(f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions ORDER BY created_at"),
         )
         return [self._row_to_model(row) for row in result.fetchall()]
 

--- a/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
+++ b/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
@@ -26,19 +26,37 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
         self.session = session
 
     async def create(self, sub: DigestSubscription) -> DigestSubscription:
-        query = text(f"""
-            INSERT INTO digest_subscriptions
-                (owner_id, chat_id, name, channel_ids, cron_expression,
-                 timezone, format, language, is_active,
-                 last_sent_at, last_digest_cursor)
-            VALUES
-                (:owner_id, :chat_id, :name, :channel_ids, :cron_expression,
-                 :timezone, :format, :language, :is_active,
-                 :last_sent_at, :last_digest_cursor)
-            RETURNING {_SELECT_COLUMNS}
-        """)
-        result = await self.session.execute(
-            query,
+        # When the caller pre-allocates an id (e.g. so that the scheduler can
+        # register the job before persistence), preserve it instead of relying
+        # on the database's gen_random_uuid() default.
+        provided_id = (sub.id or "").strip()
+        if provided_id:
+            query = text(f"""
+                INSERT INTO digest_subscriptions
+                    (id, owner_id, chat_id, name, channel_ids, cron_expression,
+                     timezone, format, language, is_active,
+                     last_sent_at, last_digest_cursor)
+                VALUES
+                    (:id, :owner_id, :chat_id, :name, :channel_ids,
+                     :cron_expression, :timezone, :format, :language,
+                     :is_active, :last_sent_at, :last_digest_cursor)
+                RETURNING {_SELECT_COLUMNS}
+            """)
+            params = {"id": provided_id}
+        else:
+            query = text(f"""
+                INSERT INTO digest_subscriptions
+                    (owner_id, chat_id, name, channel_ids, cron_expression,
+                     timezone, format, language, is_active,
+                     last_sent_at, last_digest_cursor)
+                VALUES
+                    (:owner_id, :chat_id, :name, :channel_ids, :cron_expression,
+                     :timezone, :format, :language, :is_active,
+                     :last_sent_at, :last_digest_cursor)
+                RETURNING {_SELECT_COLUMNS}
+            """)
+            params = {}
+        params.update(
             {
                 "owner_id": sub.owner_id,
                 "chat_id": sub.chat_id,
@@ -51,8 +69,9 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
                 "is_active": sub.is_active,
                 "last_sent_at": sub.last_sent_at,
                 "last_digest_cursor": sub.last_digest_cursor,
-            },
+            }
         )
+        result = await self.session.execute(query, params)
         row = result.fetchone()
         await self.session.commit()
         return self._row_to_model(row)
@@ -152,6 +171,19 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
             text(
                 f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
                 f"WHERE is_active = TRUE ORDER BY created_at"
+            ),
+        )
+        return [self._row_to_model(row) for row in result.fetchall()]
+
+    async def list_all(self) -> list[DigestSubscription]:
+        """Return every subscription regardless of ``is_active`` (admin views).
+
+        Sorted by ``created_at`` ascending.
+        """
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
+                f"ORDER BY created_at"
             ),
         )
         return [self._row_to_model(row) for row in result.fetchall()]

--- a/tg_parser/storage/sqlalchemy/schemas/ingestion_state.py
+++ b/tg_parser/storage/sqlalchemy/schemas/ingestion_state.py
@@ -82,6 +82,30 @@ CREATE INDEX IF NOT EXISTS idx_uam_lookup ON user_auth_mappings(auth_type, auth_
 
 ALTER TABLE sources ADD COLUMN IF NOT EXISTS owner_id UUID REFERENCES users(id);
 CREATE INDEX IF NOT EXISTS idx_sources_owner ON sources(owner_id);
+
+-- Scheduled Digests (F6)
+CREATE TABLE IF NOT EXISTS digest_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    chat_id BIGINT NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    channel_ids TEXT[] NOT NULL,
+    cron_expression VARCHAR(100) NOT NULL DEFAULT '0 9 * * *',
+    timezone VARCHAR(50) NOT NULL DEFAULT 'UTC',
+    format VARCHAR(20) NOT NULL DEFAULT 'summary',
+    language VARCHAR(10) NOT NULL DEFAULT 'ru',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    last_sent_at TIMESTAMPTZ,
+    last_digest_cursor TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT digest_subscriptions_channel_ids_nonempty
+        CHECK (array_length(channel_ids, 1) >= 1)
+);
+CREATE INDEX IF NOT EXISTS idx_digest_subscriptions_owner_active
+    ON digest_subscriptions(owner_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_digest_subscriptions_active_cron
+    ON digest_subscriptions(is_active) WHERE is_active = TRUE;
 """
 
 


### PR DESCRIPTION
## Summary

Реализует **F6 — Scheduled Digests**: пользователь подписывается на автоматические сводки по выбранным Telegram-каналам, бот доставляет их в указанный чат по cron-расписанию.

**Дизайн:** [`docs/plans/F6_SCHEDULED_DIGESTS_PLAN.md`](docs/plans/F6_SCHEDULED_DIGESTS_PLAN.md)
**Issue/Future:** [`docs/notes/FUTURE_FEATURES.md`](docs/notes/FUTURE_FEATURES.md) §F6 (помечено ✅ DONE).
**Scope:** 2 коммита, +3590/-8, 23 файла.

### Что делает

1. Новая таблица `digest_subscriptions` (БД `ingestion`) хранит подписки: `owner_id`, `chat_id`, `channel_ids[]`, `cron_expression`, `timezone`, `format`, `language`, `last_digest_cursor`, `last_sent_at`.
2. `BackgroundScheduler` расширен `add_cron_task()` (APScheduler `CronTrigger`) + helpers `register/unregister/reschedule_digest_subscription`.
3. На каждом cron-тике `run_scheduled_digests_task` вызывает `DigestService`:
   - Берёт новые `ProcessedDocument`-ы (фильтр `processed_at > last_digest_cursor`, кап `DIGEST_MAX_DOCS_PER_RUN` per channel).
   - Группирует по каналам, рендерит prompt (`prompts/digest.yaml`) и зовёт LLM в новом стейдже **`digest`** (per-stage env / runtime override через `set_llm_config(scope=\"digest\")`).
   - Доставляет результат в Telegram через MarkdownV2 с эскейпом, splitting'ом >4096 и file-fallback (паттерн F2 size-gate).
4. **Bot runtime singleton** (`tg_parser/bot/runtime.py`) — process-local `Bot` reference, чтобы фоновые cron-задачи могли пушить сообщения вне polling-loop.
5. **Reconciliation loop** в bot-процессе (раз в `DIGEST_REFRESH_INTERVAL` сек) делает diff `digest_subscriptions` ↔ зарегистрированные jobs — подписки, созданные через MCP в API-процессе, подхватываются без рестарта.
6. **Bot-инструменты:** `subscribe_digest` / `list_digests` / `unsubscribe_digest` (LLM-агент бота вызывает их на естественные команды; `subscribe_digest` берёт `chat_id` из контекста сообщения).
7. **MCP-инструменты:** те же три тула с Pydantic Result-моделями и admin-vs-user семантикой listing'а; channel ownership через `assert_channel_access`.

### Cursor / idempotency

- Strict `>` (не `>=`) — последний документ не дубликатится на следующем тике.
- Первый запуск без `last_digest_cursor` → lookback `DIGEST_FIRST_RUN_LOOKBACK_HOURS` (default 24h); даже при пустом результате cursor сдвигается в `now()`, чтобы избежать повторной 24h-выборки.
- При `bot.send_message` failure cursor НЕ обновляется → следующий тик повторит (no message loss).
- Empty digest → сообщение НЕ отправляется, но `last_sent_at` обновляется для статистики.

### Single-process delivery

Дайджест-jobs запускаются **только в bot-процессе** (`DIGEST_SCHEDULER_ENABLED=true`). API/CLI daemon не шлют — нет дублей. Отдельный `BackgroundScheduler` инстанс для digest-loop, чтобы не конфликтовать с pipeline-scheduler'ом.

### Документация

- `docs/USER_GUIDE.md` — новая секция «Scheduled Digests (F6)»: обзор, cron-cheatsheet, форматы, LLM-конфиг, ownership, env-флаги.
- `docs/MCP_AGENT_GUIDE.md` — категория «Digests (F6)» в Tools by Category, schema-блоки трёх тулов и workflow #7 (subscribe → list → unsubscribe).
- `ENV_VARIABLES_GUIDE.md` — новая подсекция «Scheduled Digests (F6)» со всеми `DIGEST_*` переменными.
- `docs/notes/FUTURE_FEATURES.md` — §F6 помечен ✅ DONE.

### Файлы

- **Migration:** `migrations/versions/ingestion/20260418_add_digest_subscriptions.py` (revision `f6a1b2c3d4e5`).
- **Domain:** `tg_parser/domain/models.py` — `DigestFormat` (StrEnum), `DigestSubscription` (Pydantic).
- **Storage:** `tg_parser/storage/ports.py` (`DigestSubscriptionRepo` Protocol), `tg_parser/storage/sqlalchemy/digest_subscription_repo.py` (SA impl), `tg_parser/storage/sqlalchemy/schemas/ingestion_state.py` (test-fixture DDL).
- **Service:** `tg_parser/services/digest_service.py` (`DigestService`, `DigestResult`, `escape_markdown_v2`).
- **Scheduler:** `tg_parser/services/background_scheduler.py` (+`add_cron_task`, digest helpers), `tg_parser/services/scheduler_service.py` (+`run_scheduled_digests_task`, +`reconcile_digest_subscriptions`).
- **Bot:** `tg_parser/bot/runtime.py` (singleton), `tg_parser/bot/main.py` (lifecycle), `tg_parser/bot/tools.py` (3 декларации/executor'а).
- **MCP:** `tg_parser/mcp_server.py` (3 tool'а + Pydantic Result-модели + обновлены `_MCP_INSTRUCTIONS`).
- **Settings:** `tg_parser/config/settings.py` — `digest_*` поля + `LLM_SCOPES` расширен до `(\"global\", \"processing\", \"topicization\", \"rag\", \"digest\")`.
- **Prompt:** `prompts/digest.yaml`.
- **Tests:** `tests/test_f6_scheduled_digests.py` (~56 тестов): repo CRUD, service generation/cursor, prompt loader, LLM scope, scheduler cron, delivery (split/file fallback), bot runtime, bot tools, MCP tools, reconciliation, run_scheduled_digests_task entry point. Также мелкие правки в `tests/test_bot_tools_v11.py`/`v12.py` — обновлён ассерт количества тулов (25 → 28).

## Test plan

- [x] **SQLite-only:** `python -m pytest tests/test_f6_scheduled_digests.py -x` → 34 passed, 21 skipped.
- [x] **Postgres + полная регрессия:** `TEST_POSTGRES=1 python -m pytest tests/ -x -q` → **1592 passed** (1536 baseline + 27 commit1 + 29 commit2), 0 failures.
- [x] Self-review checklist §1.7 (commit 1) и §2.7 (commit 2) — пройден.
- [x] Linter clean на всех изменённых файлах.
- [ ] **Smoke-test на реальном окружении** (рекомендуется до merge): применить миграцию, поднять бота с `DIGEST_SCHEDULER_ENABLED=true`, оформить тестовую подписку через `/start` и через MCP, убедиться, что доставка работает и cursor сдвигается. Параллельно проверить file-fallback при искусственно низком `DIGEST_MAX_MESSAGE_PARTS`.

## Migration & rollout

1. `alembic -c migrations/alembic.ini upgrade f6a1b2c3d4e5` — создаёт `digest_subscriptions` (idempotent через `IF NOT EXISTS`, есть и `downgrade()`).
2. Включить флаги в `.env`:
   ```
   SCHEDULER_ENABLED=true
   DIGEST_SCHEDULER_ENABLED=true
   DIGEST_DEFAULT_TIMEZONE=Europe/Moscow
   ```
3. Перезапустить bot-процесс (singleton, отвечает за доставку). API/CLI рестарт не нужен — они подписки **только** создают/удаляют, доставку не делают.

## Backwards compatibility

- Никаких breaking changes: новая таблица, новые env-флаги (все с дефолтами), новые tool'ы (без переименований существующих). При `DIGEST_SCHEDULER_ENABLED=false` фича полностью disabled, поведение системы идентично pre-F6.


Made with [Cursor](https://cursor.com)