### PR TITLE
fix(tests): isolate global logging state across tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,8 +397,6 @@ def _baseline_structlog_for_caplog():
     snapshots is always the stdlib-routed one — so ``caplog`` works
     deterministically everywhere.
     """
-    import structlog
-
     _apply_structlog_baseline()
     yield
 
@@ -425,14 +423,14 @@ def _isolate_global_logging_config():
     what previous tests did.
     """
     import logging  # local imports keep conftest startup time low
+
     import structlog
 
     root_logger = logging.getLogger()
     saved_root_handlers = root_logger.handlers[:]
     saved_root_level = root_logger.level
     saved_named_levels = {
-        name: logging.getLogger(name).level
-        for name in _LOGGER_NAMES_TOUCHED_BY_APP_CONFIG
+        name: logging.getLogger(name).level for name in _LOGGER_NAMES_TOUCHED_BY_APP_CONFIG
     }
     saved_structlog_config = structlog.get_config()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,134 @@ def mock_telethon_client():
     return mock_client
 
 
+# Logger names that ``tg_parser.config.logging.configure_logging``,
+# ``tg_parser.mcp_server._configure_mcp_logging`` and
+# ``tg_parser.bot.main._configure_logging`` mutate beyond the root
+# logger. Must be restored alongside root, otherwise named-logger
+# levels (e.g. ``aiogram`` clamped to WARNING by the bot config
+# function) leak into subsequent tests.
+_LOGGER_NAMES_TOUCHED_BY_APP_CONFIG = (
+    "httpx",
+    "httpcore",
+    "urllib3",
+    "asyncio",
+    "aiogram",
+)
+
+
+def _apply_structlog_baseline() -> None:
+    """Force structlog into a deterministic stdlib-routed configuration.
+
+    Idempotent: safe to call any number of times. Used by both the
+    session-scoped baseline fixture and the per-test fixture (latter
+    re-applies on setup to defeat module-level imports performed
+    between tests).
+    """
+    import structlog
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _baseline_structlog_for_caplog():
+    """Configure structlog → stdlib logging baseline for the whole session.
+
+    structlog's out-of-the-box ``logger_factory`` is
+    :class:`structlog.PrintLoggerFactory`, which writes directly to
+    ``stdout`` / ``stderr`` and **bypasses stdlib logging entirely**.
+    Pytest's ``caplog`` fixture only captures records that flow through
+    stdlib propagation — without an explicit
+    ``LoggerFactory()``/``BoundLogger`` configuration, ``caplog.records``
+    is empty for any structlog log call, even at WARN/ERROR level.
+
+    Historically a few tests in this repo were working "by accident":
+    upstream tests (e.g. ``test_logging.py``) called ``configure_logging``
+    which switched the global factory to ``stdlib.LoggerFactory``, and
+    that state leaked downstream into tests like
+    ``TestMigrateUsersDI12::test_warns_when_settings_collections_empty``
+    which depend on ``caplog`` seeing structlog WARN logs. Once those
+    upstream tests acquired proper teardown (see the per-test fixture
+    below), the latent brittleness in the downstream tests surfaced.
+
+    This session-scoped fixture installs a deterministic
+    structlog-→-stdlib baseline once at the start of the suite. The
+    per-test fixture below snapshots and restores around each test so
+    mid-session reconfigurations (e.g. ``_configure_mcp_logging``)
+    don't bleed between tests, but the *baseline* the per-test fixture
+    snapshots is always the stdlib-routed one — so ``caplog`` works
+    deterministically everywhere.
+    """
+    import structlog
+
+    _apply_structlog_baseline()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_logging_config():
+    """Snapshot + restore process-global logging state around every test.
+
+    Several tests (and several module-import side effects) call
+    ``configure_logging`` / ``_configure_mcp_logging`` / similar
+    helpers that mutate process-global state: the structlog config
+    (including ``logger_factory`` — switching to ``PrintLoggerFactory``
+    bypasses stdlib propagation entirely, so ``caplog`` no longer sees
+    structlog records), the root stdlib logger's handlers and level,
+    and the named-logger levels for ``httpx`` / ``httpcore`` /
+    ``urllib3`` / ``asyncio`` / ``aiogram``. Without isolation, a
+    single test that sets ``log_level=ERROR`` (or installs
+    ``PrintLoggerFactory``) silently swallows WARN-level assertions in
+    any later test that runs in the same pytest session.
+
+    Pairs with :func:`_baseline_structlog_for_caplog` (session-scoped):
+    the baseline ensures structlog → stdlib routing is the snapshot
+    target, so each test sees a deterministic config regardless of
+    what previous tests did.
+    """
+    import logging  # local imports keep conftest startup time low
+    import structlog
+
+    root_logger = logging.getLogger()
+    saved_root_handlers = root_logger.handlers[:]
+    saved_root_level = root_logger.level
+    saved_named_levels = {
+        name: logging.getLogger(name).level
+        for name in _LOGGER_NAMES_TOUCHED_BY_APP_CONFIG
+    }
+    saved_structlog_config = structlog.get_config()
+
+    # Re-apply baseline at setup so each test starts with a known-good
+    # structlog → stdlib routing, defeating any module-level pollution
+    # that may have occurred between tests (e.g. side-effects of
+    # importing ``tg_parser.bot.main`` at collection time of another
+    # test file that happens to be collected just before this one).
+    _apply_structlog_baseline()
+
+    try:
+        yield
+    finally:
+        root_logger.handlers.clear()
+        for handler in saved_root_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(saved_root_level)
+        for name, level in saved_named_levels.items():
+            logging.getLogger(name).setLevel(level)
+        structlog.configure(**saved_structlog_config)
+        structlog.contextvars.clear_contextvars()
+
+
 @pytest.fixture(autouse=True)
 async def cleanup_job_store():
     """

--- a/tests/test_migrate_users_cmd.py
+++ b/tests/test_migrate_users_cmd.py
@@ -211,9 +211,21 @@ class TestMigrateUsersDI12:
             await db_check.close()
             Database.reset_instance()
 
-    async def test_warns_when_settings_collections_empty(self, clean_users_db, monkeypatch, caplog):
+    async def test_warns_when_settings_collections_empty(self, clean_users_db, monkeypatch):
         """DI-12 observability: empty settings must produce explicit WARN logs
-        AND total_*_in_settings=0 in stats so the operator knows why mapped=0."""
+        AND total_*_in_settings=0 in stats so the operator knows why mapped=0.
+
+        Uses ``structlog.testing.capture_logs`` instead of pytest's ``caplog``
+        because structlog is not guaranteed to route through stdlib logging in
+        every test session — module-level imports of helpers like
+        ``tg_parser.bot.main`` / ``tg_parser.mcp_server`` at collection time
+        can install ``PrintLoggerFactory`` and bypass stdlib propagation, in
+        which case ``caplog.records`` is empty even though WARN logs were
+        emitted (visible in stderr). ``capture_logs`` hooks directly into the
+        structlog processor chain and is order-independent.
+        """
+        from structlog.testing import capture_logs
+
         from tg_parser.cli.migrate_users_cmd import run_migrate_users
 
         _patch_settings_credentials(
@@ -223,7 +235,8 @@ class TestMigrateUsersDI12:
             bot_allowed_users="",
         )
 
-        stats = await run_migrate_users(dry_run=False)
+        with capture_logs() as captured:
+            stats = await run_migrate_users(dry_run=False)
 
         assert stats["api_keys_in_settings"] == 0
         assert stats["mcp_tokens_in_settings"] == 0
@@ -232,10 +245,10 @@ class TestMigrateUsersDI12:
         assert stats["mcp_tokens_mapped"] == 0
         assert stats["telegram_users_mapped"] == 0
 
-        msgs = [r.getMessage() for r in caplog.records]
-        assert any("migrate_users_no_api_keys_in_settings" in m for m in msgs)
-        assert any("migrate_users_no_mcp_tokens_in_settings" in m for m in msgs)
-        assert any("migrate_users_no_telegram_users_in_settings" in m for m in msgs)
+        events = {entry.get("event") for entry in captured if entry.get("log_level") == "warning"}
+        assert "migrate_users_no_api_keys_in_settings" in events
+        assert "migrate_users_no_mcp_tokens_in_settings" in events
+        assert "migrate_users_no_telegram_users_in_settings" in events
 
     async def test_idempotent_second_run_skips_existing(self, clean_users_db, monkeypatch):
         """Running migrate-users twice must be a no-op for existing mappings."""


### PR DESCRIPTION
## Summary

Closes a long-standing **test-pollution flake** that surfaced when running the full suite with `TEST_POSTGRES=1 TEST_TESTCONTAINERS=1`, blocking the green signal on the 162 previously-skipped Postgres/Testcontainers tests.

The single failing test was `tests/test_migrate_users_cmd.py::TestMigrateUsersDI12::test_warns_when_settings_collections_empty` — passing in isolation, failing in the full suite (canonical pollution signature).

Two underlying issues:

1. Tests calling `configure_logging()` / `_configure_mcp_logging()` left process-global structlog/stdlib state mutated, silently suppressing WARN-level log assertions in any later test.
2. structlog defaults to `PrintLoggerFactory`, which writes directly to stderr and bypasses stdlib propagation → pytest's `caplog` cannot capture structlog records unless structlog is explicitly configured with a stdlib `LoggerFactory` at session start.

### Fixes

- `tests/conftest.py` (+128):
  - `_baseline_structlog_for_caplog` (session-scoped, autouse): once-per-session deterministic structlog → stdlib routing via `structlog.configure(logger_factory=stdlib.LoggerFactory(), ...)`.
  - `_isolate_global_logging_config` (function-scoped, autouse): snapshots and restores root-logger handlers/level, named-logger levels (`httpx`/`httpcore`/`urllib3`/`asyncio`/`aiogram`), and structlog config around every test. Re-applies the baseline at setup so each test starts from a known-good config.
- `tests/test_migrate_users_cmd.py` (+20/-7): switch `test_warns_when_settings_collections_empty` from `caplog.records` to `structlog.testing.capture_logs` — hooks into structlog's processor chain directly, immune to whatever global routing structlog is using at the moment, order-independent.

Production code untouched. No CHANGELOG / BUG_LOG entries — pure test-infra hardening, no user-visible behaviour change.

## Test plan

- [x] Target test in isolation: `pytest tests/test_migrate_users_cmd.py::TestMigrateUsersDI12::test_warns_when_settings_collections_empty -q` → PASS.
- [x] `pytest -q` (no env): **1863 passed, 162 skipped, 1 deselected, 0 failed** in 136s.
- [x] `TEST_POSTGRES=1 TEST_TESTCONTAINERS=1 pytest -q`: **2025 passed, 0 failed, 1 deselected** in 147s.
- [ ] CI green on this PR.


Made with [Cursor](https://cursor.com)