### PR TITLE
fix(bug-002 M3): NOW() in delete_source + compose DB_HOST hardcode (PR #35 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,5 +257,6 @@ jobs:
           GEMINI_API_KEY: test
         run: |
           pytest -v --tb=short \
-            tests/test_migrations_runtime_upgrade.py
+            tests/test_migrations_runtime_upgrade.py \
+            tests/test_ingestion_state_repo_soft_delete.py
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,12 @@ services:
     ports:
       - "127.0.0.1:${API_PORT:-8000}:8000"
     environment:
-      # Database
-      - DB_HOST=${DB_HOST:-postgres}
-      - DB_PORT=${DB_PORT:-5432}
+      # Database — DB_HOST hardcoded to compose service name; host-side `.env`
+      # may set DB_HOST=localhost for `tg-parser db ...` CLI runs against the
+      # published 127.0.0.1:5432 port, but inside the container the only
+      # reachable Postgres is `postgres` on the bridge network.
+      - DB_HOST=postgres
+      - DB_PORT=5432
       - DB_NAME=${DB_NAME:-tg_parser}
       - DB_USER=${DB_USER:-tg_parser_user}
       - DB_PASSWORD=${DB_PASSWORD:?Database password required}
@@ -113,9 +116,9 @@ services:
     ports:
       - "127.0.0.1:${MCP_PORT:-8080}:8080"
     environment:
-      # Database
-      - DB_HOST=${DB_HOST:-postgres}
-      - DB_PORT=${DB_PORT:-5432}
+      # Database — see tg_parser service for rationale (DB_HOST hardcoded).
+      - DB_HOST=postgres
+      - DB_PORT=5432
       - DB_NAME=${DB_NAME:-tg_parser}
       - DB_USER=${DB_USER:-tg_parser_user}
       - DB_PASSWORD=${DB_PASSWORD:?Database password required}
@@ -166,9 +169,9 @@ services:
       - ./.env:/app/.env:ro
       - ./prompts:/app/prompts:ro
     environment:
-      # Database
-      - DB_HOST=${DB_HOST:-postgres}
-      - DB_PORT=${DB_PORT:-5432}
+      # Database — see tg_parser service for rationale (DB_HOST hardcoded).
+      - DB_HOST=postgres
+      - DB_PORT=5432
       - DB_NAME=${DB_NAME:-tg_parser}
       - DB_USER=${DB_USER:-tg_parser_user}
       - DB_PASSWORD=${DB_PASSWORD:?Database password required}

--- a/tests/test_ingestion_state_repo_soft_delete.py
+++ b/tests/test_ingestion_state_repo_soft_delete.py
@@ -1,0 +1,145 @@
+"""Integration regression for BUG-002 mitigation M3 (`SAIngestionStateRepo`).
+
+Sprint Hot-fix B+ post-merge — the unit tests in
+``tests/test_mcp_management.py`` and ``tests/test_bot_tools_v12.py`` mock
+``state_repo.delete_source`` so the actual SQL never runs, which let a
+real driver-level bug ship: the original implementation reused a single
+``:now`` named parameter for both ``deleted_at`` and ``updated_at``, and
+asyncpg raised ``AmbiguousParameterError: inconsistent types deduced for
+parameter $1`` at runtime when both columns asked for that placeholder.
+This file exercises the SQL against a live pgvector PG17 container and
+covers the full M3 cycle so the same class of regression cannot pass
+CI silently again.
+
+Uses the session-scoped ``pgvector_container`` fixture from
+``tests/_testcontainer_fixtures.py`` (opt-in via ``TEST_TESTCONTAINERS=1``)
+so the default pytest run on a Docker-less host stays fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _testcontainer_fixtures import (
+    alembic_upgrade_for_branch,
+    async_url_for_db,
+    requires_testcontainers,
+)
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+
+pytest_plugins = ("_testcontainer_fixtures",)
+
+
+@pytest.fixture
+def ingestion_db_url(pgvector_container) -> str:
+    """Fresh ingestion DB at head; returns its asyncpg URL.
+
+    Kept synchronous on purpose: ``alembic_upgrade_for_branch`` boots an
+    async engine inside ``env.py`` via ``asyncio.run(...)``, so it cannot
+    run inside a pytest-asyncio test loop (would raise ``asyncio.run()
+    cannot be called from a running event loop``).  Fixture stays sync
+    so the upgrade happens before the test's loop is even created;
+    the async test then builds its own engine against the URL.
+    """
+    db = alembic_upgrade_for_branch(pgvector_container, "ingestion")
+    return async_url_for_db(pgvector_container, db)
+
+
+async def _seed_owner(session_factory: async_sessionmaker) -> str:
+    """Insert a placeholder admin user; returns its UUID as text.
+
+    ``sources.owner_id`` is a NOT NULL FK to ``users.id`` so we cannot
+    skip this step.  We pick admin role purely to stay clear of the
+    ``users_role_check`` CHECK constraint; it has no other effect.
+    """
+    async with session_factory() as session:
+        result = await session.execute(
+            text(
+                "INSERT INTO users (id, name, role) "
+                "VALUES (gen_random_uuid(), 'm3-test', 'admin') "
+                "RETURNING id"
+            )
+        )
+        owner_id = str(result.scalar_one())
+        await session.commit()
+    return owner_id
+
+
+@requires_testcontainers
+async def test_delete_source_soft_deletes_then_resurrects(ingestion_db_url: str):
+    """Full M3 contract: upsert → delete → filtered → find_deleted → resurrect.
+
+    Asserts the four observable invariants of M3:
+
+    1. ``delete_source`` returns ``True`` on first call (rowcount == 1).
+    2. After delete, ``get_source`` returns ``None`` (default filter
+       hides soft-deleted) but ``find_deleted_source`` /
+       ``get_source(include_deleted=True)`` return the row with a
+       non-null ``deleted_at``.
+    3. Re-``upsert_source`` (the channel reanimation path triggered by
+       ``add_channel`` after a soft-delete) resets ``deleted_at`` back
+       to ``NULL`` so the channel becomes visible again.
+    4. A second ``delete_source`` on an already-deleted row is
+       idempotent (returns ``False``).
+    """
+    engine = create_async_engine(ingestion_db_url)
+    try:
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        owner_id = await _seed_owner(sessionmaker)
+        sid = "m3_smoke_chan"
+        await _run_cycle(sessionmaker, owner_id, sid)
+    finally:
+        await engine.dispose()
+
+
+async def _run_cycle(sessionmaker: async_sessionmaker, owner_id: str, sid: str) -> None:
+    async with sessionmaker() as session:
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=sid,
+                channel_id=sid,
+                status="active",
+                include_comments=False,
+                batch_size=100,
+                owner_id=owner_id,
+            )
+        )
+        fresh = await repo.get_source(sid)
+        assert fresh is not None
+        assert fresh.deleted_at is None
+
+    async with sessionmaker() as session:
+        repo = SAIngestionStateRepo(session)
+        assert await repo.delete_source(sid) is True
+
+    async with sessionmaker() as session:
+        repo = SAIngestionStateRepo(session)
+        assert await repo.get_source(sid) is None
+        deleted = await repo.find_deleted_source(sid)
+        assert deleted is not None
+        assert deleted.deleted_at is not None
+        with_flag = await repo.get_source(sid, include_deleted=True)
+        assert with_flag is not None
+        assert with_flag.deleted_at is not None
+        assert await repo.delete_source(sid) is False
+
+    async with sessionmaker() as session:
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=sid,
+                channel_id=sid,
+                status="active",
+                include_comments=False,
+                batch_size=100,
+                owner_id=owner_id,
+            )
+        )
+        revived = await repo.get_source(sid)
+        assert revived is not None
+        assert revived.deleted_at is None
+        assert await repo.find_deleted_source(sid) is None

--- a/tg_parser/storage/sqlalchemy/ingestion_state_repo.py
+++ b/tg_parser/storage/sqlalchemy/ingestion_state_repo.py
@@ -342,13 +342,10 @@ class SAIngestionStateRepo(IngestionStateRepo):
         result = await self.session.execute(
             text(
                 "UPDATE sources "
-                "SET deleted_at = :now, updated_at = :now "
+                "SET deleted_at = NOW(), updated_at = NOW() "
                 "WHERE source_id = :source_id AND deleted_at IS NULL"
             ),
-            {
-                "source_id": source_id,
-                "now": self._format_datetime(datetime.now(UTC)),
-            },
+            {"source_id": source_id},
         )
         await self.session.commit()
         return result.rowcount > 0


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #35 surfaced while smoke-testing the BUG-002 hot-fix locally before VPS deploy.

### 1. SQL bug in `delete_source` (M3)

The original implementation reused a single named parameter `:now` for both `deleted_at` and `updated_at` columns. asyncpg raised `AmbiguousParameterError: inconsistent types deduced for parameter $1` on the first real call. Unit tests in `tests/test_mcp_management.py` and `tests/test_bot_tools_v12.py` mock `state_repo.delete_source`, so the SQL never executed in CI — the bug was found by manually walking the soft-delete cycle in the live `tg_parser_mcp` container after the redeploy.

Fix: `SET deleted_at = NOW(), updated_at = NOW()` — server-side, typed, atomically consistent.

### 2. Integration regression for the full M3 cycle

New file: `tests/test_ingestion_state_repo_soft_delete.py`

Exercises the SQL against a live pgvector PG17 container via the existing testcontainers fixture (opt-in via `TEST_TESTCONTAINERS=1`). Covers the four observable invariants of M3:

1. `delete_source` returns True first time (soft-deletes the row)
2. After delete, `get_source` returns None but `find_deleted_source` / `get_source(include_deleted=True)` return the row with non-null `deleted_at`
3. Re-`upsert_source` (the channel reanimation path) clears `deleted_at = NULL`
4. Second `delete_source` on already-deleted row is idempotent (False)

This test reproduces the original failure if the SQL fix is reverted — verified locally.

### 3. Compose DB_HOST config drift (separate commit)

The three Python services declared `DB_HOST=${DB_HOST:-postgres}`. The repo's `.env` legitimately has `DB_HOST=localhost` so host-side `tg-parser db ...` CLI works against the published `127.0.0.1:5432` port — but compose substitution then leaked localhost into container env, where it loops back to the container itself.

Fix: hardcode `DB_HOST=postgres` and `DB_PORT=5432` in container env for `tg_parser`, `mcp`, `tg_bot`. The host CLI keeps using `.env`'s `DB_HOST=localhost`. Published port mapping stays parametric.

Symptom that revealed it: redeploying after PR #35 merge crashed `tg_parser` with asyncpg ConnectionRefusedError against `localhost:5432`. The `mcp` and `tg_bot` containers stayed "healthy" because their HTTP `/health` doesn't touch the DB pool.

## Test plan

- [x] `TEST_TESTCONTAINERS=1 pytest tests/test_ingestion_state_repo_soft_delete.py` — passes (3.4s)
- [x] `pytest tests/test_mcp_management.py tests/test_bot_tools_v12.py tests/test_mock_llm.py` — 64 passed
- [x] ruff check + ruff format --check — clean on touched files
- [x] Manual end-to-end smoke in local docker-compose stack: `add_channel` (rejected for placeholders) ✅; `upsert_source → delete_source → find_deleted_source → upsert_source` cycle ✅
- [ ] CI green on this PR before merge

Made with [Cursor](https://cursor.com)