### PR TITLE
fix(config): declare anthropic prompt-cache + token-estimate as Settings fields (TD-03b, Phase 1 close)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,16 @@ PROCESSING_RETRY_JITTER_MAX=0.3
 # tg_parser_anthropic_billing_block_total. Минимум 60s, по умолчанию 1h.
 BILLING_BLOCK_BACKOFF_S=3600
 
+# Anthropic prompt-caching (cache_control on long-lived prompt prefixes).
+# Disable only for debugging cache bugs; cuts ~90% of repeated input tokens.
+ANTHROPIC_PROMPT_CACHING_ENABLED=true
+
+# Per-call input/output token estimate passed to the Anthropic rate limiter
+# for processing-stage calls. Used as a pre-flight estimate so the limiter
+# can schedule conservatively before real token counts are known.
+PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE=2000
+PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE=2048
+
 
 # =============================================================================
 # Database Configuration (PostgreSQL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/test_watchlist_metrics.py` (new, 8 tests) — unit-coverage helper'ов + service-level smoke тест что `check_interests` дёргает `record_watchlist_match` хотя бы один раз.
 - `docs/runbooks/F5C_DEPLOY_AND_WATCH.md` — новая sub-section «F11 watchlist health» (PromQL для match-flow, score-distribution для F11 P2 калибровки, delivery success rate, active gauge, error-rate tripwire).
 
+#### TD-03b: Declare anthropic prompt-cache + token-estimate as `Settings` fields (S-003 / CODE-004)
+- `tg_parser/config/settings.py` — три новых поля в `Settings`: `anthropic_prompt_caching_enabled: bool` (default `True`), `processing_anthropic_input_token_estimate: int` (default `2000`, `ge=100`/`le=200_000`), `processing_anthropic_output_token_estimate: int` (default `2048`, `ge=100`/`le=64_000`). Defaults сохраняют production-поведение, наблюдавшееся через legacy `getattr` fallback (никаких behavior changes на хостах без env-override).
+- `tg_parser/processing/llm/factory.py` — три `getattr(settings, ...)` заменены на прямые `settings.<field>`. Env-vars `ANTHROPIC_PROMPT_CACHING_ENABLED`, `PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE`, `PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE` теперь действительно подхватываются Pydantic'ом (раньше silently dropped).
+- `.env.example` — три новых строки с дефолтами и описанием.
+- `tests/test_settings.py` (new, 2 tests) — `test_anthropic_cap_settings_declared` (defaults + env-override roundtrip), `test_anthropic_token_estimates_validate_bounds` (ge/le contracts: 0 / 300_000 / 128_000 → ValidationError).
+
 #### TD-03a: Surface `resummarize` across all LLM-config tools (S-002 / CODE-002 + CODE-003 + CODE-006)
 - `tg_parser/config/settings.py` — `LLMConfigManager.get_all()` теперь строит `stages` dict из `LLM_SCOPES` (исключая `"global"`), а не из захардкоженного списка из 4 элементов. Future scopes автоматически появляются в snapshot. `resummarize` теперь видим в `get_llm_config` MCP/REST output. Class docstring обновлён со ссылкой на `LLM_SCOPES`.
 - `tg_parser/mcp_server.py` — server-level docstring (top-of-file, MCP capabilities banner) и `set_llm_config` / `reset_llm_config` Args-секции теперь перечисляют все 6 scopes (включая `resummarize`) вместо 5.

--- a/docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md
+++ b/docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md
@@ -438,20 +438,24 @@ Alternative: start F11 P2, but only after landing `C-001` watchlist metrics. Sta
 
 ## 6. Tech-debt backlog (merged)
 
-| ID | Title | Source findings | Status | Scope | Priority |
-|---|---|---|---|---|---|
-| TD-01 | Align scheduler `error_message` truncation contract | S-001 | single | S | P0 |
-| TD-02 | Add F11 watchlist Prometheus metrics | C-001 | confirmed | S/M | P0 |
-| TD-03 | Consolidate LLM scopes, Anthropic settings, and prompt-loader fail-loud behavior | S-002, S-003, S-004 | single | M | P0 |
-| TD-04 | Close Living-KB docs in deploy guide, Karpathy roadmap, Future Features, and ROADMAP_V3 | C-002, C-003, C-004, S-005 | confirmed/single | M | P0 |
-| TD-05 | Normalize scheduler billing-error handling and scheduler structured logs | C-006, S-007 | confirmed/single | S/M | P1 |
-| TD-06 | Clean observability ownership and F5-C metric/client lifecycle edges | S-006, S-008, S-011 | single | M | P1 |
-| TD-07 | Fix changelog and architecture reference drift | C-007, S-010 | confirmed/single | S | P1 |
-| TD-08 | Document or guard schema/config invariants for F5-C/F11 storage | S-014, S-015 | single | S/M | P1 |
-| TD-09 | Archive stale `docs/notes/` prompts and add an index | C-005 | confirmed | M | P2 |
-| TD-10 | Sweep minor dead-code/dependency consistency issues | S-009, S-012, S-013, S-016 | single | M | P2 |
+| ID | Title | Source findings | Reviewers | Status | Scope | Priority |
+|---|---|---|---|---|---|---|
+| TD-01 | Align scheduler `error_message` truncation contract | S-001 | single | **closed (Phase 1, commit `1b8c8e8`)** | S | P0 |
+| TD-02 | Add F11 watchlist Prometheus metrics | C-001 | confirmed | **closed (Phase 1, commit `98bba10`)** | S/M | P0 |
+| TD-03a | Surface `resummarize` across LLM-config tools | S-002 / CODE-002+003+006 | single | **closed (Phase 1, commit `1231ede`)** | S | P0 |
+| TD-03b | Declare anthropic prompt-cache + token-estimate as Settings fields | S-003 / CODE-004 | single | **closed (Phase 1, commit `7f26b71`)** | S | P0 |
+| TD-03c | Prompt-loader fail-loud | S-004 / CODE-005 | single | open (deferred to Phase 2 — touches F5-C `prompt_loader.get` upstream of resummarize, watch-impact non-zero) | S | P0 |
+| TD-04 | Close Living-KB docs in deploy guide, Karpathy roadmap, Future Features, and ROADMAP_V3 | C-002, C-003, C-004, S-005 | confirmed/single | **closed (Phase 1)** | M | P0 |
+| TD-05 | Normalize scheduler billing-error handling and scheduler structured logs | C-006, S-007 | confirmed/single | open (Phase 2) | S/M | P1 |
+| TD-06 | Clean observability ownership and F5-C metric/client lifecycle edges | S-006, S-008, S-011 | single | open (Phase 2) | M | P1 |
+| TD-07 | Fix changelog and architecture reference drift | C-007, S-010 | confirmed/single | open (Phase 2) | S | P1 |
+| TD-08 | Document or guard schema/config invariants for F5-C/F11 storage | S-014, S-015 | single | open (Phase 2) | S/M | P1 |
+| TD-09 | Archive stale `docs/notes/` prompts and add an index | C-005 | confirmed | open (post-Phase-2 hygiene) | M | P2 |
+| TD-10 | Sweep minor dead-code/dependency consistency issues | S-009, S-012, S-013, S-016 | single | open (post-Phase-2 hygiene) | M | P2 |
 
 Priority key: `P0` next sprint before feature work; `P1` include if sprint capacity allows; `P2` later hygiene.
+
+> **Status legend:** `closed (Phase 1, commit <SHA>)` — landed on `fix/post-living-kb-debt-phase1-2026-04-26` during the post-Living-KB Phase 1 sprint (2026-04-26), see § 9 Phase 1 landing log. `open (Phase 2)` — to be picked up in the Phase 2 sprint after the 24h F5-C watch closes (`2026-04-27T11:07Z`). `open (post-Phase-2 hygiene)` — non-blocking, to be triaged separately.
 
 ---
 
@@ -501,3 +505,40 @@ Suggested issue grouping:
 - **Tests:** not re-run during merge. `gpt55` cites `1881 passed, 4 skipped, 1 deselected` from CHANGELOG/no-PG context; `opus` did not run full coverage.
 - **Gap from review baseline:** base commits differ by review-protocol commits only according to source notes; no independent code re-review performed in merge session.
 - **Source files:** `gpt55` deliverable committed in `4008f36`; `opus` deliverable exists in working tree but is not committed.
+
+---
+
+### Phase 1 landing log (2026-04-26)
+
+Branch: `fix/post-living-kb-debt-phase1-2026-04-26` (local; not yet pushed / PR'd at the time of writing — operator pushes + opens PRs against `main`).
+
+Per master § 7 PR conventions: one PR per TD, but landed here as one stacked branch with five linear commits (operator may split into 5 PRs at push-time). All commits include `Refs: REVIEW_2026-04-26_MERGED_PLAN.md TD-NN, Phase 1.` footer.
+
+| TD | Commit | Landed (UTC) | Tests added | Notes |
+|---|---|---|---|---|
+| TD-04 | `84ccea3` | 2026-04-26T13:04:23Z | 0 (docs only) | `PRODUCTION_DEPLOYMENT.md` v4.4 + roadmap closure across 4 docs. Q3 default applied (file as source of truth for issue #15). Q4 default applied (`Next contract — TBD` placeholder). |
+| TD-02 | `98bba10` | 2026-04-26T13:10:19Z | +8 (`tests/test_watchlist_metrics.py`) | 4 metric families: `tg_watchlist_matches_total`, `tg_watchlist_score`, `tg_watchlist_delivery_total`, `tg_watchlist_active_interests`. Runbook updated with PromQL recipes. |
+| TD-01 | `1b8c8e8` | 2026-04-26T13:12:55Z | +2 (`tests/test_scheduler_service.py`) | `_truncate_error_message` default bumped 500 → 4096 (Q1 default applied). Signature-level + behavioral regression test. |
+| TD-03a | `1231ede` | 2026-04-26T13:14:50Z | +1 (`tests/test_llm_factory.py::test_get_all_includes_every_scope`) | `get_all()` builds stages from `LLM_SCOPES`. MCP/factory docstrings updated. |
+| TD-03b | `7f26b71` | 2026-04-26T13:19:39Z | +2 (new `tests/test_settings.py`) | Three Pydantic fields declared with defaults preserved (`True` / `2000` / `2048`); `getattr` removed; `.env.example` extended. |
+
+**Watch state at Phase 1 close:** GREEN (last verified verdict `GREEN (idle)` at `2026-04-26T11:07:13Z`; no remote re-check possible from this sandbox session — operator should run `ssh prod 'tail -5 ~/f5c-watch/cron.log'` before pushing PRs).
+
+**24h watch ETA close:** `2026-04-27T11:07Z` (operator-local UTC+4 → `2026-04-27T15:07` MSK).
+
+**OPEN QUESTIONS resolved (per § 1.3 Phase 1):**
+- **Q1 (S-001 / TD-01)** — bump code to **4096** (docs were the contract; code was the bug). Default applied per master § 1.3.
+- **Q3 (C-004 / TD-04)** — **`docs/notes/FUTURE_FEATURES.md` is source of truth**. Issue #15 to be synced from file as a separate follow-up. Default applied per master § 1.3.
+- **Q4 (C-003 / Karpathy roadmap)** — **`Next contract — TBD`** placeholder added; explicit planning session to be opened separately. Default applied per master § 1.3.
+
+**Q2 (TD-03c, prompt-loader fail-loud)** — left open; deferred to Phase 2 per scope rules (master § 4.3c → Phase 2 § 1).
+
+**Test deltas:** Phase 1 added **+13 tests** total (8 + 2 + 1 + 2). Local full suite (excluding `tests/integration/`): **1737 passed, 161 skipped, 1 deselected** (green) at Phase 1 close. Anchor count 1881 cited in § 9 above is from a non-PG environment that includes integration suite; not directly comparable to local sandbox count.
+
+**Phase 2 entry-points (handoff):**
+- TD-03c (prompt-loader fail-loud) — master § 4.3c
+- TD-05..08 (P1 stretch) — master § 5
+- Post-watch report (after `2026-04-27T11:07Z`) — `docs/runbooks/F5C_DEPLOY_AND_WATCH.md` § Post-watch report template
+- Open GitHub issues for closed TDs (one per landed PR) — operator task post-push
+
+Phase 2 prompt: [`docs/notes/START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE2.md`](START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE2.md). Phase 2 reads § 6 Status column + § 9 Phase 1 landing log on entry to determine starting state.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,73 @@
+"""Tests for top-level :class:`Settings` Pydantic fields.
+
+Currently focused on TD-03b: Anthropic prompt-cache + token-estimate fields
+that previously lived as ``getattr`` fallbacks on the runtime settings object
+(silently ignoring the matching ``ANTHROPIC_*`` / ``PROCESSING_ANTHROPIC_*``
+env vars). See REVIEW_2026-04-26 MERGED_PLAN S-003 / CODE-004.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tg_parser.config.settings import Settings
+
+
+def test_anthropic_cap_settings_declared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``Settings`` declares the three Anthropic cap/cache fields with documented defaults.
+
+    Regression for REVIEW_2026-04-26 MERGED_PLAN S-003 (CODE-004): factory.py
+    used to read these via ``getattr(settings, ...)`` so env-vars
+    ``ANTHROPIC_PROMPT_CACHING_ENABLED`` /
+    ``PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE`` /
+    ``PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE`` were silently dropped by
+    Pydantic's ``extra="ignore"`` and the hardcoded fallback was always used.
+
+    This test guards three contracts:
+    1. The three attributes exist on the Settings model.
+    2. Defaults match production behavior (``True``, ``2000``, ``2048``)
+       observed via the legacy ``getattr`` path — preserved exactly so this
+       refactor doesn't change runtime behavior on hosts without env override.
+    3. Env-var overrides are picked up by Pydantic.
+    """
+    for var in (
+        "ANTHROPIC_PROMPT_CACHING_ENABLED",
+        "PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE",
+        "PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    s = Settings()
+    assert hasattr(s, "anthropic_prompt_caching_enabled")
+    assert hasattr(s, "processing_anthropic_input_token_estimate")
+    assert hasattr(s, "processing_anthropic_output_token_estimate")
+    assert s.anthropic_prompt_caching_enabled is True
+    assert s.processing_anthropic_input_token_estimate == 2000
+    assert s.processing_anthropic_output_token_estimate == 2048
+
+    monkeypatch.setenv("ANTHROPIC_PROMPT_CACHING_ENABLED", "false")
+    monkeypatch.setenv("PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE", "8000")
+    monkeypatch.setenv("PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE", "1500")
+
+    s2 = Settings()
+    assert s2.anthropic_prompt_caching_enabled is False
+    assert s2.processing_anthropic_input_token_estimate == 8000
+    assert s2.processing_anthropic_output_token_estimate == 1500
+
+
+def test_anthropic_token_estimates_validate_bounds() -> None:
+    """Token estimates respect the documented ``ge``/``le`` constraints.
+
+    A regression that bumps the estimate to a non-positive number (or beyond
+    Anthropic's hard model context limits) should fail-fast at Settings init,
+    not silently propagate to the rate-limiter.
+    """
+    with pytest.raises(ValidationError):
+        Settings(processing_anthropic_input_token_estimate=0)
+    with pytest.raises(ValidationError):
+        Settings(processing_anthropic_input_token_estimate=300_000)
+    with pytest.raises(ValidationError):
+        Settings(processing_anthropic_output_token_estimate=0)
+    with pytest.raises(ValidationError):
+        Settings(processing_anthropic_output_token_estimate=128_000)

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -475,6 +475,35 @@ class Settings(BaseSettings):
         ge=60,
     )
 
+    anthropic_prompt_caching_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable Anthropic prompt-caching (cache_control on long-lived prefixes). "
+            "Disable only for debugging cache bugs; saves ~90 percent tokens on repeated"
+            " prompts."
+        ),
+    )
+    processing_anthropic_input_token_estimate: int = Field(
+        default=2000,
+        description=(
+            "Per-call input token budget passed to the Anthropic rate-limiter for "
+            "processing-stage calls. Used as a pre-flight estimate so the limiter can "
+            "schedule conservatively before the real token count is known."
+        ),
+        ge=100,
+        le=200_000,
+    )
+    processing_anthropic_output_token_estimate: int = Field(
+        default=2048,
+        description=(
+            "Per-call output token budget passed to the Anthropic rate-limiter for "
+            "processing-stage calls. Mirrors the realistic upper bound on completion "
+            "size for processing prompts."
+        ),
+        ge=100,
+        le=64_000,
+    )
+
     # ==========================================================================
     # Scheduled Digests (F6)
     # ==========================================================================

--- a/tg_parser/processing/llm/factory.py
+++ b/tg_parser/processing/llm/factory.py
@@ -113,13 +113,9 @@ def create_llm_client(
             api_key=api_key,
             model=resolved_model,
             rate_limiter=rate_limiter,
-            prompt_caching_enabled=getattr(settings, "anthropic_prompt_caching_enabled", True),
-            rate_limit_input_estimate=getattr(
-                settings, "processing_anthropic_input_token_estimate", 2000
-            ),
-            rate_limit_output_estimate=getattr(
-                settings, "processing_anthropic_output_token_estimate", 2048
-            ),
+            prompt_caching_enabled=settings.anthropic_prompt_caching_enabled,
+            rate_limit_input_estimate=settings.processing_anthropic_input_token_estimate,
+            rate_limit_output_estimate=settings.processing_anthropic_output_token_estimate,
             max_retries=kwargs.pop("max_retries", 5),
             **kwargs,
         )


### PR DESCRIPTION
## Summary

Phase 1 / TD-03b — declares the three Anthropic cap/cache knobs as proper Pydantic `Settings` fields (previously read via `getattr(settings, ..., default)` in `factory.py`, which silently dropped the matching env-vars due to Pydantic v2 `extra="ignore"`). **This PR is the Phase 1 closer** — it also carries the `MERGED_PLAN.md` Status column + § 9 Phase 1 landing log handoff.

**Source findings:** S-003 (CODE-004).

**Stacked on:** [#19 (TD-03a)](../pull/19) — re-target to `main` after #19 merges.

## Fields declared (`tg_parser/config/settings.py`)

```python
anthropic_prompt_caching_enabled: bool = Field(default=True, ...)
processing_anthropic_input_token_estimate: int = Field(
    default=2000, ge=100, le=200_000, ...
)
processing_anthropic_output_token_estimate: int = Field(
    default=2048, ge=100, le=64_000, ...
)
```

**Defaults preserved exactly** to match prior production behavior observed via the legacy `getattr` fallback path — no behavior change on hosts without env-override. Now the env-vars `ANTHROPIC_PROMPT_CACHING_ENABLED`, `PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE`, `PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE` are actually picked up by Pydantic.

`tg_parser/processing/llm/factory.py` — replaced 3× `getattr(...)` with direct `settings.<field>` access.

`.env.example` — three new entries with operator-facing descriptions.

## Tests

- **`test_anthropic_cap_settings_declared`** — defaults + env-override roundtrip (`monkeypatch.setenv` → `Settings()` picks up overrides).
- **`test_anthropic_token_estimates_validate_bounds`** — `ge`/`le` validation guards (0, 300_000, 128_000 → `ValidationError`).

## Phase 1 handoff (commit `e173058`)

This PR also carries [`docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md`](docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md) updates (last commit on the branch):

- **§ 6:** Reviewers + Status columns added; TD-01/02/03a/03b/04 marked `closed (Phase 1, commit <SHA>)`. TD-03 split into TD-03a / TD-03b (closed) + TD-03c (deferred to Phase 2 because prompt-loader fail-loud touches F5-C `prompt_loader.get` upstream of resummarize). TD-05..10 → `open (Phase 2)` / `open (post-Phase-2 hygiene)`.
- **§ 9 Phase 1 landing log:** per-TD commit SHA + UTC timestamp + tests added; 24h watch ETA `2026-04-27T11:07Z`; Q1/Q3/Q4 resolutions; Q2 (TD-03c) explicitly deferred.

Phase 2 reads § 6 Status + § 9 landing log on entry to determine starting state.

## Test plan

- [x] `pytest tests/test_settings.py -q` → 2/2 green
- [x] `pytest tests/test_llm_factory.py -q` → 18/18 green (factory.py refactor lossless)
- [x] Full local suite (excl. integration): **1737 passed, 161 skipped** — green
- [x] ruff/mypy clean
- [ ] Post-deploy smoke: `printenv ANTHROPIC_PROMPT_CACHING_ENABLED` reflected in `Settings()` instance (operator)

## Phase 1 closeout — operator next-actions

After this PR merges, Phase 1 is closed. Next-steps:
1. Verify watch GREEN: `ssh prod 'tail -5 ~/f5c-watch/cron.log'`
2. Wait for `2026-04-27T11:07Z` watch close (≈ tomorrow 12:07 UTC / 16:07 MSK).
3. Open Phase 2 session: [`docs/notes/START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE2.md`](docs/notes/START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE2.md).
4. Phase 2 scope: TD-03c + P1 stretch (TD-05..08) + post-watch report.

Refs: [`docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md`](docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md) S-003 (CODE-004) + Phase 1 handoff.

Made with [Cursor](https://cursor.com)