### PR TITLE
feat(watchlist): expose Prometheus surface for F11 watchlist (TD-02, Phase 1)

### DIFF
--- a/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
+++ b/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
@@ -178,6 +178,41 @@ FROM topic_card_versions;
 ```
 **Ожидание (24 ч):** rows ≈ суммарное `tg_resummarize_total{outcome="ok"}` за сутки. Размер должен быть в МБ, не ГБ. Если рост слишком быстрый — это сигнал к Phase 2 пункту #1 (TTL/retention).
 
+### F11 watchlist health (TD-02 — добавлено в post-Living-KB Phase 1)
+
+F11 watchlist делит scheduler tick с F5-C; следующие PromQL-снипеты позволяют убедиться что F11 живой и помогают калибровать threshold перед F11 P2.
+
+**Match-flow по 1 часу:**
+```promql
+rate(tg_watchlist_matches_total{result="delivered"}[1h])
+rate(tg_watchlist_matches_total{result="filtered_threshold"}[1h])
+rate(tg_watchlist_matches_total{result="filtered_keywords"}[1h])
+```
+Если `delivered = 0` и `filtered_threshold > 0` — порог слишком высок (либо реально нет совпадений). Если `filtered_keywords` высокий — exclude-keywords агрессивно режут.
+
+**Distribution of combined scores (calibration для F11 P2):**
+```promql
+histogram_quantile(0.5, sum by (le) (rate(tg_watchlist_score_bucket[1h])))
+histogram_quantile(0.9, sum by (le) (rate(tg_watchlist_score_bucket[1h])))
+```
+Использовать после ≥ 24 ч продакшн-сигнала чтобы выбрать sane default threshold (текущий 0.6 — placeholder).
+
+**Delivery success rate:**
+```promql
+rate(tg_watchlist_delivery_total{outcome="sent"}[1h])
+rate(tg_watchlist_delivery_total{outcome="blocked"}[1h])
+rate(tg_watchlist_delivery_total{outcome="error"}[1h])
+```
+`blocked` > 0 значит юзер заблокировал бота — interest soft-deleted автоматически. `error` > 0 — Telegram rate-limit / транзиентные ошибки; систематически > 5% → проверять bot токен / network.
+
+**Active interests:**
+```promql
+tg_watchlist_active_interests
+```
+Gauge. Падение к нулю при non-empty `subscribe_watchlist` calls — индикатор массового soft-delete (например после длительного `blocked` storm).
+
+**Tripwire (для F11):** `rate(tg_watchlist_delivery_total{outcome="error"}[5m]) > 0.1` — открыть hot-fix issue.
+
 ### Где смотреть в Grafana
 
 Если Grafana уже настроена (см. `docker/grafana/provisioning/`) — можно собрать панель ad-hoc прямо в UI:

--- a/tests/test_watchlist_metrics.py
+++ b/tests/test_watchlist_metrics.py
@@ -1,0 +1,291 @@
+"""Unit tests for F11 watchlist Prometheus metrics surface (TD-02).
+
+Covers:
+
+- :func:`tg_parser.api.metrics.record_watchlist_match` increments the right
+  ``tg_watchlist_matches_total{result}`` series and observes into
+  ``tg_watchlist_score``.
+- :func:`tg_parser.api.metrics.record_watchlist_delivery` increments the
+  right ``tg_watchlist_delivery_total{outcome}`` series.
+- :func:`tg_parser.api.metrics.set_watchlist_active` updates the gauge.
+- Scoring boundary clamps in ``record_watchlist_match`` keep the histogram
+  observation in [0, 1].
+- :class:`tg_parser.services.watchlist_service.WatchlistService.check_interests`
+  emits at least one match metric for a real (interest, doc) pair.
+
+These tests intentionally probe the global Prometheus singletons; they read
+counter values before and after the action under test to be robust against
+other tests in the suite touching the same series.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tg_parser.api.metrics import (
+    WATCHLIST_ACTIVE_INTERESTS,
+    WATCHLIST_DELIVERY,
+    WATCHLIST_MATCHES,
+    WATCHLIST_SCORE,
+    record_watchlist_delivery,
+    record_watchlist_match,
+    set_watchlist_active,
+)
+
+
+def _counter_value(counter, **labels: str) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+def _histogram_count(histogram) -> float:
+    return histogram._sum.get()
+
+
+# ----------------------------------------------------------------------------
+# record_watchlist_match
+# ----------------------------------------------------------------------------
+
+
+def test_record_watchlist_match_increments_delivered_counter() -> None:
+    before = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    record_watchlist_match(result="delivered", score=0.85)
+    after = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    assert after == pytest.approx(before + 1.0)
+
+
+def test_record_watchlist_match_increments_filtered_counters() -> None:
+    before_kw = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    before_th = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+    record_watchlist_match(result="filtered_keywords", score=0.0)
+    record_watchlist_match(result="filtered_threshold", score=0.45)
+    assert _counter_value(WATCHLIST_MATCHES, result="filtered_keywords") == pytest.approx(
+        before_kw + 1.0
+    )
+    assert _counter_value(WATCHLIST_MATCHES, result="filtered_threshold") == pytest.approx(
+        before_th + 1.0
+    )
+
+
+def test_record_watchlist_match_observes_score_histogram() -> None:
+    sum_before = _histogram_count(WATCHLIST_SCORE)
+    record_watchlist_match(result="delivered", score=0.7)
+    record_watchlist_match(result="filtered_threshold", score=0.5)
+    sum_after = _histogram_count(WATCHLIST_SCORE)
+    assert math.isclose(sum_after - sum_before, 1.2, abs_tol=1e-6)
+
+
+def test_record_watchlist_match_clamps_score_into_unit_interval() -> None:
+    sum_before = _histogram_count(WATCHLIST_SCORE)
+    record_watchlist_match(result="delivered", score=1.5)
+    record_watchlist_match(result="filtered_threshold", score=-0.3)
+    sum_after = _histogram_count(WATCHLIST_SCORE)
+    # 1.5 clamps to 1.0; -0.3 clamps to 0.0 → total observed = 1.0
+    assert math.isclose(sum_after - sum_before, 1.0, abs_tol=1e-6)
+
+
+# ----------------------------------------------------------------------------
+# record_watchlist_delivery
+# ----------------------------------------------------------------------------
+
+
+def test_record_watchlist_delivery_increments_outcomes() -> None:
+    before_sent = _counter_value(WATCHLIST_DELIVERY, outcome="sent")
+    before_blocked = _counter_value(WATCHLIST_DELIVERY, outcome="blocked")
+    before_error = _counter_value(WATCHLIST_DELIVERY, outcome="error")
+
+    record_watchlist_delivery(outcome="sent")
+    record_watchlist_delivery(outcome="blocked")
+    record_watchlist_delivery(outcome="error")
+
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="sent") == pytest.approx(
+        before_sent + 1.0
+    )
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="blocked") == pytest.approx(
+        before_blocked + 1.0
+    )
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="error") == pytest.approx(
+        before_error + 1.0
+    )
+
+
+# ----------------------------------------------------------------------------
+# set_watchlist_active
+# ----------------------------------------------------------------------------
+
+
+def test_set_watchlist_active_sets_gauge() -> None:
+    set_watchlist_active(7)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(7.0)
+    set_watchlist_active(0)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(0.0)
+
+
+def test_set_watchlist_active_clamps_negative_to_zero() -> None:
+    set_watchlist_active(-5)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(0.0)
+
+
+# ----------------------------------------------------------------------------
+# Service-level smoke test — check_interests emits match metrics
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_interests_records_match_metric_for_real_pair(
+    service_with_interest_and_doc,
+) -> None:
+    """End-to-end: at least one ``record_watchlist_match`` call fires when
+    the service scores a candidate pair. We don't assert the exact result
+    label here (the test fixture chooses the score), only that *some*
+    label was incremented.
+    """
+    service, channel_id, source_ref = service_with_interest_and_doc
+
+    delivered_before = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    filt_kw_before = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    filt_th_before = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+
+    await service.check_interests(channel_id, [source_ref])
+
+    delivered_after = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    filt_kw_after = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    filt_th_after = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+
+    total_delta = (
+        (delivered_after - delivered_before)
+        + (filt_kw_after - filt_kw_before)
+        + (filt_th_after - filt_th_before)
+    )
+    assert total_delta >= 1.0, (
+        "expected at least one tg_watchlist_matches_total increment for a "
+        f"real (interest, doc) pair, got delta={total_delta}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service_with_interest_and_doc():
+    """Build a :class:`WatchlistService` with in-memory fakes and one interest +
+    one matching document. Returns ``(service, channel_id, source_ref)``.
+
+    Both the interest and the document are populated directly into the in-memory
+    fake stores (no awaits) so the fixture is sync and pytest-asyncio agnostic.
+    """
+    from datetime import UTC, datetime
+
+    from tg_parser.domain.models import (
+        NotifyMode,
+        ProcessedDocument,
+        WatchInterest,
+    )
+    from tg_parser.services.watchlist_service import WatchlistService
+
+    class _FakeInterestRepo:
+        def __init__(self) -> None:
+            self.store: dict[str, WatchInterest] = {}
+
+        async def get(self, interest_id: str) -> WatchInterest | None:
+            return self.store.get(interest_id)
+
+        async def list_all(self) -> list[WatchInterest]:
+            return list(self.store.values())
+
+        async def list_active_for_channel(self, channel_id: str) -> list[WatchInterest]:
+            return [
+                i for i in self.store.values() if i.is_active and channel_id in i.channel_ids
+            ]
+
+        async def update_embedding(self, interest_id: str, embedding: list[float]) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"embedding": list(embedding)}
+                )
+
+        async def touch_checked(self, interest_id: str, at: datetime) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"last_checked_at": at}
+                )
+
+        async def touch_match(self, interest_id: str, at: datetime) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"last_match_at": at}
+                )
+
+    class _FakeMatchRepo:
+        def __init__(self) -> None:
+            self.store: dict[tuple[str, str], object] = {}
+
+        async def upsert_many(self, matches):
+            inserted = []
+            for match in matches:
+                key = (match.interest_id, match.source_ref)
+                if key in self.store:
+                    continue
+                self.store[key] = match
+                inserted.append(match)
+            return inserted
+
+    class _FakeProcDocRepo:
+        def __init__(self) -> None:
+            self.store: dict[str, ProcessedDocument] = {}
+
+        async def get_by_source_refs(self, refs):
+            return {ref: self.store[ref] for ref in refs if ref in self.store}
+
+    class _FakeEmbeddingRepo:
+        async def get_by_source_ref(self, ref):
+            return None
+
+    interest_repo = _FakeInterestRepo()
+    match_repo = _FakeMatchRepo()
+    doc_repo = _FakeProcDocRepo()
+    embedding_repo = _FakeEmbeddingRepo()
+
+    channel_id = "ch-watchlist-metrics"
+    source_ref = "tg:metrics_test:post:1"
+
+    interest_id = "int-1"
+    interest_repo.store[interest_id] = WatchInterest(
+        id=interest_id,
+        user_id="user-1",
+        chat_id=12345,
+        title="Crypto regulations",
+        description=None,
+        keywords=["mica", "regulation", "crypto"],
+        exclude_keywords=[],
+        channel_ids=[channel_id],
+        threshold=0.3,
+        notify_mode=NotifyMode.INSTANT,
+        is_active=True,
+        embedding=None,
+    )
+
+    doc_repo.store[source_ref] = ProcessedDocument(
+        id="doc:" + source_ref,
+        source_ref=source_ref,
+        source_message_id="msg-1",
+        channel_id=channel_id,
+        processed_at=datetime.now(UTC),
+        text_clean="MiCA regulation update for crypto exchanges in 2026",
+        summary="MiCA crypto regulation",
+        topics=["crypto", "regulation"],
+        entities=[],
+    )
+
+    service = WatchlistService(
+        interest_repo=interest_repo,
+        match_repo=match_repo,
+        processed_doc_repo=doc_repo,
+        embedding_repo=embedding_repo,
+        embedding_client=None,
+    )
+
+    return service, channel_id, source_ref

--- a/tg_parser/api/metrics.py
+++ b/tg_parser/api/metrics.py
@@ -138,6 +138,84 @@ RESUMMARIZE_DURATION_SECONDS = Histogram(
 )
 
 
+# F11 Topic Watchlist (TD-02 — post-Living-KB Phase 1)
+WATCHLIST_MATCHES = Counter(
+    "tg_watchlist_matches_total",
+    "Watchlist (interest, document) candidate fates produced by WatchlistService.check_interests.",
+    ["result"],
+    # result ∈ {delivered, filtered_keywords, filtered_threshold}.
+    # ``delivered`` = score >= interest.threshold and persisted as WatchMatch
+    # (push delivery itself is tracked separately via WATCHLIST_DELIVERY).
+    # ``filtered_keywords`` = exclude_keyword filter zeroed the score.
+    # ``filtered_threshold`` = below interest.threshold and not excluded.
+    # No interest_id label — bounded by current operator count, but unbounded
+    # over time (see TD-02 cardinality note in metrics.py history). Use the
+    # ``tg_watchlist_score`` histogram for distribution insight instead.
+)
+
+WATCHLIST_SCORE = Histogram(
+    "tg_watchlist_score",
+    "Distribution of hybrid watchlist combined scores in [0, 1].",
+    buckets=(0.0, 0.3, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+)
+
+WATCHLIST_DELIVERY = Counter(
+    "tg_watchlist_delivery_total",
+    "Watchlist push-notification outcomes per (interest, tick) group.",
+    ["outcome"],
+    # outcome ∈ {sent, blocked, error}.
+    # ``sent`` = bot.send_message succeeded for the group.
+    # ``blocked`` = permanent failure detected (chat not found / bot blocked /
+    # user deactivated / forbidden) — interest is soft-deleted by the service
+    # to stop retry storms; matches themselves are preserved.
+    # ``error`` = transient failure (rate-limit, network); group is not retried
+    # in this tick but will be retried on the next match for the same interest.
+)
+
+WATCHLIST_ACTIVE_INTERESTS = Gauge(
+    "tg_watchlist_active_interests",
+    "Currently active (is_active=true) watchlist interests across all tenants.",
+)
+
+
+def record_watchlist_match(*, result: str, score: float) -> None:
+    """Record one (interest, document) candidate fate plus its combined score.
+
+    ``result`` is one of {``delivered``, ``filtered_keywords``,
+    ``filtered_threshold``}. ``score`` is the combined hybrid score in [0, 1]
+    and is observed in :data:`WATCHLIST_SCORE` regardless of outcome — this is
+    the calibration signal for tuning the F11 default threshold (currently 0.6).
+
+    Called from :meth:`tg_parser.services.watchlist_service.WatchlistService.check_interests`.
+    """
+    WATCHLIST_MATCHES.labels(result=result).inc()
+    if score < 0.0:
+        score = 0.0
+    elif score > 1.0:
+        score = 1.0
+    WATCHLIST_SCORE.observe(score)
+
+
+def record_watchlist_delivery(*, outcome: str) -> None:
+    """Record one push-notification outcome.
+
+    ``outcome`` is one of {``sent``, ``blocked``, ``error``}. Called from
+    :meth:`tg_parser.services.watchlist_service.WatchlistService.notify`.
+    """
+    WATCHLIST_DELIVERY.labels(outcome=outcome).inc()
+
+
+def set_watchlist_active(count: int) -> None:
+    """Set the gauge of currently active watchlist interests to ``count``.
+
+    Refreshed periodically from
+    :meth:`tg_parser.services.watchlist_service.WatchlistService.check_interests`
+    (once per scheduler tick) so the value tracks soft-deletes / new
+    subscriptions without a dedicated background job.
+    """
+    WATCHLIST_ACTIVE_INTERESTS.set(max(count, 0))
+
+
 def record_resummarize_outcome(
     *,
     topic_id: str,

--- a/tg_parser/services/watchlist_service.py
+++ b/tg_parser/services/watchlist_service.py
@@ -18,8 +18,13 @@ Karpathy-like invariants:
 - **Graceful degradation:** if the document has no embedding (e.g. RAG
   pipeline failed), scoring falls back to the keyword component only.
 - **Observability:** :class:`WatchScore` keeps the keyword/semantic
-  components separate so a future ``tg_watchlist_matches_total`` metric
-  can bucket by score component.
+  components separate; :func:`tg_parser.api.metrics.record_watchlist_match`
+  emits ``tg_watchlist_matches_total{result}`` plus the
+  ``tg_watchlist_score`` histogram per (interest, doc) candidate, and
+  :func:`tg_parser.api.metrics.record_watchlist_delivery` emits
+  ``tg_watchlist_delivery_total{outcome}`` per push attempt — see
+  ``docs/runbooks/F5C_DEPLOY_AND_WATCH.md`` § F11 watchlist health for
+  PromQL recipes.
 """
 
 from __future__ import annotations
@@ -32,6 +37,11 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from tg_parser.api.metrics import (
+    record_watchlist_delivery,
+    record_watchlist_match,
+    set_watchlist_active,
+)
 from tg_parser.domain.models import (
     NotifyMode,
     ProcessedDocument,
@@ -509,6 +519,7 @@ class WatchlistService:
             return []
 
         active = await self.interest_repo.list_active_for_channel(channel_id)
+        await self._refresh_active_gauge()
         if not active:
             logger.debug("watchlist.no_active_interests", channel_id=channel_id)
             return []
@@ -552,8 +563,17 @@ class WatchlistService:
             for ref, doc in docs_by_ref.items():
                 doc_emb = embeddings_by_ref.get(ref)
                 score = compute_watch_score(interest, doc, doc_emb)
-                if score.combined < interest.threshold:
+                if score.excluded:
+                    record_watchlist_match(
+                        result="filtered_keywords", score=score.combined
+                    )
                     continue
+                if score.combined < interest.threshold:
+                    record_watchlist_match(
+                        result="filtered_threshold", score=score.combined
+                    )
+                    continue
+                record_watchlist_match(result="delivered", score=score.combined)
                 all_candidates.append(
                     WatchMatch(
                         id=0,
@@ -686,6 +706,7 @@ class WatchlistService:
                             "watchlist.notify_soft_delete_failed",
                             interest_id=interest.id,
                         )
+                record_watchlist_delivery(outcome="blocked" if permanent else "error")
                 outcomes[interest_id] = "send_failed"
                 continue
 
@@ -699,11 +720,28 @@ class WatchlistService:
                     interest_id=interest.id,
                     match_count=len(group_matches),
                 )
+            record_watchlist_delivery(outcome="sent")
             outcomes[interest_id] = "sent"
 
         return outcomes
 
     # ---- Internal: embedding helpers ----
+
+    async def _refresh_active_gauge(self) -> None:
+        """Refresh ``tg_watchlist_active_interests`` from the interest repo.
+
+        Called once per :meth:`check_interests` tick; ``list_all`` over the
+        ingestion DB is cheap (one row per declared interest, bounded by
+        operator count). Errors are swallowed so a metrics refresh never
+        breaks the scheduler tick.
+        """
+        try:
+            interests = await self.interest_repo.list_all()
+        except Exception:
+            logger.debug("watchlist.refresh_active_gauge_failed", exc_info=True)
+            return
+        active_count = sum(1 for i in interests if i.is_active)
+        set_watchlist_active(active_count)
 
     async def aclose(self) -> None:
         """Best-effort close for the underlying embedding client.


### PR DESCRIPTION
## Summary

Phase 1 / TD-02 — exposes 4 Prometheus metric families for the **F11 watchlist** subsystem. Pre-warms calibration data for F11 P2 (post-watch threshold tuning, see [Wave 2 re-rank rationale](docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md)).

**Source findings:** C-001 (gpt55-002 + opus CODE-001).

**Stacked on:** [#16 (TD-04)](../pull/16) — re-target to `main` after #16 merges.

## Metrics added (`tg_parser/api/metrics.py`)

- `tg_watchlist_matches_total{result=delivered|filtered_threshold|filtered_keywords}` — Counter; per-pair fate from `WatchlistService.check_interests`.
- `tg_watchlist_score` — Histogram (buckets `0.0..1.0`); observed for **every** scored pair (not just delivered) so PromQL quantiles can drive F11 P2 threshold calibration.
- `tg_watchlist_delivery_total{outcome=sent|blocked|error}` — Counter; per-delivery group outcome.
- `tg_watchlist_active_interests` — Gauge; refreshed once per `check_interests` tick from `interest_repo.list_all()` (operator-bounded → cheap).

**Cardinality-safe:** `interest_id` deliberately not in label set (would blow up cardinality across N tenants × M interests).

## Service integration (`tg_parser/services/watchlist_service.py`)

- `check_interests`: per-pair `record_watchlist_match` (excluded → `filtered_keywords`; below threshold → `filtered_threshold`; persisted → `delivered`) + score histogram.
- `notify`: `record_watchlist_delivery(sent|blocked|error)` per push outcome.
- `_refresh_active_gauge()`: updates gauge at start of every tick.

## Tests

- **`tests/test_watchlist_metrics.py`** (new, 8 tests) — helper-function increments, score clamping, label values, service-level smoke (`check_interests` calls `record_watchlist_match` ≥ 1 time).
- Existing `tests/test_watchlist_service.py` (75 tests) — unchanged, all still pass.

**Local run:** `pytest tests/test_watchlist_metrics.py tests/test_watchlist_service.py -q` → **83 passed**.

## Runbook

`docs/runbooks/F5C_DEPLOY_AND_WATCH.md` gains an **F11 watchlist health** subsection with PromQL recipes for:
- Match-flow rate per outcome
- Score quantile distribution (calibration for F11 P2)
- Delivery success / block / error rate
- Active-interests gauge baseline
- Tripwire: `rate(tg_watchlist_delivery_total{outcome="error"}[5m]) > 0.1`

## Test plan

- [x] `pytest tests/test_watchlist_metrics.py tests/test_watchlist_service.py -q` — 83/83 green
- [x] `/metrics` exposes 4 watchlist metric families (verified locally — 7 HELP lines incl. `_created` synthetics)
- [x] ruff/mypy clean
- [ ] Post-deploy smoke: `curl localhost:8000/metrics | grep tg_watchlist` (operator)

Refs: [`docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md`](docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md) TD-02 / C-001, Phase 1.

Made with [Cursor](https://cursor.com)