### PR TITLE
feat(bot): ADR 0005 mini-refactor — bot-scope LLM config + fallback runbook (Session J)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Session J — ADR 0005 mini-refactor: bot-scope LLM config + BOT_LLM_FALLBACK runbook (2026-05-07)
+
+**Контекст.** Реализует ADR 0005 Variant A — добавляет `"bot"` в `LLMConfigManager` с Gemini-only constraint. Устраняет последнюю «снежинку» в LLM-конфигурации: бот теперь получает симметричную runtime-конфигурацию через `set_llm_config(scope="bot", provider="gemini", model=...)` без рестарта. Tracker: GH issue [#60](https://github.com/AlexEfimov/TG_parser/issues/60). Branch: `feat/session-j-adr0005-bot-llm-2026-05-06`.
+
+#### Commit 1 — bot-scope LLM config + GeminiAgent.resolve (ADR 0005)
+
+- `tg_parser/config/settings.py` — добавлен `"bot"` в `LLM_SCOPES`; `LLMConfigManager.set("bot", ...)` валидирует `provider == "gemini"` (D-1) и отвергает `temperature`/`max_tokens` с `ValueError` (D-2 model-only); `resolve("bot")` возвращает Gemini static defaults (`bot_gemini_model`) и иммунен к global override (D-1: `elif global_ov and stage != "bot"`).
+- `tg_parser/processing/prompt_loader.py` — добавлен `"bot"` в `REQUIRED_PROMPT_STAGES` (регрессионная синхронизация с `LLM_SCOPES \ {"global"}`).
+- `tg_parser/bot/agent.py` — добавлен метод `_resolved_model()`: lazy-import `llm_config.resolve("bot")` с `try/except` fallback на `self._model`; `_call_gemini` URL переключён с `self._model` на `self._resolved_model()` — runtime model switch без рестарта.
+- `tg_parser/bot/tools.py` — TOOL_DECLARATIONS для `set_llm_config` и `reset_llm_config` обновлены (scope description включает `"bot"` + Gemini-only + D-2 constraints).
+- `tg_parser/mcp_server.py` — docstrings `set_llm_config` и `reset_llm_config` обновлены (scope `"bot"` + ADR 0005 D-2 ref).
+- `tests/test_settings_bot_scope.py` — новый файл, 9 тестов T-1..T-8 + T-11 (settings layer): LLM_SCOPES includes bot, resolve defaults, set success/failure, D-1 global immunity critical test, clear/revert, get_all output, D-2 temperature/max_tokens raises.
+- `tests/test_bot_agent_resolved_model.py` — новый файл, 2 теста T-9..T-10 (agent layer): `_resolved_model()` uses runtime override, `_resolved_model()` falls back to init default on singleton error.
+
+**Verification:** full pytest baseline 2047 passed (baseline Session I: 2036; +11 новых), 0 regressions. `ruff check` + `ruff format --check` clean.
+
+**Locked decisions:** D-1 (global override immunity for "bot" scope), D-2 ("bot" scope is model-only).
+
+#### Commit 2 — BOT_LLM_FALLBACK runbook (ADR 0005 operational complement)
+
+- `docs/runbooks/BOT_LLM_FALLBACK.md` — manual procedure для оператора при Google Gemini outage: триггеры, pre-flight, runtime model downgrade, rollback, smoke check, quarterly drill.
+
 ### Session I — Source username alias resolution: BUG-010 structural close (2026-05-06)
 
 **Контекст.** Закрывает структурно BUG-010 — write-tools (`remove_channel`, `pause_channel`, `resume_channel`, `trigger_pipeline`, `add_channel` dedup) через bot и MCP принимали `channel_id=username` от пользователя, но передавали его в `get_source(source_id)` который выполняет PK-lookup по числовому Telegram chat ID. Пользователь вводил `AgeManagment`, бот возвращал «Channel not found» хотя канал был виден в `list_channels`. Source: `BUG_LOG.md` § BUG-010. Tracker: GH issue [#50](https://github.com/AlexEfimov/TG_parser/issues/50). Branch: `fix/bug-010-source-username-alias-2026-05-06`.

--- a/docs/runbooks/BOT_LLM_FALLBACK.md
+++ b/docs/runbooks/BOT_LLM_FALLBACK.md
@@ -1,0 +1,141 @@
+# BOT_LLM_FALLBACK — Manual Fallback Runbook for Google Gemini Outage
+
+**ADR reference:** `docs/adr/0005-bot-llm-provider-flexibility.md` — Operational complement (вместо Variant B failover).
+
+**Last reviewed:** 2026-05-07 (Session J, initial creation).
+
+---
+
+## 1. Когда использовать
+
+Этот runbook применяется при **Google Gemini API outage**, когда:
+
+- Telegram-бот перестаёт отвечать на сообщения (агент возвращает «Произошла ошибка при обращении к LLM»).
+- Метрика `tg_bot_gemini_empty_parts_total` с `finish_reason ∈ {"no_candidates", "blocked", "OTHER"}` резко растёт.
+- Google API Status Page ([status.cloud.google.com](https://status.cloud.google.com)) или Gemini API отображает инцидент.
+- Outage длится ≥30 минут (более короткие инциденты — wait-and-see; Gemini обычно восстанавливается быстро).
+
+**НЕ применять** при:
+- Единичных ошибках / таймаутах (≤5 минут) — нормальный jitter API.
+- Проблемах с `BOT_GEMINI_API_KEY` — это billing/key issue, не provider outage.
+- Pipeline-ошибках processing/rag/digest — они не влияют на бот-агент.
+
+---
+
+## 2. Pre-flight проверка
+
+Перед переключением убедитесь, что проблема именно в провайдере:
+
+```bash
+# 1. Проверить текущий статус бота
+ssh -p 2296 user@212.72.189.15 'docker logs --since 30m tg_parser 2>&1 | grep -E "gemini_empty|gemini_no_candidates|gemini_blocked|gemini_api_error" | tail -20'
+
+# 2. Убедиться, что контейнер живёт
+ssh -p 2296 user@212.72.189.15 'docker exec tg_parser_prometheus wget -qO- \
+  "http://localhost:9090/api/v1/query?query=up{service=\"bot\"}" \
+  | python3 -m json.tool | grep -A2 "value"'
+# Expected: value="1"
+
+# 3. Проверить текущую конфигурацию LLM через MCP (если MCP доступен)
+# Вызвать get_llm_config через Cursor MCP → stages.bot.provider должен быть "gemini"
+```
+
+---
+
+## 3. Процедура переключения (downgrade модели)
+
+Так как Telegram-бот — Gemini-only (ADR 0005 D-1), переключение на другой провайдер невозможно. **Единственная операция** — смена модели внутри Gemini-семейства (например, downgrade с `gemini-2.5-flash` на `gemini-2.0-flash` если outage затрагивает только 2.5-серию).
+
+### Шаг 3.1 — Определить резервную модель
+
+| Основная модель | Резервная модель | Когда применять |
+|---|---|---|
+| `gemini-2.5-flash` | `gemini-2.0-flash` | Outage специфичен для 2.5-серии |
+| `gemini-2.5-pro` | `gemini-2.5-flash` | Downgrade при quota/capacity issues |
+| любая | `gemini-1.5-flash` | Последний резерв при широком outage |
+
+### Шаг 3.2 — Применить runtime override (без рестарта)
+
+Через Telegram-бота (если бот частично работает) или через MCP-инструмент:
+
+```
+# Через MCP (Cursor):
+set_llm_config(scope="bot", provider="gemini", model="gemini-2.0-flash")
+
+# Через Telegram-бота (если у вас admin rights):
+set_llm_config scope=bot provider=gemini model=gemini-2.0-flash
+```
+
+Проверить немедленно через `get_llm_config` — `stages.bot.model` должен показать новую модель.
+
+### Шаг 3.3 — Smoke test
+
+Отправить боту простой Q&A запрос через Telegram:
+- «какие есть каналы?» — должен вернуть список
+- «главные темы» — должен вернуть топ-5 тем
+
+Если ответ получен — переключение успешно, переходите к § 5 (мониторинг).
+
+### Шаг 3.4 — Если runtime override не помогает (полный Gemini outage)
+
+При полном недоступном Gemini API (все модели) единственный вариант — **рестарт с другим ключом** (другой Google проект/billing account):
+
+```bash
+ssh -p 2296 user@212.72.189.15 'cd ~/TG_parser && \
+  GEMINI_API_KEY="<backup_key>" docker compose up -d --no-deps --force-recreate tg_parser'
+```
+
+> **Примечание:** Backup-ключ должен быть подготовлен заранее и храниться в защищённом месте (password manager / secrets vault). При наличии — добавьте как `GEMINI_API_KEY_BACKUP` в `.env`.
+
+---
+
+## 4. Rollback
+
+После восстановления основного Gemini API вернуть исходную модель:
+
+```
+# Через MCP или Telegram-бота:
+reset_llm_config(scope="bot")
+```
+
+Проверить через `get_llm_config` — `stages.bot.model` должен показать значение из `.env` (`BOT_GEMINI_MODEL`).
+
+Финальный smoke test (аналогично § 3.3).
+
+---
+
+## 5. Post-procedure мониторинг (≥30 минут после переключения)
+
+```bash
+# Убедиться что ошибки пропали
+ssh -p 2296 user@212.72.189.15 'docker logs --since 30m tg_parser 2>&1 \
+  | grep -cE "gemini_empty|gemini_no_candidates|gemini_api_error"'
+# Expected: 0
+
+# Проверить Prometheus метрики
+ssh -p 2296 user@212.72.189.15 'docker exec tg_parser_prometheus wget -qO- \
+  "http://localhost:9090/api/v1/query?query=tg_bot_gemini_empty_parts_total" \
+  | python3 -m json.tool'
+```
+
+---
+
+## 6. Quarterly drill (тест без реального outage)
+
+Раз в квартал проверять runbook работоспособность:
+
+1. Выбрать нагрузку < 5 пользователей (желательно в нерабочее время).
+2. Применить override на 5 минут: `set_llm_config(scope="bot", provider="gemini", model="gemini-2.0-flash")`.
+3. Отправить 2-3 тестовых запроса — убедиться что работает.
+4. Откатить: `reset_llm_config(scope="bot")`.
+5. Записать результат в `docs/notes/BUG_LOG.md` (раздел «Quarterly drills»).
+
+**Цель drill:** убедиться что резервная модель (`gemini-2.0-flash`) доступна и принимает наши tool_declarations. API может изменить deprecation/availability между дрилами.
+
+---
+
+## 7. Условия пересмотра решения
+
+Если этот runbook применялся ≥1 раза за квартал с outage ≥30 минут — это **триггер пересмотра ADR 0005** (условие пересмотра #1 в ADR). В этом случае рассмотреть Variant B (автоматический failover) или Variant C (полный refactor BotAgent).
+
+Подробнее: `docs/adr/0005-bot-llm-provider-flexibility.md` § «Условия пересмотра».

--- a/tests/test_bot_agent_resolved_model.py
+++ b/tests/test_bot_agent_resolved_model.py
@@ -1,0 +1,67 @@
+"""Tests for ADR 0005 Session J: GeminiAgent._resolved_model() dynamic dispatch.
+
+T-9..T-10 (agent layer). Kept separate from test_settings_bot_scope.py
+because these tests mock the global singleton tg_parser.config.llm_config.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tg_parser.bot.agent import GeminiAgent
+from tg_parser.config.settings import LLMConfigManager
+
+
+class _FakeSettings:
+    """Minimal stand-in for tg_parser.config.Settings."""
+
+    llm_provider = "openai"
+    llm_model = "gpt-4o-mini"
+
+    processing_llm_provider = None
+    processing_llm_model = None
+    topicization_llm_provider = None
+    topicization_llm_model = None
+
+    openai_api_key = "sk-openai"
+    anthropic_api_key = "sk-anthropic"
+    gemini_api_key = "sk-gemini"
+    google_api_key = None
+
+    bot_gemini_model = "gemini-2.5-flash"
+
+
+@pytest.fixture(autouse=True)
+def _clear_manager():
+    LLMConfigManager.reset()
+    yield
+    LLMConfigManager.reset()
+
+
+# ── T-9 ─────────────────────────────────────────────────────────────────
+
+
+def test_gemini_agent_resolved_model_uses_llm_config():
+    """_resolved_model() returns the runtime override, not the init-time default."""
+    fake = _FakeSettings()
+    LLMConfigManager.reset()
+    mgr = LLMConfigManager(fake)
+    mgr.set("bot", "gemini", model="gemini-2.5-pro")
+
+    agent = GeminiAgent(api_key="sk-gemini", model="gemini-2.5-flash")
+    with patch("tg_parser.config.llm_config", mgr):
+        assert agent._resolved_model() == "gemini-2.5-pro"
+
+
+# ── T-10 ────────────────────────────────────────────────────────────────
+
+
+def test_gemini_agent_resolved_model_falls_back_on_error():
+    """_resolved_model() falls back to self._model when singleton is unavailable."""
+    LLMConfigManager.reset()
+    agent = GeminiAgent(api_key="sk-gemini", model="gemini-2.5-flash")
+
+    # Patch llm_config.resolve to raise so we exercise the except branch.
+    broken = object()  # has no .resolve() — AttributeError inside try/except
+    with patch("tg_parser.config.llm_config", broken):
+        assert agent._resolved_model() == "gemini-2.5-flash"

--- a/tests/test_settings_bot_scope.py
+++ b/tests/test_settings_bot_scope.py
@@ -1,0 +1,130 @@
+"""Tests for ADR 0005 Session J: bot-scope LLM config in LLMConfigManager.
+
+Covers T-1..T-8 + T-11 (settings layer).
+Agent-layer tests (T-9..T-10) live in test_bot_agent_resolved_model.py.
+"""
+
+import pytest
+
+from tg_parser.config.settings import LLM_SCOPES, LLMConfigManager
+
+
+class _FakeSettings:
+    """Minimal stand-in for tg_parser.config.Settings."""
+
+    llm_provider = "openai"
+    llm_model = "gpt-4o-mini"
+
+    processing_llm_provider = None
+    processing_llm_model = None
+    topicization_llm_provider = None
+    topicization_llm_model = None
+
+    openai_api_key = "sk-openai"
+    anthropic_api_key = "sk-anthropic"
+    gemini_api_key = "sk-gemini"
+    google_api_key = None
+
+    bot_gemini_model = "gemini-2.5-flash"
+
+
+@pytest.fixture(autouse=True)
+def _clear_manager():
+    """Ensure clean LLMConfigManager singleton state between tests."""
+    LLMConfigManager.reset()
+    yield
+    LLMConfigManager.reset()
+
+
+@pytest.fixture()
+def manager():
+    fake = _FakeSettings()
+    LLMConfigManager.reset()
+    return LLMConfigManager(fake)
+
+
+# ── T-1 ─────────────────────────────────────────────────────────────────
+
+
+def test_llm_scopes_includes_bot():
+    assert "bot" in LLM_SCOPES
+
+
+# ── T-2 ─────────────────────────────────────────────────────────────────
+
+
+def test_resolve_bot_returns_gemini_defaults(manager):
+    provider, api_key, model = manager.resolve("bot")
+    assert provider == "gemini"
+    assert model == "gemini-2.5-flash"
+    assert api_key == "sk-gemini"
+
+
+# ── T-3 ─────────────────────────────────────────────────────────────────
+
+
+def test_set_bot_scope_gemini_succeeds(manager):
+    manager.set("bot", "gemini", model="gemini-2.5-pro")
+    _, _, model = manager.resolve("bot")
+    assert model == "gemini-2.5-pro"
+
+
+# ── T-4 ─────────────────────────────────────────────────────────────────
+
+
+def test_set_bot_scope_non_gemini_raises(manager):
+    with pytest.raises(ValueError, match="only supports provider='gemini'"):
+        manager.set("bot", "anthropic", model="claude-sonnet-4")
+
+
+# ── T-5 ─────────────────────────────────────────────────────────────────
+
+
+def test_global_override_does_not_affect_bot_scope(manager):
+    """D-1: global switch to non-Gemini must NOT break the bot agent."""
+    manager.set("global", "anthropic", model="claude-sonnet-4")
+    provider, _, model = manager.resolve("bot")
+    assert provider == "gemini"
+    assert model == "gemini-2.5-flash"
+
+
+# ── T-6 ─────────────────────────────────────────────────────────────────
+
+
+def test_resolve_bot_after_runtime_set(manager):
+    manager.set("bot", "gemini", model="gemini-2.5-pro")
+    provider, key, model = manager.resolve("bot")
+    assert provider == "gemini"
+    assert model == "gemini-2.5-pro"
+    assert key == "sk-gemini"
+
+
+# ── T-7 ─────────────────────────────────────────────────────────────────
+
+
+def test_clear_bot_scope_reverts_to_default(manager):
+    manager.set("bot", "gemini", model="gemini-2.5-pro")
+    manager.clear("bot")
+    _, _, model = manager.resolve("bot")
+    assert model == "gemini-2.5-flash"
+
+
+# ── T-8 ─────────────────────────────────────────────────────────────────
+
+
+def test_get_all_includes_bot_stage(manager):
+    config = manager.get_all()
+    assert "bot" in config["stages"]
+    assert config["stages"]["bot"]["provider"] == "gemini"
+
+
+# ── T-11 ────────────────────────────────────────────────────────────────
+
+
+def test_set_bot_scope_with_temperature_raises(manager):
+    """D-2: bot scope is model-only — temperature/max_tokens must raise."""
+    with pytest.raises(ValueError, match="model-only"):
+        manager.set("bot", "gemini", model="gemini-2.5-pro", temperature=0.5)
+
+    with pytest.raises(ValueError, match="model-only"):
+        manager.set("bot", "gemini", model="gemini-2.5-pro", max_tokens=16384)

--- a/tg_parser/bot/agent.py
+++ b/tg_parser/bot/agent.py
@@ -140,6 +140,20 @@ class GeminiAgent:
         """Reload the system prompt from YAML (called after reload_prompts)."""
         self._system_prompt = _load_bot_system_prompt()
 
+    def _resolved_model(self) -> str:
+        """Return current model from LLMConfigManager (BUG-safe fallback to init default).
+
+        Called on every _call_gemini invocation so runtime set_llm_config(scope='bot')
+        takes effect immediately without agent restart (ADR 0005 Session J).
+        """
+        try:
+            from tg_parser.config import llm_config
+
+            _, _, model = llm_config.resolve("bot")
+            return model or self._model
+        except Exception:
+            return self._model
+
     async def process_message(
         self,
         user_message: str,
@@ -346,7 +360,7 @@ class GeminiAgent:
         so Gemini can resolve ambiguous channel references on this turn.
         The block is read-only: write-tools are explicitly exempted (D-6).
         """
-        url = f"{GEMINI_API_BASE}/{self._model}:generateContent"
+        url = f"{GEMINI_API_BASE}/{self._resolved_model()}:generateContent"
 
         generation_config: dict[str, Any] = {
             "temperature": 0.2,

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -433,9 +433,12 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
                     "type": "STRING",
                     "description": (
                         "Which config to change. One of: 'global', 'processing', "
-                        "'topicization', 'rag', 'digest', 'resummarize'. "
-                        "'global' is the fallback used by every stage that has no "
-                        "explicit override; the others are real pipeline stages."
+                        "'topicization', 'rag', 'digest', 'resummarize', 'bot'. "
+                        "'global' is the fallback used by every pipeline stage that has no "
+                        "explicit override (does NOT affect 'bot' scope — bot is Gemini-only). "
+                        "'bot' controls the Gemini model used by the Telegram bot agent at runtime "
+                        "(provider must be 'gemini'; ONLY model can be overridden — temperature/"
+                        "max_tokens for bot scope are not supported and will be rejected)."
                     ),
                 },
                 "provider": {
@@ -476,7 +479,7 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
                     "type": "STRING",
                     "description": (
                         "Scope to reset. One of: 'global', 'processing', "
-                        "'topicization', 'rag', 'digest', 'resummarize'. "
+                        "'topicization', 'rag', 'digest', 'resummarize', 'bot'. "
                         "Omit to reset ALL overrides."
                     ),
                 },

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -834,20 +834,24 @@ class RetrySettings(BaseSettings):
 
 
 SUPPORTED_LLM_PROVIDERS = ("openai", "anthropic", "gemini", "ollama")
-LLM_SCOPES = ("global", "processing", "topicization", "rag", "digest", "resummarize")
+LLM_SCOPES = ("global", "processing", "topicization", "rag", "digest", "resummarize", "bot")
 
 
 class LLMConfigManager:
     """Runtime LLM configuration overlay.
 
     Holds per-scope (one of :data:`LLM_SCOPES`: global / processing /
-    topicization / rag / digest / resummarize)
+    topicization / rag / digest / resummarize / bot)
     overrides that take effect immediately for new LLM client creation.
     Thread-safe via a reentrant lock so concurrent pipeline workers can
     read safely while an MCP/API call writes.
 
     Static settings from ``.env`` are used as defaults; runtime overrides
     are lost on restart (safe fallback by design).
+
+    ADR 0005 (Session J): "bot" scope is Gemini-only and immune to global
+    overrides (D-1). Only model= can be changed at runtime; temperature and
+    max_tokens are rejected with ValueError (D-2).
     """
 
     _instance: "LLMConfigManager | None" = None
@@ -915,6 +919,23 @@ class LLMConfigManager:
         """
         if scope not in LLM_SCOPES:
             raise ValueError(f"Invalid scope '{scope}'. Use one of: {', '.join(LLM_SCOPES)}")
+
+        # ADR 0005 D-1 + D-2 (Session J): bot scope is Gemini-only and model-only.
+        if scope == "bot":
+            if provider != "gemini":
+                raise ValueError(
+                    "scope='bot' only supports provider='gemini' (ADR 0005 Variant A). "
+                    "Use set_llm_config(scope='bot', provider='gemini', model='gemini-2.5-pro') "
+                    "to switch Gemini model at runtime."
+                )
+            if temperature is not None or max_tokens is not None:
+                raise ValueError(
+                    "scope='bot' is model-only (ADR 0005 D-2). "
+                    "temperature/max_tokens overrides are not supported — "
+                    "they are pinned to BOT_GEMINI_* env vars at startup. "
+                    "Pass only model= for runtime model switching."
+                )
+
         self._validate_provider(provider)
 
         with self._lock:
@@ -948,9 +969,16 @@ class LLMConfigManager:
         if stage_ov:
             provider = stage_ov["provider"]  # type: ignore[assignment]
             model = stage_ov.get("model")
-        elif global_ov:
+        elif global_ov and stage != "bot":
+            # ADR 0005 D-1 (Session J): global override does NOT affect "bot" scope —
+            # bot is Gemini-only; a global switch to "anthropic" must not
+            # silently break the bot agent.
             provider = global_ov["provider"]  # type: ignore[assignment]
             model = global_ov.get("model")
+        elif stage == "bot":
+            # ADR 0005 Variant A (Session J): bot static defaults — always Gemini.
+            provider = "gemini"
+            model = getattr(self._static, "bot_gemini_model", None)
         else:
             provider = (
                 getattr(self._static, f"{stage}_llm_provider", None) or self._static.llm_provider

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -1656,7 +1656,10 @@ async def set_llm_config(
     Changes are NOT persisted to .env — a restart reverts to defaults.
 
     Args:
-        scope: Which config to change: 'global', 'processing', 'topicization', 'rag', 'digest', or 'resummarize'.
+        scope: Which config to change: 'global', 'processing', 'topicization', 'rag',
+               'digest', 'resummarize', or 'bot'. 'bot' controls the Gemini model for
+               the Telegram bot agent (provider must be 'gemini'; temperature and
+               max_tokens are not supported for bot scope per ADR 0005 D-2).
         provider: LLM provider name: 'openai', 'anthropic', 'gemini', or 'ollama'.
         model: Optional model name override (e.g. 'gpt-4o', 'claude-sonnet-4-20250514').
                If omitted, the provider's default model is used.
@@ -1702,8 +1705,8 @@ async def reset_llm_config(
     """Reset runtime LLM overrides, reverting to .env defaults.
 
     Args:
-        scope: Scope to reset ('global', 'processing', 'topicization', 'rag', 'digest', or 'resummarize').
-               If omitted, resets ALL runtime overrides."""
+        scope: Scope to reset ('global', 'processing', 'topicization', 'rag',
+               'digest', 'resummarize', or 'bot'). If omitted, resets ALL overrides."""
     from tg_parser.auth.ownership import PermissionDenied, assert_admin
     from tg_parser.config import llm_config
 

--- a/tg_parser/processing/prompt_loader.py
+++ b/tg_parser/processing/prompt_loader.py
@@ -33,7 +33,7 @@ class PromptLoaderError(RuntimeError):
 
 
 REQUIRED_PROMPT_STAGES: frozenset[str] = frozenset(
-    {"processing", "topicization", "rag", "digest", "resummarize"}
+    {"processing", "topicization", "rag", "digest", "resummarize", "bot"}
 )
 """Stages that must resolve to a non-empty system prompt.
 


### PR DESCRIPTION
## Summary

Closes #60. Implements ADR 0005 Variant A — adds `"bot"` scope to `LLMConfigManager` with Gemini-only constraint, enabling runtime model switching without restart.

## Changes

**Commit 1 — bot-scope LLM config + GeminiAgent.resolve:**
- `tg_parser/config/settings.py` — `"bot"` added to `LLM_SCOPES`; `set("bot", provider!="gemini")` → ValueError (D-1); `set("bot", temperature=...)` → ValueError (D-2 model-only); `resolve("bot")` returns Gemini static defaults, immune to global override
- `tg_parser/processing/prompt_loader.py` — `"bot"` added to `REQUIRED_PROMPT_STAGES` (synced with `LLM_SCOPES`)
- `tg_parser/bot/agent.py` — `_resolved_model()` added; `_call_gemini` URL uses `_resolved_model()` instead of `self._model`
- `tg_parser/bot/tools.py` — TOOL_DECLARATIONS for both `set_llm_config` and `reset_llm_config` updated with `"bot"` scope
- `tg_parser/mcp_server.py` — docstrings for both `set_llm_config` and `reset_llm_config` updated
- `tests/test_settings_bot_scope.py` — 9 tests: T-1..T-8 + T-11 (settings layer)
- `tests/test_bot_agent_resolved_model.py` — 2 tests: T-9..T-10 (agent layer)

**Commit 2 — BOT_LLM_FALLBACK runbook:**
- `docs/runbooks/BOT_LLM_FALLBACK.md` — operator runbook: triggers, pre-flight, downgrade, rollback, smoke check, quarterly drill

## Locked decisions

- **D-1**: `"bot"` scope is immune to global override — bot is Gemini-only
- **D-2**: `"bot"` scope is model-only — `temperature`/`max_tokens` rejected with ValueError

## Test plan

- [x] `pytest tests/test_bot_fsm.py -q` → 69 passed (pre-test verification, no regression)
- [x] `pytest tests/test_settings_bot_scope.py -v` → 9 passed (T-1..T-8 + T-11)
- [x] `pytest tests/test_bot_agent_resolved_model.py -v` → 2 passed (T-9..T-10)
- [x] `pytest --tb=short -q` → **2047 passed, 0 failed** (baseline Session I: 2036, +11 new)
- [x] `ruff check . && ruff format --check .` → 0 violations

Made with [Cursor](https://cursor.com)