### PR TITLE
fix(migrations): linearize duplicate revision e5f6a7b8c9d0

### DIFF
--- a/migrations/versions/processing/20260418_add_content_hash.py
+++ b/migrations/versions/processing/20260418_add_content_hash.py
@@ -1,7 +1,7 @@
 """add content_hash to processed_documents (F5-A Phase 3)
 
-Revision ID: e5f6a7b8c9d0
-Revises: d4e5f6a7b8c9
+Revision ID: f5a3c0d7e8b9
+Revises: e5f6a7b8c9d0
 Create Date: 2026-04-18
 
 F5-A Phase 3: Deduplication via SHA-256 content-hash.
@@ -13,6 +13,20 @@ Safe for large tables: column is NULLable so ADD COLUMN is O(1); index
 is created concurrently-safe (the partial predicate lets us rebuild
 without blocking).  Backfill is done via the ``backfill-content-hash``
 CLI, not in this migration.
+
+NOTE on revision id: this migration originally landed in main with
+``revision = "e5f6a7b8c9d0"``, colliding with
+``20260417_add_fts_to_topic_cards``.  Both files declared the same
+revision and both pointed at ``d4e5f6a7b8c9`` as the parent, which made
+Alembic refuse to resolve heads
+(``UserWarning: Revision e5f6a7b8c9d0 is present more than once``).
+The fix is structural, not behavioural: we re-id this (newer-by-date)
+migration to ``f5a3c0d7e8b9`` and chain it after
+``e5f6a7b8c9d0`` (FTS topic_cards), restoring a linear history.  No
+``alembic_version`` rewrites are needed on environments that have not
+yet run either migration; environments where the original (buggy) id
+was already stamped should ``alembic stamp f5a3c0d7e8b9`` after pulling
+this fix to keep their bookkeeping aligned.
 """
 
 from collections.abc import Sequence
@@ -20,8 +34,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "e5f6a7b8c9d0"
-down_revision: str | None = "d4e5f6a7b8c9"
+revision: str = "f5a3c0d7e8b9"
+down_revision: str | None = "e5f6a7b8c9d0"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Problem

Two F5-A migrations landed in main with the same Alembic revision id and the same parent, which broke head resolution:

| File | revision | down_revision |
|---|---|---|
| `20260417_add_fts_to_topic_cards.py` (Phase 1) | `e5f6a7b8c9d0` | `d4e5f6a7b8c9` |
| `20260418_add_content_hash.py` (Phase 3) | `e5f6a7b8c9d0` | `d4e5f6a7b8c9` |

Symptom: any `alembic` invocation emits `UserWarning: Revision e5f6a7b8c9d0 is present more than once`, and `tg-parser db upgrade --db processing` cannot resolve a single head — making the project unusable on a clean database.

This was discovered while preparing the dev environment for the F6 smoke-test (PR #11). It is pre-existing in main and unrelated to F6 itself.

## Fix

Re-id the **newer-by-date** migration (`add_content_hash`, 18 Apr) to `f5a3c0d7e8b9` and chain it **after** `e5f6a7b8c9d0`. The actual DDL is untouched — purely a metadata/topology fix.

```
... d4e5f6a7b8c9
      -> e5f6a7b8c9d0 (FTS topic_cards)
          -> f5a3c0d7e8b9 (content_hash)   [NEW HEAD]
```

## Operator notes

- **Clean / pre-Phase3 environments** — just `tg-parser db upgrade --db processing` after pull. Catches up linearly.
- **Environments that already ran the buggy version** and have `e5f6a7b8c9d0` stamped — run `tg-parser db stamp --db processing f5a3c0d7e8b9` after pull to align `alembic_version` with the new linear history. Schema is already correct, no DDL re-runs.

## Why a separate PR (not in F6)

F6 (#11) is a feature change. This is a metadata bug-fix in shipped main that affects every consumer of the project, not just F6. Keeping them separate makes the history readable and lets this hotfix land independently of feature review cycles.

## Verification

- `tg-parser db history --db processing` reports a single head `f5a3c0d7e8b9`, linear chain.
- `pytest tests/ -q` -> 1446 passed, 90 skipped (PG-only without TEST_POSTGRES=1), 0 failed.
- Doc references to `e5f6a7b8c9d0` in USER_GUIDE / ENV_VARIABLES_GUIDE intentionally left as-is — they describe the FTS-topic_cards migration, whose id is unchanged.

## Follow-ups (not in this PR)

- Consider adding a CI step `alembic check` (or equivalent) that fails on duplicate revision ids — this would have caught the conflict at PR-time and is the same thing that surfaced the bug here.

Made with [Cursor](https://cursor.com)