### PR TITLE
feat(watchlist): expose Prometheus surface for F11 watchlist (TD-02, Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Sprint Debt-Fix Post-Living-KB — Phase 1 (2026-04-26)
+
+**Контекст:** post-Living-KB merged-plan debt-fix, фаза 1 — выполняется параллельно с 24h F5-C deploy-watch окном (`2026-04-26T11:07:13Z` → ≈`2026-04-27T11:07Z`). Закрываются debt-items, не пересекающиеся с F5-C critical path. См. [`docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md`](docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md), [`docs/notes/START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE1.md`](docs/notes/START_PROMPT_SPRINT_POST_LIVING_KB_DEBT_FIX_PHASE1.md). Phase 2 (TD-03c + P1 stretch + post-watch report) — отдельная сессия после закрытия watch'а.
+
+#### TD-04: Close Living-KB docs across deploy and roadmap docs (C-002, C-003, C-004, S-005)
+- `PRODUCTION_DEPLOYMENT.md` — bumped to **v4.4**, added top-level closure note, ToC entry, и новый раздел `## v4.4 Living-KB upgrade notes` (миграции `ac6a4414ac58` / `c8e9f0a1b2c3` / `a4b5c6d7e8f9`, F5-C/F11/Anthropic-billing env vars, cron entry для `f5c_watch.sh`, verification curl/SQL, ссылки на `F5C_DEPLOY_AND_WATCH.md` и `ANTHROPIC_BILLING_RECOVERY.md` runbook'ы).
+- `docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md` — добавлен top-level баннер `Living-KB contract: CLOSED 2026-04-26`, новый раздел `## 2026-04-26 — Contract closed` со ссылками на CHANGELOG для D.1 / F11 / F5-C, revision-history table обновлена (Wave C **MVP merged**), новый раздел `## Next contract — TBD` с явным placeholder'ом (per merged-plan Q4 default).
+- `docs/notes/FUTURE_FEATURES.md` — § Level C (F5-C P2 backlog) теперь явно ссылается на GitHub issue #15 как tracker и помечает каждый из 9 deferred items суффиксом `(see #15 — <subtask>)`. Файл — source of truth (per merged-plan Q3 default); sync issue body — отдельный follow-up.
+- `docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md` — top-level баннер `Wave 1 closed 2026-04-26`, новый раздел `## Done — Living-KB contract (Wave 1)` (D.1 / F11 / F5-C), Wave 2 re-ranked: F11 P2 (closest after TD-02 metrics calibration window) → F5-C P2 → F1 Full → F10-A → F12-A. Rationale зафиксирован в подсекции «Wave 2 re-rank rationale».
+
 ### Sprint F5-C — Evolving Topic Summaries (2026-04-26)
 
 **Статус:** ✅ MVP DONE 2026-04-26 — commit 1/2 `473f107` (schema + service + counter + core tests), commit 2/2 `53f72ef` (scheduler hook + MCP/CLI + remaining tests + docs). См. `docs/notes/START_PROMPT_SPRINT_F5C.md`, `docs/notes/F5C_PR_CHECKLIST.md`.

--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -1,8 +1,12 @@
 # Production Deployment Guide
 
-**TG_parser v4.3 Production Deployment**
+**TG_parser v4.4 Production Deployment**
 
 Complete guide for deploying TG_parser with PostgreSQL, REST API, and MCP server in production.
+
+> **v4.4 (2026-04-26): Living-KB contract closed** — D.1 (topicization hardening) +
+> F11 (topic watchlist) + F5-C (evolving topic summaries). New migrations,
+> env vars and operational runbooks below in [v4.4 Living-KB upgrade notes](#v44-living-kb-upgrade-notes).
 
 ---
 
@@ -12,6 +16,7 @@ Complete guide for deploying TG_parser with PostgreSQL, REST API, and MCP server
 - [Architecture](#architecture)
 - [Server Setup](#server-setup)
 - [Application Deployment](#application-deployment)
+- [v4.4 Living-KB upgrade notes](#v44-living-kb-upgrade-notes)
 - [Connecting AI Agents](#connecting-ai-agents)
 - [SSL/TLS Configuration](#ssltls-configuration)
 - [Monitoring](#monitoring)
@@ -280,6 +285,111 @@ docker compose run --rm tg_parser run --source my_channel --out /app/data/output
 # Trigger incremental processing
 docker compose run --rm tg_parser process --channel my_channel
 ```
+
+---
+
+## v4.4 Living-KB upgrade notes
+
+This release closes the Living-KB contract: D.1 (topicization hardening) +
+F11 (topic watchlist) + F5-C (evolving topic summaries). When upgrading
+from v4.3 to v4.4 follow the steps below; for fresh installs everything is
+applied automatically by the entrypoint and the defaults below are sane.
+
+### Migrations to apply (Alembic)
+
+Run after `docker compose build` and **before** `docker compose up -d`:
+
+```bash
+docker compose run --rm --no-deps tg_parser db upgrade --db all
+docker compose run --rm --no-deps tg_parser db current --db all
+```
+
+Heads after upgrade (each branch is a single linear chain):
+
+| Branch | Head | Sprint | Adds |
+|---|---|---|---|
+| `ingestion` | `ac6a4414ac58` | D.1 | `source_attempts.failed_stage`, `error_message` (TEXT, truncated to 4096 chars at write time) |
+| `ingestion` | `c8e9f0a1b2c3` | F11 | `watch_interests` (+ pgvector `embedding`), `watch_matches` (UNIQUE `(interest_id, source_ref)`) |
+| `processing` | `a4b5c6d7e8f9` | F5-C | `topic_cards.last_summarized_at` / `summary_version` / `new_items_since_last_summary`, partial index `idx_topic_cards_resummarize_candidates`, append-only table `topic_card_versions` |
+
+Idempotent extension creation (`CREATE EXTENSION IF NOT EXISTS vector`) is
+included in the F11 migration; existing pgvector deployments are not affected.
+
+### New environment variables
+
+Add to `.env` (defaults are production-safe; tune only if needed):
+
+```env
+# F5-C — Evolving Topic Summaries
+RESUMMARIZE_ENABLED=true                  # kill-switch; set to false to skip the hook
+RESUMMARIZE_TRIGGER_N=5                   # re-summarize when ≥ N new supporting items accumulated
+RESUMMARIZE_MAX_PER_TICK=10               # max topics processed per scheduler tick
+RESUMMARIZE_MAX_DURATION_S=60             # cap on tick wall-time spent in F5-C
+RESUMMARIZE_MAX_TOKENS_PER_TICK=50000     # TCO upper bound per tick
+RESUMMARIZE_INPUT_WINDOW_N=10             # sliding window of supporting items fed to LLM
+RESUMMARIZE_LLM_PROVIDER=                 # unset → inherits LLM_PROVIDER
+RESUMMARIZE_LLM_MODEL=                    # unset → inherits LLM_MODEL (typically gpt-4o-mini)
+
+# F11 — Topic Watchlist
+MAX_DOCS_PER_TICK=100                     # backfill flood guard for watchlist scoring
+
+# Anthropic billing safety (TD-03b — declared as Settings fields in v4.4)
+ANTHROPIC_PROMPT_CACHING_ENABLED=true                       # use prompt caching when supported
+PROCESSING_ANTHROPIC_INPUT_TOKEN_ESTIMATE=8000              # billing-safety cap estimate
+PROCESSING_ANTHROPIC_OUTPUT_TOKEN_ESTIMATE=1500             # billing-safety cap estimate
+```
+
+### Cron entry — F5-C deploy watch
+
+After deploying F5-C, install the deploy-time watch script. It samples the
+F5-C `outcome` distribution every minute and writes a single verdict line
+to `~/f5c-watch/cron.log`. See [`docs/runbooks/F5C_DEPLOY_AND_WATCH.md`](docs/runbooks/F5C_DEPLOY_AND_WATCH.md)
+for full instructions and the post-watch report template.
+
+```bash
+mkdir -p ~/f5c-watch
+crontab -e
+# Add:
+* * * * * /opt/tg_parser/scripts/f5c_watch.sh >> ~/f5c-watch/cron.log 2>&1
+```
+
+Verdict semantics (read by operators / on-call):
+
+- `GREEN (idle)` — no re-summarize ticks in the window (legitimate if no new items).
+- `GREEN (active, healthy)` — ticks observed, error/lock ratios under threshold.
+- `TRIPWIRE` — error or lock ratio above threshold; **stop deploys, run RCA**
+  before resuming any debt-fix work.
+
+### Verification commands
+
+After `docker compose up -d`:
+
+```bash
+# F5-C + F11 metrics surface
+curl -s localhost:8000/metrics | grep -E 'tg_resummarize|tg_watchlist'
+
+# Migration heads — ingestion + processing both at v4.4 heads
+docker compose exec tg_parser tg-parser db current --db all
+# Expected:
+#   ingestion: c8e9f0a1b2c3
+#   processing: a4b5c6d7e8f9
+
+# Postgres tables created
+docker compose exec postgres psql -U tg_parser -d tg_parser -c \
+  "SELECT count(*) FROM topic_card_versions"
+docker compose exec postgres psql -U tg_parser -d tg_parser -c \
+  "SELECT count(*) FROM watch_interests"
+
+# Anthropic billing-pause behaviour (read-only check)
+docker compose exec postgres psql -U tg_parser -d tg_parser -c \
+  "SELECT id, billing_paused_at, billing_pause_reason FROM sources WHERE billing_paused_at IS NOT NULL"
+```
+
+### Operational runbooks
+
+- **F5-C deploy watch + tripwire RCA:** [`docs/runbooks/F5C_DEPLOY_AND_WATCH.md`](docs/runbooks/F5C_DEPLOY_AND_WATCH.md)
+  (includes the `F11 watchlist health` PromQL section added in TD-02).
+- **Anthropic billing recovery:** [`docs/runbooks/ANTHROPIC_BILLING_RECOVERY.md`](docs/runbooks/ANTHROPIC_BILLING_RECOVERY.md).
 
 ---
 

--- a/docs/notes/FUTURE_FEATURES.md
+++ b/docs/notes/FUTURE_FEATURES.md
@@ -749,15 +749,21 @@ async def is_known(text: str, channel_ids: list[str]) -> tuple[bool, float]:
 
 ##### Что НЕ входит в MVP (Phase 2 при сигнале)
 
-- TTL/retention для `topic_card_versions` (храним всё в MVP).
-- `get_topic_history_diff(topic_id, version_a, version_b)` MCP/CLI.
-- F6 digest на topic-level summary (см. § F6 line 949 ниже — отдельная задача после F5-C MVP, требует тюнинга промпта digest).
-- Bot tools для F5-C (только при UX-сигнале «хочу видеть историю темы из бота»).
-- Time-based триггер (раз в N часов независимо от количества items).
-- Singleton → Cluster type promotion при re-summarize (текущая полная топикизация делает это сама).
-- Удаление supporting items (текущий `_update_bundles_for_assignments` только добавляет).
-- HTTP API endpoints (MCP/CLI достаточно).
-- Topic-level dedup при re-summarize (связано с F5-B, не часть F5-C).
+> **Tracked in GitHub:** [issue #15 — F5-C Phase 2 backlog](https://github.com/your-org/tg_parser/issues/15)
+>
+> Этот файл — **source of truth** для F5-C P2 backlog'а; issue body
+> синхронизируется отдельным follow-up'ом (см. post-Living-KB merged plan
+> § 1.3 Q3 default). Каждый пункт ниже размечен суффиксом `(see #15 — <subtask>)`.
+
+- TTL/retention для `topic_card_versions` (храним всё в MVP) `(see #15 — TTL/retention)`.
+- `get_topic_history_diff(topic_id, version_a, version_b)` MCP/CLI `(see #15 — diff API)`.
+- F6 digest на topic-level summary (см. § F6 line 949 ниже — отдельная задача после F5-C MVP, требует тюнинга промпта digest) `(see #15 — F6 digest на topic.summary)`.
+- Bot tools для F5-C (только при UX-сигнале «хочу видеть историю темы из бота») `(see #15 — Bot tools)`.
+- Time-based триггер (раз в N часов независимо от количества items) `(see #15 — time-based trigger)`.
+- Singleton → Cluster type promotion при re-summarize (текущая полная топикизация делает это сама) `(see #15 — type promotion)`.
+- Удаление supporting items (текущий `_update_bundles_for_assignments` только добавляет) `(see #15 — supporting item removal)`.
+- HTTP API endpoints (MCP/CLI достаточно) `(see #15 — HTTP API)`.
+- Topic-level dedup при re-summarize (связано с F5-B, не часть F5-C) `(see #15 — topic-level dedup)`.
 
 ##### Trigger summary
 

--- a/docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md
+++ b/docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md
@@ -1,8 +1,30 @@
 # Roadmap: Karpathy-like подход и Living KB
 
+> **Living-KB contract: CLOSED 2026-04-26**
+> (D.1 hardening + F11 watchlist + F5-C evolving summaries — Wave A/B/C ниже)
+> См. [`## 2026-04-26 — Contract closed`](#2026-04-26--contract-closed-) и `CHANGELOG.md`.
+
 **Статус:** активный ориентир для развития продукта (дополняет, не заменяет [`ROADMAP_V3_PRODUCTION_FIRST.md`](ROADMAP_V3_PRODUCTION_FIRST.md) и [`FUTURE_FEATURES.md`](FUTURE_FEATURES.md)).
 
-**Дата:** 25 апреля 2026.
+**Дата:** 25 апреля 2026 (последняя крупная правка: 2026-04-26 — закрытие Living-KB-контракта).
+
+---
+
+## 2026-04-26 — Contract closed ✅
+
+Living-KB-контракт (волны A + B + C) закрыт коммитами этого спринтового
+цикла. Ссылки на CHANGELOG-секции и detailed deliverables — в каждом
+пункте.
+
+| Wave | Sprint | Что закрыто | CHANGELOG |
+|---|---|---|---|
+| A | D.1 | Topicization hardening — truthful `failed_stage`, per-batch checkpointing, error_message persistence (4096-char contract aligned in TD-01, post-Living-KB sprint Phase 1). | § Sprint D.1 — Topicization Hardening |
+| B | F11 | Topic Watchlist MVP — hybrid keyword+embedding scoring, idempotent matches, instant push via aiogram, MCP/Bot/CLI surface, scheduler hook with graceful degradation. | § Sprint F11 — Topic Watchlist |
+| C | F5-C | Evolving Topic Summaries MVP — counter-driven re-summarize, append-only `topic_card_versions` audit trail, advisory-lock + UNIQUE second line of defence, MCP/CLI surface. | § Sprint F5-C — Evolving Topic Summaries |
+
+24h F5-C deploy-watch window: opens at `2026-04-26T11:07:13Z`, closes
+≈ `2026-04-27T11:07Z`. Verdict reporting per [`docs/runbooks/F5C_DEPLOY_AND_WATCH.md`](../runbooks/F5C_DEPLOY_AND_WATCH.md)
+§ Post-watch report.
 
 ---
 
@@ -104,3 +126,32 @@ ingestion → processing → topicization → **обновляемые темы*
 |------|-----------|
 | 2026-04-25 | Первая версия: склейка обсуждения karpathy-like с Roadmap v3 и F11/F5-C. |
 | 2026-04-26 | Волна C — статус **READY к реализации**: F5-C планировочная сессия закрыта, фиксированы 12 решений (триггер по счётчику N=5, append-only `topic_card_versions`, hook между F11-prep embedding и F11 watchlist, MCP/CLI без Bot в MVP, triple cap, advisory lock). Артефакты: `START_PROMPT_SPRINT_F5C.md`, `F5C_PR_CHECKLIST.md`. F11 (Волна B) смерджен (commit `c1c9f35`). |
+| 2026-04-26 | Волна C — **MVP merged** (commits `473f107` + `53f72ef`). Living-KB-контракт (Waves A/B/C) **закрыт**, баннер сверху + `## 2026-04-26 — Contract closed` секция; 24h F5-C deploy-watch окно открыто `2026-04-26T11:07:13Z`. Добавлен `## Next contract — TBD` placeholder для будущей планирующей сессии. Правка из post-Living-KB debt-fix Phase 1 (TD-04). |
+
+---
+
+## Next contract — TBD
+
+Следующий Karpathy-like контракт **формулируется в отдельной планирующей
+сессии** — не в этом roadmap-документе, чтобы:
+
+- не выдумывать scope без планирующей сессии (per merge-plan default Q4),
+- сохранять чистую границу «закрытый контракт ↔ следующий контракт»
+  (предыдущая Living-KB-секция уже закрыта выше),
+- прийти к следующему контракту с явным набором OPEN QUESTIONS, которые
+  стоят за приоритезацией (F11 P2 vs F5-C P2 vs F1 Full vs F10-A vs F12-A).
+
+**Не ставить здесь conjectured contract.** Когда планирующая сессия
+закроется — добавить отдельный раздел `## 202X-XX-XX — Next contract:
+<title>` со ссылкой на `docs/notes/PLANNING_NEXT_CONTRACT_*.md` (или
+аналогичный артефакт), повторяющий формат раздела `## 2026-04-26 — Contract closed`.
+
+Кандидаты на следующий контракт (без приоритезации, для контекста
+планирующей сессии — см. `docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md` § 5):
+
+- **F11 Phase 2** — `notify_mode=batch`/`silent`, calibration по watchlist
+  metrics surface (TD-02 в этом sprint'е); ближайший после ≥ 24h prod-сигнала.
+- **F5-C Phase 2** — TTL/retention для `topic_card_versions`, diff API,
+  F6 digest на topic-level summary, time-based триггер, Bot tools (см. issue #15).
+- Прочие feature-кандидаты (F1 Full / F10-A / F12-A) — в Wave 2 / Wave 3
+  таблице `ROADMAP_V3_PRODUCTION_FIRST.md`.

--- a/docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md
+++ b/docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md
@@ -1,11 +1,31 @@
 # Roadmap v3 — Production-First Strategy
 
-**Дата:** 30 марта 2026 (обновлено: 13 апреля 2026)
+> **Wave 1 closed 2026-04-26** — Living-KB контракт закрыт (D.1 + F11 + F5-C).
+> См. `## Done — Living-KB contract (Wave 1)` ниже и
+> [`ROADMAP_KARPATHY_LIKE_LIVING_KB.md`](ROADMAP_KARPATHY_LIKE_LIVING_KB.md)
+> § «2026-04-26 — Contract closed» для full deliverables.
+> Wave 2 re-ranked после debt-fix sprint'а (F11 P2 — closest follow-up after TD-02).
+
+**Дата:** 30 марта 2026 (обновлено: 2026-04-26 — Living-KB closure + Wave 2 re-rank)
 **Статус:** Активный
 **Предыдущие документы:**
 - `SESSION48_PRODUCT_STRATEGY.md` — исходная стратегия продукта
 - `SESSION48_ROADMAP_V2.md` — roadmap v2 (P6a → P6b → P6c → P6d → P7 → P8)
 - `docs/technical-debt-roadmap.md` — трекер техдолга S1–S7, D1
+
+---
+
+## Done — Living-KB contract (Wave 1)
+
+| Sprint | Дата | Что закрыто | См. |
+|---|---|---|---|
+| D.1 | 2026-04-25 | Topicization hardening — truthful `failed_stage`, per-batch checkpointing, `error_message` persistence (4096-char contract aligned in TD-01, post-Living-KB Phase 1). | CHANGELOG § Sprint D.1 |
+| F11 | 2026-04-25 | Topic Watchlist MVP — hybrid keyword+embedding scoring, idempotent matches, instant push via aiogram, MCP/Bot/CLI surface. | CHANGELOG § Sprint F11 |
+| F5-C | 2026-04-26 | Evolving Topic Summaries MVP — counter-driven re-summarize, append-only `topic_card_versions`, MCP/CLI surface. | CHANGELOG § Sprint F5-C |
+
+24h F5-C deploy-watch окно: `2026-04-26T11:07:13Z` → ≈`2026-04-27T11:07Z`,
+verdict reporting per [`docs/runbooks/F5C_DEPLOY_AND_WATCH.md`](../runbooks/F5C_DEPLOY_AND_WATCH.md)
+§ Post-watch report.
 
 ---
 
@@ -417,14 +437,29 @@ Sprint D.1 (topicization hardening) задеплоен на VPS `redboxtgbot` 25
 | Волна | Фокус | Effort | Функции |
 |-------|-------|--------|---------|
 | ~~1~~ | ~~Фундамент (security + stability)~~ | ~~~1.5 сессии~~ | ~~F9-quick ✅, F4 ✅~~ |
-| **1.5** | **RAG & Prompt Config** | ~0.5–0.7 сессии | YAML все промпты + reload + rag scope + RAG-промпт рефакторинг |
-| **1.5→2** | **F8-A: Hardening** | ~1 сессия | Unified retry, DB pool metrics, circuit breaker, graceful degradation |
-| 2 | Core Value (качество продукта) | ~4 сессии | F5-A, F2, F10-A, F12-A |
-| 3 | User Experience (engagement) | ~6–7 сессий | F6, F11, F1 (полная — DB + A/B), F5-C |
+| ~~1.5~~ | ~~RAG & Prompt Config~~ | ~~~0.5–0.7 сессии~~ | ~~YAML все промпты + reload + rag scope + RAG-промпт рефакторинг ✅~~ |
+| ~~1.5→2~~ | ~~F8-A: Hardening~~ | ~~~1 сессия~~ | ~~Unified retry, DB pool metrics, circuit breaker, graceful degradation ✅~~ |
+| ~~2 (tail) / 3 (head) — Living-KB~~ | ~~Living-KB contract — D.1 + F11 + F5-C~~ | ~~~3 сессии~~ | ~~D.1 ✅, F11 ✅, F5-C ✅ (closed 2026-04-26)~~ |
+| **2 (re-ranked, post-Living-KB)** | **Core Value — calibrated extensions** | ~3–4 сессии | **F11 P2** (closest after TD-02 metrics calibration), **F5-C P2** (TTL/diff/digest), **F1 Full**, **F10-A**, **F12-A** |
+| 3 | User Experience (engagement) | ~3–4 сессии | F6 enhancements, F1 (полная — DB + A/B) |
 | 4 | Scale & Monetize (рост) | ~11–12 сессий | F9-2, F8-B, F7 |
 | 5 | Strategic (по потребности) | — | F3, F5-D, F10-C, F8-C |
 
-**Примечание:** F1 в Волне 3 — это **полная** версия Configurable Prompt System (DB, версионирование, A/B тесты). Базовая управляемость (YAML + reload + LLM config) реализуется в Волне 1.5 и покрывает все потребности single-server deployment.
+**Wave 2 re-rank rationale (2026-04-26, post-Living-KB merged plan § 5):**
+
+1. **F11 P2** — closest feature after TD-02 lands; needs ≥ 24h prod-сигнал
+   на `tg_watchlist_*` метриках для калибровки threshold/notify_mode
+   defaults. Не запускать до того, как metrics в проде > 24h.
+2. **F5-C P2** — TTL/retention + diff API + F6 digest на topic.summary +
+   Bot tools (см. issue #15 в [`docs/notes/FUTURE_FEATURES.md`](FUTURE_FEATURES.md) § Level C).
+   Не запускать до закрытия 24h F5-C deploy-watch + post-watch report.
+3. **F1 Full** — полная версия Configurable Prompt System (DB, версионирование,
+   A/B тесты). Базовая управляемость уже в Wave 1.5.
+4. **F10-A** — Multimodal Content Processing (Level A — images + voice).
+5. **F12-A** — Channel Discovery (Level A — поиск каналов).
+
+**Примечание:** F1 в Wave 2 (полная) ≠ F1 базовой управляемости из Wave 1.5
+(YAML + reload + LLM config), которая уже закрывает single-server deployment.
 
 Отложенные направления из предыдущей версии roadmap:
 - **UI фаза** (P6c Web Catalog, P6d Web Chat) — приоритет пересмотрен в пользу F5/F6/F11

--- a/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
+++ b/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
@@ -178,6 +178,41 @@ FROM topic_card_versions;
 ```
 **Ожидание (24 ч):** rows ≈ суммарное `tg_resummarize_total{outcome="ok"}` за сутки. Размер должен быть в МБ, не ГБ. Если рост слишком быстрый — это сигнал к Phase 2 пункту #1 (TTL/retention).
 
+### F11 watchlist health (TD-02 — добавлено в post-Living-KB Phase 1)
+
+F11 watchlist делит scheduler tick с F5-C; следующие PromQL-снипеты позволяют убедиться что F11 живой и помогают калибровать threshold перед F11 P2.
+
+**Match-flow по 1 часу:**
+```promql
+rate(tg_watchlist_matches_total{result="delivered"}[1h])
+rate(tg_watchlist_matches_total{result="filtered_threshold"}[1h])
+rate(tg_watchlist_matches_total{result="filtered_keywords"}[1h])
+```
+Если `delivered = 0` и `filtered_threshold > 0` — порог слишком высок (либо реально нет совпадений). Если `filtered_keywords` высокий — exclude-keywords агрессивно режут.
+
+**Distribution of combined scores (calibration для F11 P2):**
+```promql
+histogram_quantile(0.5, sum by (le) (rate(tg_watchlist_score_bucket[1h])))
+histogram_quantile(0.9, sum by (le) (rate(tg_watchlist_score_bucket[1h])))
+```
+Использовать после ≥ 24 ч продакшн-сигнала чтобы выбрать sane default threshold (текущий 0.6 — placeholder).
+
+**Delivery success rate:**
+```promql
+rate(tg_watchlist_delivery_total{outcome="sent"}[1h])
+rate(tg_watchlist_delivery_total{outcome="blocked"}[1h])
+rate(tg_watchlist_delivery_total{outcome="error"}[1h])
+```
+`blocked` > 0 значит юзер заблокировал бота — interest soft-deleted автоматически. `error` > 0 — Telegram rate-limit / транзиентные ошибки; систематически > 5% → проверять bot токен / network.
+
+**Active interests:**
+```promql
+tg_watchlist_active_interests
+```
+Gauge. Падение к нулю при non-empty `subscribe_watchlist` calls — индикатор массового soft-delete (например после длительного `blocked` storm).
+
+**Tripwire (для F11):** `rate(tg_watchlist_delivery_total{outcome="error"}[5m]) > 0.1` — открыть hot-fix issue.
+
 ### Где смотреть в Grafana
 
 Если Grafana уже настроена (см. `docker/grafana/provisioning/`) — можно собрать панель ad-hoc прямо в UI:

--- a/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
+++ b/docs/runbooks/F5C_DEPLOY_AND_WATCH.md
@@ -292,7 +292,7 @@ Exit codes: `0` — все четыре tripwire'а молчат, `1` — сра
 
 ### Post-watch report — шаблон комментария для issue #15
 
-Скопировать в комментарий к [F5-C Phase 2 tracking issue](https://github.com/<owner>/<repo>/issues/15), подставить значения вместо `<...>`. Вердикт по каждому пункту — один из `green` / `yellow` / `red` (объяснить если не green).
+Скопировать в комментарий к [F5-C Phase 2 tracking issue](https://github.com/your-org/tg_parser/issues/15), подставить значения вместо `<...>`. Вердикт по каждому пункту — один из `green` / `yellow` / `red` (объяснить если не green).
 
 ```markdown
 ## F5-C MVP — 24h post-watch report

--- a/tests/test_watchlist_metrics.py
+++ b/tests/test_watchlist_metrics.py
@@ -1,0 +1,285 @@
+"""Unit tests for F11 watchlist Prometheus metrics surface (TD-02).
+
+Covers:
+
+- :func:`tg_parser.api.metrics.record_watchlist_match` increments the right
+  ``tg_watchlist_matches_total{result}`` series and observes into
+  ``tg_watchlist_score``.
+- :func:`tg_parser.api.metrics.record_watchlist_delivery` increments the
+  right ``tg_watchlist_delivery_total{outcome}`` series.
+- :func:`tg_parser.api.metrics.set_watchlist_active` updates the gauge.
+- Scoring boundary clamps in ``record_watchlist_match`` keep the histogram
+  observation in [0, 1].
+- :class:`tg_parser.services.watchlist_service.WatchlistService.check_interests`
+  emits at least one match metric for a real (interest, doc) pair.
+
+These tests intentionally probe the global Prometheus singletons; they read
+counter values before and after the action under test to be robust against
+other tests in the suite touching the same series.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tg_parser.api.metrics import (
+    WATCHLIST_ACTIVE_INTERESTS,
+    WATCHLIST_DELIVERY,
+    WATCHLIST_MATCHES,
+    WATCHLIST_SCORE,
+    record_watchlist_delivery,
+    record_watchlist_match,
+    set_watchlist_active,
+)
+
+
+def _counter_value(counter, **labels: str) -> float:
+    return counter.labels(**labels)._value.get()
+
+
+def _histogram_count(histogram) -> float:
+    return histogram._sum.get()
+
+
+# ----------------------------------------------------------------------------
+# record_watchlist_match
+# ----------------------------------------------------------------------------
+
+
+def test_record_watchlist_match_increments_delivered_counter() -> None:
+    before = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    record_watchlist_match(result="delivered", score=0.85)
+    after = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    assert after == pytest.approx(before + 1.0)
+
+
+def test_record_watchlist_match_increments_filtered_counters() -> None:
+    before_kw = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    before_th = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+    record_watchlist_match(result="filtered_keywords", score=0.0)
+    record_watchlist_match(result="filtered_threshold", score=0.45)
+    assert _counter_value(WATCHLIST_MATCHES, result="filtered_keywords") == pytest.approx(
+        before_kw + 1.0
+    )
+    assert _counter_value(WATCHLIST_MATCHES, result="filtered_threshold") == pytest.approx(
+        before_th + 1.0
+    )
+
+
+def test_record_watchlist_match_observes_score_histogram() -> None:
+    sum_before = _histogram_count(WATCHLIST_SCORE)
+    record_watchlist_match(result="delivered", score=0.7)
+    record_watchlist_match(result="filtered_threshold", score=0.5)
+    sum_after = _histogram_count(WATCHLIST_SCORE)
+    assert math.isclose(sum_after - sum_before, 1.2, abs_tol=1e-6)
+
+
+def test_record_watchlist_match_clamps_score_into_unit_interval() -> None:
+    sum_before = _histogram_count(WATCHLIST_SCORE)
+    record_watchlist_match(result="delivered", score=1.5)
+    record_watchlist_match(result="filtered_threshold", score=-0.3)
+    sum_after = _histogram_count(WATCHLIST_SCORE)
+    # 1.5 clamps to 1.0; -0.3 clamps to 0.0 → total observed = 1.0
+    assert math.isclose(sum_after - sum_before, 1.0, abs_tol=1e-6)
+
+
+# ----------------------------------------------------------------------------
+# record_watchlist_delivery
+# ----------------------------------------------------------------------------
+
+
+def test_record_watchlist_delivery_increments_outcomes() -> None:
+    before_sent = _counter_value(WATCHLIST_DELIVERY, outcome="sent")
+    before_blocked = _counter_value(WATCHLIST_DELIVERY, outcome="blocked")
+    before_error = _counter_value(WATCHLIST_DELIVERY, outcome="error")
+
+    record_watchlist_delivery(outcome="sent")
+    record_watchlist_delivery(outcome="blocked")
+    record_watchlist_delivery(outcome="error")
+
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="sent") == pytest.approx(before_sent + 1.0)
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="blocked") == pytest.approx(
+        before_blocked + 1.0
+    )
+    assert _counter_value(WATCHLIST_DELIVERY, outcome="error") == pytest.approx(before_error + 1.0)
+
+
+# ----------------------------------------------------------------------------
+# set_watchlist_active
+# ----------------------------------------------------------------------------
+
+
+def test_set_watchlist_active_sets_gauge() -> None:
+    set_watchlist_active(7)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(7.0)
+    set_watchlist_active(0)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(0.0)
+
+
+def test_set_watchlist_active_clamps_negative_to_zero() -> None:
+    set_watchlist_active(-5)
+    assert WATCHLIST_ACTIVE_INTERESTS._value.get() == pytest.approx(0.0)
+
+
+# ----------------------------------------------------------------------------
+# Service-level smoke test — check_interests emits match metrics
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_interests_records_match_metric_for_real_pair(
+    service_with_interest_and_doc,
+) -> None:
+    """End-to-end: at least one ``record_watchlist_match`` call fires when
+    the service scores a candidate pair. We don't assert the exact result
+    label here (the test fixture chooses the score), only that *some*
+    label was incremented.
+    """
+    service, channel_id, source_ref = service_with_interest_and_doc
+
+    delivered_before = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    filt_kw_before = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    filt_th_before = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+
+    await service.check_interests(channel_id, [source_ref])
+
+    delivered_after = _counter_value(WATCHLIST_MATCHES, result="delivered")
+    filt_kw_after = _counter_value(WATCHLIST_MATCHES, result="filtered_keywords")
+    filt_th_after = _counter_value(WATCHLIST_MATCHES, result="filtered_threshold")
+
+    total_delta = (
+        (delivered_after - delivered_before)
+        + (filt_kw_after - filt_kw_before)
+        + (filt_th_after - filt_th_before)
+    )
+    assert total_delta >= 1.0, (
+        "expected at least one tg_watchlist_matches_total increment for a "
+        f"real (interest, doc) pair, got delta={total_delta}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service_with_interest_and_doc():
+    """Build a :class:`WatchlistService` with in-memory fakes and one interest +
+    one matching document. Returns ``(service, channel_id, source_ref)``.
+
+    Both the interest and the document are populated directly into the in-memory
+    fake stores (no awaits) so the fixture is sync and pytest-asyncio agnostic.
+    """
+    from datetime import UTC, datetime
+
+    from tg_parser.domain.models import (
+        NotifyMode,
+        ProcessedDocument,
+        WatchInterest,
+    )
+    from tg_parser.services.watchlist_service import WatchlistService
+
+    class _FakeInterestRepo:
+        def __init__(self) -> None:
+            self.store: dict[str, WatchInterest] = {}
+
+        async def get(self, interest_id: str) -> WatchInterest | None:
+            return self.store.get(interest_id)
+
+        async def list_all(self) -> list[WatchInterest]:
+            return list(self.store.values())
+
+        async def list_active_for_channel(self, channel_id: str) -> list[WatchInterest]:
+            return [i for i in self.store.values() if i.is_active and channel_id in i.channel_ids]
+
+        async def update_embedding(self, interest_id: str, embedding: list[float]) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"embedding": list(embedding)}
+                )
+
+        async def touch_checked(self, interest_id: str, at: datetime) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"last_checked_at": at}
+                )
+
+        async def touch_match(self, interest_id: str, at: datetime) -> None:
+            if interest_id in self.store:
+                self.store[interest_id] = self.store[interest_id].model_copy(
+                    update={"last_match_at": at}
+                )
+
+    class _FakeMatchRepo:
+        def __init__(self) -> None:
+            self.store: dict[tuple[str, str], object] = {}
+
+        async def upsert_many(self, matches):
+            inserted = []
+            for match in matches:
+                key = (match.interest_id, match.source_ref)
+                if key in self.store:
+                    continue
+                self.store[key] = match
+                inserted.append(match)
+            return inserted
+
+    class _FakeProcDocRepo:
+        def __init__(self) -> None:
+            self.store: dict[str, ProcessedDocument] = {}
+
+        async def get_by_source_refs(self, refs):
+            return {ref: self.store[ref] for ref in refs if ref in self.store}
+
+    class _FakeEmbeddingRepo:
+        async def get_by_source_ref(self, ref):
+            return None
+
+    interest_repo = _FakeInterestRepo()
+    match_repo = _FakeMatchRepo()
+    doc_repo = _FakeProcDocRepo()
+    embedding_repo = _FakeEmbeddingRepo()
+
+    channel_id = "ch-watchlist-metrics"
+    source_ref = "tg:metrics_test:post:1"
+
+    interest_id = "int-1"
+    interest_repo.store[interest_id] = WatchInterest(
+        id=interest_id,
+        user_id="user-1",
+        chat_id=12345,
+        title="Crypto regulations",
+        description=None,
+        keywords=["mica", "regulation", "crypto"],
+        exclude_keywords=[],
+        channel_ids=[channel_id],
+        threshold=0.3,
+        notify_mode=NotifyMode.INSTANT,
+        is_active=True,
+        embedding=None,
+    )
+
+    doc_repo.store[source_ref] = ProcessedDocument(
+        id="doc:" + source_ref,
+        source_ref=source_ref,
+        source_message_id="msg-1",
+        channel_id=channel_id,
+        processed_at=datetime.now(UTC),
+        text_clean="MiCA regulation update for crypto exchanges in 2026",
+        summary="MiCA crypto regulation",
+        topics=["crypto", "regulation"],
+        entities=[],
+    )
+
+    service = WatchlistService(
+        interest_repo=interest_repo,
+        match_repo=match_repo,
+        processed_doc_repo=doc_repo,
+        embedding_repo=embedding_repo,
+        embedding_client=None,
+    )
+
+    return service, channel_id, source_ref

--- a/tg_parser/api/metrics.py
+++ b/tg_parser/api/metrics.py
@@ -138,6 +138,84 @@ RESUMMARIZE_DURATION_SECONDS = Histogram(
 )
 
 
+# F11 Topic Watchlist (TD-02 — post-Living-KB Phase 1)
+WATCHLIST_MATCHES = Counter(
+    "tg_watchlist_matches_total",
+    "Watchlist (interest, document) candidate fates produced by WatchlistService.check_interests.",
+    ["result"],
+    # result ∈ {delivered, filtered_keywords, filtered_threshold}.
+    # ``delivered`` = score >= interest.threshold and persisted as WatchMatch
+    # (push delivery itself is tracked separately via WATCHLIST_DELIVERY).
+    # ``filtered_keywords`` = exclude_keyword filter zeroed the score.
+    # ``filtered_threshold`` = below interest.threshold and not excluded.
+    # No interest_id label — bounded by current operator count, but unbounded
+    # over time (see TD-02 cardinality note in metrics.py history). Use the
+    # ``tg_watchlist_score`` histogram for distribution insight instead.
+)
+
+WATCHLIST_SCORE = Histogram(
+    "tg_watchlist_score",
+    "Distribution of hybrid watchlist combined scores in [0, 1].",
+    buckets=(0.0, 0.3, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+)
+
+WATCHLIST_DELIVERY = Counter(
+    "tg_watchlist_delivery_total",
+    "Watchlist push-notification outcomes per (interest, tick) group.",
+    ["outcome"],
+    # outcome ∈ {sent, blocked, error}.
+    # ``sent`` = bot.send_message succeeded for the group.
+    # ``blocked`` = permanent failure detected (chat not found / bot blocked /
+    # user deactivated / forbidden) — interest is soft-deleted by the service
+    # to stop retry storms; matches themselves are preserved.
+    # ``error`` = transient failure (rate-limit, network); group is not retried
+    # in this tick but will be retried on the next match for the same interest.
+)
+
+WATCHLIST_ACTIVE_INTERESTS = Gauge(
+    "tg_watchlist_active_interests",
+    "Currently active (is_active=true) watchlist interests across all tenants.",
+)
+
+
+def record_watchlist_match(*, result: str, score: float) -> None:
+    """Record one (interest, document) candidate fate plus its combined score.
+
+    ``result`` is one of {``delivered``, ``filtered_keywords``,
+    ``filtered_threshold``}. ``score`` is the combined hybrid score in [0, 1]
+    and is observed in :data:`WATCHLIST_SCORE` regardless of outcome — this is
+    the calibration signal for tuning the F11 default threshold (currently 0.6).
+
+    Called from :meth:`tg_parser.services.watchlist_service.WatchlistService.check_interests`.
+    """
+    WATCHLIST_MATCHES.labels(result=result).inc()
+    if score < 0.0:
+        score = 0.0
+    elif score > 1.0:
+        score = 1.0
+    WATCHLIST_SCORE.observe(score)
+
+
+def record_watchlist_delivery(*, outcome: str) -> None:
+    """Record one push-notification outcome.
+
+    ``outcome`` is one of {``sent``, ``blocked``, ``error``}. Called from
+    :meth:`tg_parser.services.watchlist_service.WatchlistService.notify`.
+    """
+    WATCHLIST_DELIVERY.labels(outcome=outcome).inc()
+
+
+def set_watchlist_active(count: int) -> None:
+    """Set the gauge of currently active watchlist interests to ``count``.
+
+    Refreshed periodically from
+    :meth:`tg_parser.services.watchlist_service.WatchlistService.check_interests`
+    (once per scheduler tick) so the value tracks soft-deletes / new
+    subscriptions without a dedicated background job.
+    """
+    WATCHLIST_ACTIVE_INTERESTS.set(max(count, 0))
+
+
 def record_resummarize_outcome(
     *,
     topic_id: str,

--- a/tg_parser/services/watchlist_service.py
+++ b/tg_parser/services/watchlist_service.py
@@ -18,8 +18,13 @@ Karpathy-like invariants:
 - **Graceful degradation:** if the document has no embedding (e.g. RAG
   pipeline failed), scoring falls back to the keyword component only.
 - **Observability:** :class:`WatchScore` keeps the keyword/semantic
-  components separate so a future ``tg_watchlist_matches_total`` metric
-  can bucket by score component.
+  components separate; :func:`tg_parser.api.metrics.record_watchlist_match`
+  emits ``tg_watchlist_matches_total{result}`` plus the
+  ``tg_watchlist_score`` histogram per (interest, doc) candidate, and
+  :func:`tg_parser.api.metrics.record_watchlist_delivery` emits
+  ``tg_watchlist_delivery_total{outcome}`` per push attempt — see
+  ``docs/runbooks/F5C_DEPLOY_AND_WATCH.md`` § F11 watchlist health for
+  PromQL recipes.
 """
 
 from __future__ import annotations
@@ -32,6 +37,11 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from tg_parser.api.metrics import (
+    record_watchlist_delivery,
+    record_watchlist_match,
+    set_watchlist_active,
+)
 from tg_parser.domain.models import (
     NotifyMode,
     ProcessedDocument,
@@ -509,6 +519,7 @@ class WatchlistService:
             return []
 
         active = await self.interest_repo.list_active_for_channel(channel_id)
+        await self._refresh_active_gauge()
         if not active:
             logger.debug("watchlist.no_active_interests", channel_id=channel_id)
             return []
@@ -552,8 +563,13 @@ class WatchlistService:
             for ref, doc in docs_by_ref.items():
                 doc_emb = embeddings_by_ref.get(ref)
                 score = compute_watch_score(interest, doc, doc_emb)
-                if score.combined < interest.threshold:
+                if score.excluded:
+                    record_watchlist_match(result="filtered_keywords", score=score.combined)
                     continue
+                if score.combined < interest.threshold:
+                    record_watchlist_match(result="filtered_threshold", score=score.combined)
+                    continue
+                record_watchlist_match(result="delivered", score=score.combined)
                 all_candidates.append(
                     WatchMatch(
                         id=0,
@@ -686,6 +702,7 @@ class WatchlistService:
                             "watchlist.notify_soft_delete_failed",
                             interest_id=interest.id,
                         )
+                record_watchlist_delivery(outcome="blocked" if permanent else "error")
                 outcomes[interest_id] = "send_failed"
                 continue
 
@@ -699,11 +716,28 @@ class WatchlistService:
                     interest_id=interest.id,
                     match_count=len(group_matches),
                 )
+            record_watchlist_delivery(outcome="sent")
             outcomes[interest_id] = "sent"
 
         return outcomes
 
     # ---- Internal: embedding helpers ----
+
+    async def _refresh_active_gauge(self) -> None:
+        """Refresh ``tg_watchlist_active_interests`` from the interest repo.
+
+        Called once per :meth:`check_interests` tick; ``list_all`` over the
+        ingestion DB is cheap (one row per declared interest, bounded by
+        operator count). Errors are swallowed so a metrics refresh never
+        breaks the scheduler tick.
+        """
+        try:
+            interests = await self.interest_repo.list_all()
+        except Exception:
+            logger.debug("watchlist.refresh_active_gauge_failed", exc_info=True)
+            return
+        active_count = sum(1 for i in interests if i.is_active)
+        set_watchlist_active(active_count)
 
     async def aclose(self) -> None:
         """Best-effort close for the underlying embedding client.


### PR DESCRIPTION
## Summary

Phase 1 / TD-02 — exposes 4 Prometheus metric families for the **F11 watchlist** subsystem. Pre-warms calibration data for F11 P2 (post-watch threshold tuning, see [Wave 2 re-rank rationale](docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md)).

**Source findings:** C-001 (gpt55-002 + opus CODE-001).

**Replaces auto-closed [#17](../pull/17)** (its base branch `fix/td-04-living-kb-docs-closure` deleted after [#16](../pull/16) merged into `main`).

## Metrics added (`tg_parser/api/metrics.py`)

- `tg_watchlist_matches_total{result=delivered|filtered_threshold|filtered_keywords}` — Counter; per-pair fate from `WatchlistService.check_interests`.
- `tg_watchlist_score` — Histogram (buckets `0.0..1.0`); observed for **every** scored pair (not just delivered) so PromQL quantiles can drive F11 P2 threshold calibration.
- `tg_watchlist_delivery_total{outcome=sent|blocked|error}` — Counter; per-delivery group outcome.
- `tg_watchlist_active_interests` — Gauge; refreshed once per `check_interests` tick from `interest_repo.list_all()` (operator-bounded → cheap).

**Cardinality-safe:** `interest_id` deliberately not in label set (would blow up cardinality across N tenants × M interests).

## Service integration (`tg_parser/services/watchlist_service.py`)

- `check_interests`: per-pair `record_watchlist_match` (excluded → `filtered_keywords`; below threshold → `filtered_threshold`; persisted → `delivered`) + score histogram.
- `notify`: `record_watchlist_delivery(sent|blocked|error)` per push outcome.
- `_refresh_active_gauge()`: updates gauge at start of every tick.

## Tests

- **`tests/test_watchlist_metrics.py`** (new, 8 tests) — helper-function increments, score clamping, label values, service-level smoke (`check_interests` calls `record_watchlist_match` ≥ 1 time).
- Existing `tests/test_watchlist_service.py` (75 tests) — unchanged, all still pass.

**Local run:** `pytest tests/test_watchlist_metrics.py tests/test_watchlist_service.py -q` → **83 passed**.

## Runbook

`docs/runbooks/F5C_DEPLOY_AND_WATCH.md` gains an **F11 watchlist health** subsection with PromQL recipes for:
- Match-flow rate per outcome
- Score quantile distribution (calibration for F11 P2)
- Delivery success / block / error rate
- Active-interests gauge baseline
- Tripwire: `rate(tg_watchlist_delivery_total{outcome="error"}[5m]) > 0.1`

## Test plan

- [x] `pytest tests/test_watchlist_metrics.py tests/test_watchlist_service.py -q` — 83/83 green
- [x] `/metrics` exposes 4 watchlist metric families (verified locally — 7 HELP lines incl. `_created` synthetics)
- [x] ruff/mypy clean
- [ ] Post-deploy smoke: `curl localhost:8000/metrics | grep tg_watchlist` (operator)

## Stacked landing order

This is **#2 of 5** in Phase 1. Land in this exact order to preserve CHANGELOG section coherence:

1. ~~TD-04 — opens \`Sprint Debt-Fix Post-Living-KB — Phase 1\` CHANGELOG section~~ ([#16](../pull/16) ✅ merged)
2. **TD-02 (this PR)** — F11 watchlist Prometheus metrics
3. TD-01 — \`error_message\` truncation 4096 ([#18](../pull/18) — will retarget after this merges)
4. TD-03a — \`resummarize\` across LLM-config tools ([#19](../pull/19))
5. TD-03b — Anthropic Settings fields + Phase 1 handoff ([#20](../pull/20))

Refs: [\`docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md\`](docs/notes/REVIEW_2026-04-26_MERGED_PLAN.md) TD-02 / C-001, Phase 1.

Made with [Cursor](https://cursor.com)