### PR TITLE
feat(bot): add /metrics Prometheus endpoint + scrape job (TD #53)

### DIFF
--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -19,3 +19,14 @@ scrape_configs:
       - targets: ["mcp:8080"]
         labels:
           service: "mcp"
+
+  # TD-bot-prometheus-scrape (#53): tg_bot exports its asyncio /metrics
+  # endpoint on 8081 (same port as Docker healthcheck /health). Required
+  # for tg_bot_gemini_empty_parts_total (Session E / BUG-006) post-deploy
+  # watch via Prometheus query path.
+  - job_name: "tg_parser_bot"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["tg_bot:8081"]
+        labels:
+          service: "bot"

--- a/tests/test_f8a_hardening.py
+++ b/tests/test_f8a_hardening.py
@@ -838,6 +838,17 @@ class TestJobStoreSharedEngine:
 
 
 class TestBotHealthServer:
+    async def _request(self, port: int, request_line: bytes) -> str:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        try:
+            writer.write(request_line + b"Host: localhost\r\n\r\n")
+            await writer.drain()
+            data = await asyncio.wait_for(reader.read(65536), timeout=5.0)
+            return data.decode("utf-8", errors="replace")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
     async def test_health_server_starts_and_responds(self):
         from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
 
@@ -845,16 +856,109 @@ class TestBotHealthServer:
         assert server is not None
 
         try:
-            reader, writer = await asyncio.open_connection("127.0.0.1", BOT_HEALTH_PORT)
-            writer.write(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
-            await writer.drain()
-
-            data = await asyncio.wait_for(reader.read(1024), timeout=5.0)
-            response = data.decode()
-
+            response = await self._request(
+                BOT_HEALTH_PORT,
+                b"GET /health HTTP/1.1\r\n",
+            )
             assert "200 OK" in response
+            assert "Content-Type: application/json" in response
             assert '"status":"ok"' in response
+        finally:
+            server.close()
+            await server.wait_closed()
 
+    async def test_metrics_endpoint_returns_prometheus_text(self):
+        """TD-bot-prometheus-scrape (#53): /metrics serves prometheus text format."""
+        # Importing api.metrics registers all bot-relevant counters
+        # (BOT_GEMINI_EMPTY_PARTS_TOTAL etc.) into the default REGISTRY.
+        from tg_parser.api.metrics import BOT_GEMINI_EMPTY_PARTS_TOTAL
+        from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
+
+        BOT_GEMINI_EMPTY_PARTS_TOTAL.labels(model="gemini-2.5-flash", finish_reason="STOP").inc(0)
+
+        server = await _start_health_server()
+        assert server is not None
+
+        try:
+            response = await self._request(
+                BOT_HEALTH_PORT,
+                b"GET /metrics HTTP/1.1\r\n",
+            )
+            assert "200 OK" in response
+            assert "text/plain" in response.lower()
+            assert "tg_bot_gemini_empty_parts_total" in response
+            assert "# HELP tg_bot_gemini_empty_parts_total" in response
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_metrics_endpoint_handles_query_string(self):
+        """Path normalisation: ``/metrics?since=1d`` resolves the same as ``/metrics``."""
+        from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
+
+        server = await _start_health_server()
+        assert server is not None
+
+        try:
+            response = await self._request(
+                BOT_HEALTH_PORT,
+                b"GET /metrics?ts=42 HTTP/1.1\r\n",
+            )
+            assert "200 OK" in response
+            assert "text/plain" in response.lower()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_unknown_path_returns_404(self):
+        """Read-only HTTP surface: anything other than /health and /metrics is 404."""
+        from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
+
+        server = await _start_health_server()
+        assert server is not None
+
+        try:
+            response = await self._request(
+                BOT_HEALTH_PORT,
+                b"GET /admin HTTP/1.1\r\n",
+            )
+            assert "404 Not Found" in response
+            assert '"error":"not_found"' in response
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_post_method_returns_404(self):
+        """Bot HTTP surface is read-only; POST /metrics is 404 (not 405)."""
+        from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
+
+        server = await _start_health_server()
+        assert server is not None
+
+        try:
+            response = await self._request(
+                BOT_HEALTH_PORT,
+                b"POST /metrics HTTP/1.1\r\n",
+            )
+            assert "404 Not Found" in response
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_malformed_request_returns_404(self):
+        """Robustness: garbage on the wire does not crash the handler."""
+        from tg_parser.bot.main import BOT_HEALTH_PORT, _start_health_server
+
+        server = await _start_health_server()
+        assert server is not None
+
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", BOT_HEALTH_PORT)
+            writer.write(b"\xff\xfe\x00\r\n\r\n")
+            await writer.drain()
+            data = await asyncio.wait_for(reader.read(1024), timeout=5.0)
+            response = data.decode("utf-8", errors="replace")
+            assert "404 Not Found" in response
             writer.close()
             await writer.wait_closed()
         finally:

--- a/tg_parser/bot/main.py
+++ b/tg_parser/bot/main.py
@@ -1,6 +1,7 @@
 """
 Bot entrypoint — initialize services, register handlers, start polling.
 F8-A: HTTP health probe for Docker healthcheck.
+TD-bot-prometheus-scrape (#53): /metrics endpoint for Prometheus scrape.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ import structlog
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from tg_parser.bot.agent import GeminiAgent
 from tg_parser.bot.handlers import router
@@ -27,28 +29,90 @@ from tg_parser.bot.middleware import (
 logger = structlog.get_logger(__name__)
 
 BOT_HEALTH_PORT = 8081
+_HEALTH_BODY = b'{"status":"ok"}'
+_NOT_FOUND_BODY = b'{"error":"not_found"}'
+
+
+def _parse_request_line(raw: bytes) -> tuple[str, str]:
+    """Parse the HTTP request line. Returns ``(method, path)``.
+
+    Returns ``("", "")`` on malformed input — the caller treats that as 404.
+    Path is normalized: query string stripped, leading whitespace stripped.
+    Robust to clients that send `GET /metrics` without a Host header
+    (Prometheus is one such client when scraping over HTTP/1.0 fallback).
+    """
+    try:
+        first_line = raw.split(b"\r\n", 1)[0]
+        parts = first_line.decode("ascii", errors="replace").split(" ")
+        if len(parts) < 2:
+            return "", ""
+        method = parts[0].upper()
+        path = parts[1].split("?", 1)[0]
+        return method, path
+    except Exception:
+        return "", ""
+
+
+def _build_response(
+    status: str,
+    body: bytes,
+    *,
+    content_type: str = "application/json",
+) -> bytes:
+    return (
+        f"HTTP/1.1 {status}\r\n"
+        f"Content-Type: {content_type}\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        "Connection: close\r\n\r\n"
+    ).encode("ascii") + body
 
 
 async def _health_handler(reader: StreamReader, writer: StreamWriter) -> None:
-    """Minimal HTTP/1.1 health endpoint for Docker healthcheck."""
+    """Minimal HTTP/1.1 endpoint dispatcher.
+
+    Routes:
+      * ``GET /health``  → 200 ``{"status":"ok"}`` (Docker healthcheck contract).
+      * ``GET /metrics`` → 200 Prometheus text format (TD-bot-prometheus-scrape).
+      * everything else  → 404 ``{"error":"not_found"}``.
+
+    Non-GET methods get the 404 response too — the bot HTTP surface is
+    deliberately read-only.
+    """
+    raw = b""
     try:
-        await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5.0)
+        raw = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5.0)
     except Exception:
         pass
-    body = b'{"status":"ok"}'
-    response = (
-        b"HTTP/1.1 200 OK\r\n"
-        b"Content-Type: application/json\r\n"
-        b"Content-Length: " + str(len(body)).encode() + b"\r\n"
-        b"Connection: close\r\n\r\n" + body
-    )
-    writer.write(response)
-    await writer.drain()
-    writer.close()
+
+    method, path = _parse_request_line(raw)
+
+    if method == "GET" and path == "/health":
+        response = _build_response("200 OK", _HEALTH_BODY)
+    elif method == "GET" and path == "/metrics":
+        try:
+            metrics_body = generate_latest()
+        except Exception:
+            logger.exception("bot_metrics_render_failed")
+            metrics_body = b""
+        response = _build_response(
+            "200 OK",
+            metrics_body,
+            content_type=CONTENT_TYPE_LATEST,
+        )
+    else:
+        response = _build_response("404 Not Found", _NOT_FOUND_BODY)
+
+    try:
+        writer.write(response)
+        await writer.drain()
+    except Exception:
+        pass
+    finally:
+        writer.close()
 
 
 async def _start_health_server() -> asyncio.Server | None:
-    """Start a tiny TCP health server on BOT_HEALTH_PORT."""
+    """Start a tiny TCP HTTP server on BOT_HEALTH_PORT serving /health and /metrics."""
     try:
         server = await asyncio.start_server(_health_handler, "0.0.0.0", BOT_HEALTH_PORT)
         logger.info("bot_health_server_started", port=BOT_HEALTH_PORT)


### PR DESCRIPTION
**Closes #53** (TD-bot-prometheus-scrape).

## Summary

- Bot's existing asyncio TCP server on port 8081 (Docker healthcheck) now also serves \`GET /metrics\` in Prometheus text format via \`prometheus_client.generate_latest()\` — same port, separate path, no extra container port or thread.
- New scrape job \`tg_parser_bot\` in \`docker/prometheus.yml\` targeting \`tg_bot:8081/metrics\` with \`service=bot\` label (mirrors \`tg_parser_api\` / \`tg_parser_mcp\` convention).
- \`_health_handler\` now parses the HTTP request line, dispatches by path: \`/health\` → 200 JSON, \`/metrics\` → 200 Prometheus text, everything else (incl. POST, garbage, unknown paths) → 404. Read-only HTTP surface preserved.
- Existing \`/health\` Docker healthcheck contract untouched (regression-tested).

## Why now

Discovered during Session F deploy (2026-04-30) Phase 0 that \`tg_bot_gemini_empty_parts_total\` (Session E / BUG-006 monitoring metric) is not actually scraped — Phase 0.1 returned empty Prometheus result. Fallback was in-process registry introspection + \`docker logs\` grep over 27h window — equivalent confidence but cannot be automated. Closing this gap before the next deploy that needs metric-watch.

## Test plan

- [x] Unit tests in \`tests/test_f8a_hardening.py::TestBotHealthServer\` (6/6 pass): \`/health\`, \`/metrics\`, query-string normalisation, unknown-path 404, POST 404, malformed-bytes 404 (handler does not crash).
- [x] Full \`pytest\` (default mode) — **1980 passed**, 162 skipped, 1 deselected (was 1975 baseline → +5 new tests, 0 regressions).
- [x] \`ruff check\` clean; \`ruff format --check\` clean.
- [ ] Post-deploy verification on VPS:
  \`\`\`bash
  ssh prod 'docker exec tg_parser_prometheus wget -qO- \\
    "http://localhost:9090/api/v1/query?query=tg_bot_gemini_empty_parts_total" \\
    | python3 -m json.tool'
  \`\`\`
  Expected: non-empty result set with labels \`model\`, \`finish_reason\`. Should appear within ~30 sec of bot startup (one Prometheus scrape cycle).
- [ ] Smoke \`/health\` after redeploy (Docker healthcheck continues to work).
- [ ] Smoke \`/metrics\` directly: \`ssh prod 'docker exec tg_parser_bot wget -qO- http://localhost:8081/metrics | head -20'\`.

## Out of scope

- Grafana dashboard panel for the new metric — separate cleanup, can be done from Grafana UI without code change.
- Alert rules in \`docker/prometheus/alerts.yml\` for sustained empty-parts spike — followup, depends on what threshold makes sense after a few days of real production data.

## Refs

- TD-bot-prometheus-scrape filed in \`docs/notes/DEPLOY_CHECKLIST_SESSION_F_2026-04-30.md\` § 0.4 with the workaround used in the predecessor deploy.
- Session E PR #42 (BUG-006) introduced the metric without the scrape side wired up.
- BUG_LOG.md § Updates → Session F (2026-04-30) deployed (mentions TD-bot-prometheus-scrape).

Made with [Cursor](https://cursor.com)