### PR TITLE
feat(F4-B Core): thematic workspaces over F4-A multi-tenancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Wave 1 Step 2 — F4-B Core Workspaces (2026-05-13)
+
+**Контекст.** Wave 1 step 2 per `PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md` § 5.1: тематические workspace-коллекции поверх F4-A multi-tenancy. Single PR + 5 atomic commits; ~1450 LOC + ~75 новых тестов. Source of truth: `docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md`.
+
+**Hard invariants (locked Q1–Q8 + Karpathy 7-checklist):**
+
+- `workspace_id=None` → bit-for-bit F4-A behaviour (regression-guarded по `tests/test_f4b_backward_compat.py`).
+- Unknown / foreign `workspace_id` → 404-like empty (`WorkspaceNotFound`); никогда не leak'аем existence.
+- Empty workspace → `effective_channel_ids=[]` (explicit, не silent "all channels" — hidden gotcha § 3).
+- `get_topic_details` / `get_document` возвращают full bundle items независимо от workspace (Q4 R3 — workspace narrows list/search, не access control).
+- Service-слойные signatures (`retrieval_service.search` и др.) не меняются — workspace resolve живёт на surface level.
+
+#### Commit 1/5 — schema + migration + Pydantic + JSON contract
+
+- `migrations/versions/ingestion/20260513_add_workspaces.py` — Alembic ingestion-branch revision `e9f0a1b2c3d5` создаёт `workspaces` + `workspace_sources` (M2M, composite PK, FK ON DELETE CASCADE).
+- `tg_parser/storage/sqlalchemy/_metadata.py` — `INGESTION_METADATA` обновлён до head `e9f0a1b2c3d5` с обоими таблицами.
+- `tg_parser/domain/models.py` — `Workspace` + `WorkspaceSource` Pydantic models с trim+length валидацией `name` (gotcha § 6 per-owner uniqueness).
+- `docs/contracts/workspace.schema.json` — JSON Schema contract для обоих domain models.
+- `tests/test_f4b_schema.py` — 10 тестов: Pydantic валидации + Postgres CHECK constraints (`UNIQUE(owner_id, name)`, `length(trim(name)) > 0`, FK CASCADE).
+
+#### Commit 2/5 — service + repo + ownership
+
+- `tg_parser/storage/ports.py` — `WorkspaceRepo` ABC (CRUD, M2M membership, `resolve_source_id_for_channel`).
+- `tg_parser/storage/sqlalchemy/workspace_repo.py` — `SAWorkspaceRepo` (raw SQL через индексы, `ON CONFLICT DO NOTHING` для idempotent membership, JOIN на `sources` с soft-delete фильтром).
+- `tg_parser/auth/ownership.py` — `WorkspaceNotFound` (404-like) + `assert_workspace_access` helper (admin-bypass per F4-A Q2 edge case 3).
+- `tg_parser/services/workspace_service.py` — `WorkspaceService` (CRUD + `effective_channel_ids` resolver, channel_id → source_id translation, `WorkspaceSourceNotFound`).
+- `tg_parser/services/db_context.py` — `workspace_repo()` async context manager.
+- 32 теста: `tests/test_f4b_workspace_repo.py` (15), `tests/test_f4b_assert_workspace_access.py` (4), `tests/test_f4b_workspace_service.py` (13).
+
+#### Commit 3/5 — MCP + CLI surface
+
+- `tg_parser/mcp_server.py` — 8 новых MCP tools: `list_workspaces`, `create_workspace`, `rename_workspace`, `delete_workspace`, `add_workspace_source`, `remove_workspace_source`, `list_workspace_sources`, `list_all_workspaces`. Result types: `WorkspaceInfo`, `ListWorkspacesResult`, `CreateWorkspaceResult`, `RenameWorkspaceResult`, `DeleteWorkspaceResult`, `WorkspaceSourceOpResult`, `ListWorkspaceSourcesResult`.
+- `tg_parser/cli/workspace_cmd.py` — `tg-parser workspace` Typer-приложение с 8 подкомандами (`list`, `create`, `rename`, `delete`, `add-source`, `remove-source`, `list-sources`, `list-all`).
+- `tg_parser/cli/app.py` — регистрация `workspace_app` через `app.add_typer(..., name="workspace")`.
+- 20 тестов: `tests/test_f4b_mcp_tools.py` (12), `tests/test_f4b_cli_workspace.py` (8).
+
+#### Commit 4/5 — scoping integration in read-tools
+
+- `tg_parser/mcp_server.py` — `_resolve_workspace_scope` helper; `workspace_id: str | None = None` на 8 read tools (`list_channels`, `list_topics`, `search_knowledge_base`, `ask_question`, `get_topic_details`, `get_document`, `get_related_topics`, `get_cross_channel_stats`). Service signatures не меняются — narrowing на surface level до downstream call.
+- `tg_parser/cli/app.py` — `_resolve_workspace_scope_cli` helper; `--workspace-id` + `--user` флаги на `tg-parser search` и `tg-parser ask`.
+- `tests/test_f4b_scoping_read_tools.py` — 14 тестов scope матрицы (None / unknown / foreign / empty / intersect) + Q4 R3 invariant для `get_topic_details` / `get_document`.
+
+#### Commit 5/5 — regression guards + observability + docs
+
+- `tg_parser/api/metrics.py` — Prometheus exporters: `tg_workspace_total` (Gauge), `tg_workspace_size` / `tg_workspace_effective_size` / `tg_workspace_resolver_seconds` (Histogram), `tg_workspace_query_total{result}` / `tg_workspace_tool_total{tool, result}` (Counter). Helpers: `record_workspace_query`, `record_workspace_tool`, `set_workspace_total`, `bump_workspace_total`.
+- `tg_parser/services/workspace_service.py` — инструментирован: gauge bump на create/delete, query counter + size/duration histograms в `effective_channel_ids`, structlog `info`/`debug` со связкой `user_id` / `workspace_id` / `resolver_seconds`.
+- 31 тест: `tests/test_f4b_backward_compat.py` (12 — каждый scoped tool без workspace_id ≡ F4-A baseline), `tests/test_f4b_workspace_isolation.py` (6 — cross-user 404-like), `tests/test_f4b_metrics.py` (8 — Prometheus exporter shape + emit на create/delete/resolver), `tests/test_f4b_golden_path.py` (1 end-to-end multi-workspace).
+- `docs/notes/FUTURE_FEATURES.md` § F4-B → ✅ Core MVP DONE 2026-05-13.
+- `docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md` — раздел `## 2026-05-13 — Wave 1 step 2 (F4-B Core) DONE ✅`.
+
+**Verification:** ~2152 passed (baseline 2047 + 75 новых для F4-B + 30 уже существовали в repo), 0 regressions. `ruff format` + `ruff check` clean. Pre-flight gate-1 GREEN (Prometheus `up{service="bot"}` = `1`, `confirm_flow_mismatch` 72h = `0`, `gemini_*` errors 72h = `0` на `tg_parser_bot`).
+
+**Deferred (Wave 1 step 3+ / Wave 2):** O-1 atomic `move_workspace_source` (non-atomic remove + add используется в MVP, см. `PARITY_DECISION_TRACKING.md` § 3); Bot integration (`tg_parser/bot/tools.py` без workspace MVP, Q3 locked); F11 watchlist workspace_id (Q7 deferred); F6 digest workspace_id (Q8 deferred); sharing / collaboration (audience A2/A3 — Wave 2+).
+
+**Roadmap:** F4-B Core ✅ → Wave 1 step 3 (Surface Parity) is next.
+
 ### Session J — ADR 0005 mini-refactor: bot-scope LLM config + BOT_LLM_FALLBACK runbook (2026-05-07)
 
 **Контекст.** Реализует ADR 0005 Variant A — добавляет `"bot"` в `LLMConfigManager` с Gemini-only constraint. Устраняет последнюю «снежинку» в LLM-конфигурации: бот теперь получает симметричную runtime-конфигурацию через `set_llm_config(scope="bot", provider="gemini", model=...)` без рестарта. Tracker: GH issue [#60](https://github.com/AlexEfimov/TG_parser/issues/60). Branch: `feat/session-j-adr0005-bot-llm-2026-05-06`.

--- a/docs/contracts/workspace.schema.json
+++ b/docs/contracts/workspace.schema.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Workspace",
+    "type": "object",
+    "description": "Thematic collection of channels owned by one user (F4-B Core). Workspaces narrow the existing F4-A allowed_channel_ids scope at the surface layer — service-layer signatures are unchanged.",
+    "required": ["id", "owner_id", "name", "created_at", "updated_at"],
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable workspace identifier (UUID).",
+        },
+        "owner_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "FK -> users.id. Cascade-deleted when the user is removed.",
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Human label, unique within (owner_id, name) (gotcha § 6). Whitespace-only names are rejected by the service layer and the CHECK constraint.",
+        },
+        "description": {
+            "type": ["string", "null"],
+            "description": "Free-form description; not used in scoping logic.",
+        },
+        "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Workspace creation timestamp (server-side default NOW()).",
+        },
+        "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last update timestamp; bumped on rename / metadata edits.",
+        },
+    },
+    "additionalProperties": true,
+    "examples": [
+        {
+            "id": "00000000-0000-0000-0000-000000000020",
+            "owner_id": "00000000-0000-0000-0000-000000000002",
+            "name": "AI/ML research",
+            "description": "Anthropic, OpenAI, DeepMind blogs",
+            "created_at": "2026-05-13T12:00:00Z",
+            "updated_at": "2026-05-13T12:00:00Z",
+        }
+    ],
+    "definitions": {
+        "WorkspaceSource": {
+            "type": "object",
+            "description": "M2M membership of a channel in a workspace. Composite PK (workspace_id, source_id); the same source_id can be in N workspaces of one owner (Q5 = A).",
+            "required": ["workspace_id", "source_id", "added_at"],
+            "properties": {
+                "workspace_id": {"type": "string", "format": "uuid"},
+                "source_id": {
+                    "type": "string",
+                    "description": "Matches sources.source_id (VARCHAR — TG channel canonical id).",
+                },
+                "added_at": {"type": "string", "format": "date-time"},
+            },
+            "additionalProperties": false,
+        }
+    },
+}

--- a/docs/notes/FUTURE_FEATURES.md
+++ b/docs/notes/FUTURE_FEATURES.md
@@ -152,7 +152,7 @@ graph TD
 | Очередь | Функция | Effort | Обоснование |
 |---------|---------|--------|-------------|
 | 4.1 | **F9 Phase 2**: Prompt Defense | ~1–1.5 сессии | Prerequisite для multi-user |
-| 4.2 | **F4-B**: Workspaces | ~2 сессии | Группировка каналов — 80% value F4 |
+| 4.2 | **F4-B Core**: Workspaces | ✅ DONE 2026-05-13 (Wave 1 step 2) | Группировка каналов — 80% value F4 |
 | 4.3 | **F8-B**: Redis + Task Queue | ~2 сессии | Prerequisite для scale |
 | 4.4 | **F4-A**: Multi-User | ~1.5–2 сессии | Поверх workspaces |
 | 4.5 | **F9 Phase 3 + F7**: Full Hardening + Billing | ~4–5 сессий | Монетизация |
@@ -529,15 +529,27 @@ Connectors ──────▶│ Connector    │
 
 Более простой вариант — не требует полной системы аутентификации.
 
-> **Status (2026-05-02):** не начат. F4-A landed раньше B (фактический
-> порядок обратный «рекомендуемому пути»), что меняет scope F4-B.
-> **Prep-документ для будущей планирующей сессии:**
-> [`PLANNING_F4B_WORKSPACES_PREP.md`](PLANNING_F4B_WORKSPACES_PREP.md)
-> — содержит revised cost estimate (~2.5–3.5 сессии вместо ~2),
-> 8 open design questions (default workspace, активный workspace
-> в `CurrentUser`, bot UX, F11/F6 интеграция), 7-checklist по
-> [`ADR 0006`](../adr/0006-karpathy-like-living-kb-principles.md),
-> minimal MVP vs full scope разбиение, reading list.
+> **Status (2026-05-13):** ✅ **Core MVP DONE.** Wave 1 step 2 closed per
+> [`START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md`](START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md) —
+> Single PR + 5 atomic commits + ~75 новых тестов. Locked Q1–Q8 (opt-in
+> workspaces, stateless `workspace_id`, MCP+CLI surface, M2M sharing,
+> any-source topic visibility, F11/F6 deferred). MCP + CLI surface
+> готов: `create_workspace` / `list_workspaces` / `rename_workspace` /
+> `delete_workspace` / `add_workspace_source` / `remove_workspace_source`
+> / `list_workspace_sources` / `list_all_workspaces`; все 8 read tools
+> принимают optional `workspace_id`. Service-слойные signatures не
+> изменились (F4-A backward-compat — `tests/test_f4b_backward_compat.py`).
+> Prometheus metrics: `tg_workspace_total` / `tg_workspace_size` /
+> `tg_workspace_query_total` / `tg_workspace_effective_size` /
+> `tg_workspace_resolver_seconds` / `tg_workspace_tool_total`.
+>
+> **Deferred (Wave 1 step 3+ / Wave 2):** O-1 atomic `move_workspace_source`
+> (non-atomic remove+add в MVP); Bot integration (`tg_parser/bot/tools.py` —
+> Q3); F11 watchlist workspace_id (Q7); F6 digest workspace_id (Q8);
+> sharing/collaboration (audience A2/A3). См.
+> [`PARITY_DECISION_TRACKING.md`](PARITY_DECISION_TRACKING.md) § 3 (O-1)
+> и [`PLANNING_F4B_WORKSPACES_PREP.md`](PLANNING_F4B_WORKSPACES_PREP.md)
+> исторический контекст.
 
 ```
 ┌─────────────────────────────────────────────┐

--- a/docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md
+++ b/docs/notes/ROADMAP_KARPATHY_LIKE_LIVING_KB.md
@@ -49,6 +49,38 @@ deployed, 24h watch GREEN. Step marker:
 
 ---
 
+## 2026-05-13 — Wave 1 step 2 (F4-B Core Workspaces) DONE ✅
+
+Audience-driven Wave 1 step 2 закрыт per
+[`START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md`](START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md):
+Single PR + 5 atomic commits, ~1450 LOC + ~75 новых тестов. Pre-flight
+gate-1 GREEN (Prometheus `up{service="bot"}` = `1`, `confirm_flow_mismatch` 72h = `0`,
+`gemini_*` errors 72h = `0` на `tg_parser_bot`).
+
+| # | Commit | Что добавлено |
+|---|---|---|
+| 1/5 | `feat(F4-B): schema + migration + Pydantic + JSON contract` | `workspaces` + `workspace_sources` (alembic `e9f0a1b2c3d5`), Pydantic `Workspace`/`WorkspaceSource`, `docs/contracts/workspace.schema.json`, 10 schema tests. |
+| 2/5 | `feat(F4-B): service + repo + ownership` | `WorkspaceRepo` ABC + `SAWorkspaceRepo`, `WorkspaceNotFound`/`assert_workspace_access`, `WorkspaceService` с `effective_channel_ids` resolver и channel_id→source_id translation, 32 теста (repo + ownership + service). |
+| 3/5 | `feat(F4-B): MCP + CLI surface` | 8 MCP tools (`create/list/rename/delete_workspace`, `add/remove_workspace_source`, `list_workspace_sources`, `list_all_workspaces`) + `tg-parser workspace` Typer-приложение с 8 подкомандами, 20 surface-тестов. |
+| 4/5 | `feat(F4-B): scoping integration in read-tools` | `workspace_id: str \| None = None` на 8 read tools + CLI `--workspace-id` для `search`/`ask`; `_resolve_workspace_scope` helper; Q4 R3 invariant для get-details, 14 scoping тестов. |
+| 5/5 | `test(F4-B): regression guards + observability + docs` | `tests/test_f4b_backward_compat.py` (12 — F4-A bit-for-bit parity), `tests/test_f4b_workspace_isolation.py` (6 — cross-user 404-like), `tests/test_f4b_metrics.py` (8 — Prometheus exporter shape), `tests/test_f4b_golden_path.py` (1 — end-to-end); `tg_workspace_*` метрики в `api/metrics.py`; structlog + metric инструментация в `WorkspaceService`. |
+
+**Hard invariants (locked):** `workspace_id=None` → bit-for-bit F4-A;
+unknown/foreign → 404-like empty (`WorkspaceNotFound`); empty workspace →
+`effective_channel_ids=[]` (не silent "all channels"); service-слойные
+signatures не меняются; `get_topic_details`/`get_document` возвращают full
+bundle (Q4 R3 — workspace narrows list/search, не access control).
+
+**Deferred (Wave 1 step 3+ / Wave 2):** O-1 atomic `move_workspace_source`
+(non-atomic remove+add в MVP — см. `PARITY_DECISION_TRACKING.md` § 3);
+Bot integration (Q3); F11 watchlist workspace_id (Q7); F6 digest
+workspace_id (Q8); sharing / audience A2/A3.
+
+Следующий шаг — Wave 1 step 3 (Surface Parity) per
+[`PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md` § 5.1](PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md).
+
+---
+
 ## 1. Что мы называем «karpathy-like» в этом проекте
 
 Речь не про конкретного автора, а про **устойчивый стиль системы знаний**, согласованный с уже принятыми решениями (TopicCard, TopicBundle, hybrid RAG, incremental topicization, `TopicLink`):

--- a/migrations/versions/ingestion/20260513_add_workspaces.py
+++ b/migrations/versions/ingestion/20260513_add_workspaces.py
@@ -1,0 +1,70 @@
+"""add workspaces and workspace_sources tables (F4-B Core)
+
+Revision ID: e9f0a1b2c3d5
+Revises: d7e8f9a0b1c4
+Create Date: 2026-05-13
+
+F4-B Core: тематические коллекции каналов внутри одного пользователя.
+Schema only (additive) — никакого изменения существующих таблиц.
+
+- `workspaces` — owner_id FK на users.id (ON DELETE CASCADE); UNIQUE
+  (owner_id, name) гарантирует per-owner namespace (gotcha § 6);
+  CheckConstraints на name (non-empty trimmed, max 200 chars).
+- `workspace_sources` — M2M между workspaces и sources с композитным PK
+  (workspace_id, source_id). Один source_id может быть в N workspaces
+  одного user'а (Q5 = A); ON DELETE CASCADE сохраняет referential
+  integrity при удалении workspace или soft-delete sources.
+
+Q1 = B (opt-in, no default) — миграция НЕ создаёт workspace для
+существующих users; их workspace-count остаётся = 0 до явного
+`create_workspace`.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "e9f0a1b2c3d5"
+down_revision: str | None = "d7e8f9a0b1c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workspaces (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            name VARCHAR(200) NOT NULL,
+            description TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_workspaces_owner_name UNIQUE (owner_id, name),
+            CONSTRAINT ck_workspaces_name_nonempty CHECK (length(trim(name)) > 0),
+            CONSTRAINT ck_workspaces_name_length CHECK (length(name) <= 200)
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_workspaces_owner_id ON workspaces(owner_id)")
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workspace_sources (
+            workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            source_id VARCHAR NOT NULL REFERENCES sources(source_id) ON DELETE CASCADE,
+            added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT pk_workspace_sources PRIMARY KEY (workspace_id, source_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_workspace_sources_source_id ON workspace_sources(source_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_workspace_sources_source_id")
+    op.execute("DROP TABLE IF EXISTS workspace_sources")
+    op.execute("DROP INDEX IF EXISTS idx_workspaces_owner_id")
+    op.execute("DROP TABLE IF EXISTS workspaces")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,8 @@ _TRUNCATE_TABLES_BY_BRANCH: dict[str, tuple[str, ...]] = {
     "ingestion": (
         "watch_matches",
         "watch_interests",
+        "workspace_sources",
+        "workspaces",
         "source_attempts",
         "comment_cursors",
         "sources",

--- a/tests/test_f4b_assert_workspace_access.py
+++ b/tests/test_f4b_assert_workspace_access.py
@@ -1,0 +1,132 @@
+"""F4-B Core — :func:`assert_workspace_access` ownership boundary tests.
+
+Q2 edge case 2 + 3: foreign / unknown / admin pass-through semantics live
+in the ownership module so MCP + CLI + service share one source of truth.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import WorkspaceNotFound, assert_workspace_access
+from tg_parser.domain.models import Workspace
+from tg_parser.storage.ports import WorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+class _FakeWorkspaceRepo(WorkspaceRepo):
+    """In-memory stub so unit tests can run without Postgres."""
+
+    def __init__(self, workspaces: dict[str, Workspace]):
+        self._workspaces = workspaces
+
+    async def get(self, workspace_id: str) -> Workspace | None:
+        return self._workspaces.get(workspace_id)
+
+    async def create(self, **_kw: Any) -> Workspace:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list_by_owner(self, owner_id: str) -> list[Workspace]:  # pragma: no cover
+        return [ws for ws in self._workspaces.values() if ws.owner_id == owner_id]
+
+    async def list_all(self, owner_id: str | None = None) -> list[Workspace]:  # pragma: no cover
+        rows = list(self._workspaces.values())
+        if owner_id is None:
+            return rows
+        return [ws for ws in rows if ws.owner_id == owner_id]
+
+    async def rename(
+        self, workspace_id: str, new_name: str
+    ) -> Workspace | None:  # pragma: no cover
+        return None
+
+    async def delete(self, workspace_id: str) -> bool:  # pragma: no cover
+        return False
+
+    async def add_source(
+        self,
+        workspace_id: str,  # noqa: ARG002
+        source_id: str,  # noqa: ARG002
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def remove_source(
+        self,
+        workspace_id: str,  # noqa: ARG002
+        source_id: str,  # noqa: ARG002
+    ) -> bool:  # pragma: no cover
+        return False
+
+    async def list_source_ids(self, workspace_id: str) -> list[str]:  # pragma: no cover
+        return []
+
+    async def list_channel_ids(self, workspace_id: str) -> list[str]:  # pragma: no cover
+        return []
+
+    async def resolve_source_id_for_channel(
+        self,
+        *,
+        owner_id: str | None,  # noqa: ARG002
+        channel_id: str,
+    ) -> str | None:  # pragma: no cover
+        return channel_id
+
+
+def _make_user(*, user_id: str, role: str = "user") -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name="alice",
+        role=role,
+        allowed_channel_ids=[] if role != "admin" else None,
+        max_channels=10,
+    )
+
+
+def _make_workspace(*, owner_id: str) -> Workspace:
+    return Workspace(
+        id=str(uuid.uuid4()),
+        owner_id=owner_id,
+        name="ws",
+    )
+
+
+class TestAssertWorkspaceAccess:
+    async def test_unknown_workspace_raises_not_found(self) -> None:
+        user = _make_user(user_id=str(uuid.uuid4()))
+        repo = _FakeWorkspaceRepo({})
+        with pytest.raises(WorkspaceNotFound):
+            await assert_workspace_access(user, str(uuid.uuid4()), repo=repo)
+
+    async def test_foreign_workspace_raises_not_found_not_permission(self) -> None:
+        owner_id = str(uuid.uuid4())
+        other_user = _make_user(user_id=str(uuid.uuid4()))
+        ws = _make_workspace(owner_id=owner_id)
+        repo = _FakeWorkspaceRepo({ws.id: ws})
+        with pytest.raises(WorkspaceNotFound):
+            await assert_workspace_access(other_user, ws.id, repo=repo)
+
+    async def test_owner_passes(self) -> None:
+        owner_id = str(uuid.uuid4())
+        user = _make_user(user_id=owner_id)
+        ws = _make_workspace(owner_id=owner_id)
+        repo = _FakeWorkspaceRepo({ws.id: ws})
+        result = await assert_workspace_access(user, ws.id, repo=repo)
+        assert result.id == ws.id
+
+    async def test_admin_passes_for_any_workspace(self) -> None:
+        owner_id = str(uuid.uuid4())
+        admin_id = str(uuid.uuid4())
+        admin = _make_user(user_id=admin_id, role="admin")
+        ws = _make_workspace(owner_id=owner_id)
+        repo = _FakeWorkspaceRepo({ws.id: ws})
+        result = await assert_workspace_access(admin, ws.id, repo=repo)
+        assert result.id == ws.id

--- a/tests/test_f4b_backward_compat.py
+++ b/tests/test_f4b_backward_compat.py
@@ -182,3 +182,174 @@ class TestGetCrossChannelStatsF4ABackwardCompat:
         ):
             await get_cross_channel_stats()
         assert captured["allowed_channel_ids"] == ["ch_a"]
+
+
+@pg_only
+class TestListTopicsF4ABackwardCompat:
+    """Hidden gotcha § 1 — ``list_topics`` without ``workspace_id`` must route
+    to the F4-A code path (``list_by_channels(allowed)`` for non-admin or
+    ``list_all`` for admin) — no repo I/O via the workspace resolver."""
+
+    @pytest.mark.parametrize("allowed", [None, ["ch_a", "ch_b"]])
+    async def test_omitted_workspace_id_routes_to_f4a_path(self, allowed):
+        from contextlib import asynccontextmanager
+
+        from tg_parser.mcp_server import list_topics
+
+        user = _user(allowed)
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        proc_repo = AsyncMock()
+        topic_card_repo.list_all.return_value = []
+        topic_card_repo.list_by_channels.return_value = []
+        topic_bundle_repo.list_all.return_value = []
+
+        captured: dict = {}
+
+        async def fake_list_by_channels(channel_ids):
+            captured["channel_ids"] = channel_ids
+            return []
+
+        topic_card_repo.list_by_channels.side_effect = fake_list_by_channels
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (proc_repo, topic_card_repo, topic_bundle_repo, AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            await list_topics()
+
+        if allowed is None:
+            # Admin: list_all path
+            topic_card_repo.list_all.assert_called_once()
+            topic_card_repo.list_by_channels.assert_not_called()
+        else:
+            # Non-admin: list_by_channels(user.allowed_channel_ids)
+            topic_card_repo.list_all.assert_not_called()
+            assert captured["channel_ids"] == allowed
+
+
+@pg_only
+class TestGetTopicDetailsF4ABackwardCompat:
+    """Q4 R3 + Hidden gotcha § 1 — without ``workspace_id`` the bundle is
+    returned in full and the F4-A any-source access check applies."""
+
+    async def test_omitted_workspace_id_returns_bundle(self):
+        from contextlib import asynccontextmanager
+        from datetime import UTC, datetime
+
+        from tg_parser.domain.models import (
+            Anchor,
+            BundleItem,
+            BundleItemRole,
+            MessageType,
+            TopicBundle,
+            TopicCard,
+            TopicType,
+        )
+        from tg_parser.mcp_server import get_topic_details
+
+        user = _user(["ch_x", "ch_y"])
+        now = datetime.now(UTC)
+        topic_id = "topic:tg:ch_x:post:1"
+        # SINGLETON to avoid the >=2 anchor requirement that CLUSTER imposes.
+        card = TopicCard(
+            id=topic_id,
+            title="bc",
+            summary="s",
+            scope_in=["focus"],
+            scope_out=["unrelated"],
+            type=TopicType.SINGLETON,
+            anchors=[
+                Anchor(
+                    channel_id="ch_x",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_x:post:1",
+                    score=1.0,
+                )
+            ],
+            sources=["ch_x", "ch_y"],
+            updated_at=now,
+        )
+        bundle = TopicBundle(
+            topic_id=topic_id,
+            items=[
+                BundleItem(
+                    channel_id="ch_x",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    source_ref="tg:ch_x:post:1",
+                    role=BundleItemRole.ANCHOR,
+                )
+            ],
+            updated_at=now,
+        )
+
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        topic_card_repo.get_by_id.return_value = card
+        topic_bundle_repo.get_by_topic_id.return_value = bundle
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (AsyncMock(), topic_card_repo, topic_bundle_repo, AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            result = await get_topic_details(topic_id=topic_id)
+
+        assert not isinstance(result, str)
+        assert result.id == topic_id
+        assert result.items is not None
+        assert len(result.items) == 1
+
+
+@pg_only
+class TestGetDocumentF4ABackwardCompat:
+    """F4-A baseline guard: ``get_document`` without ``workspace_id`` resolves
+    a document via the F4-A path."""
+
+    async def test_omitted_workspace_id_returns_document(self):
+        from contextlib import asynccontextmanager
+        from datetime import UTC, datetime
+
+        from tg_parser.domain.models import ProcessedDocument
+        from tg_parser.mcp_server import get_document
+
+        user = _user(["ch_doc"])
+        doc = ProcessedDocument(
+            id="d-bc",
+            source_ref="tg:ch_doc:post:1",
+            source_message_id="1",
+            channel_id="ch_doc",
+            processed_at=datetime.now(UTC),
+            text_clean="hi",
+            summary="s",
+            topics=[],
+        )
+        proc_repo = AsyncMock()
+        proc_repo.get_by_source_ref.return_value = doc
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (proc_repo, AsyncMock(), AsyncMock(), AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            result = await get_document(source_ref="tg:ch_doc:post:1")
+
+        assert not isinstance(result, str)
+        assert result.source_ref == "tg:ch_doc:post:1"
+        assert result.channel_id == "ch_doc"

--- a/tests/test_f4b_backward_compat.py
+++ b/tests/test_f4b_backward_compat.py
@@ -1,0 +1,184 @@
+"""F4-B Core — Phase 5 backward-compat regression guards.
+
+Hidden gotcha § 1 of ``docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md``:
+
+> Any scoped tool called WITHOUT ``workspace_id`` (or with ``workspace_id=None``)
+> MUST return bit-for-bit identical output to the F4-A baseline. Hard requirement.
+
+This file pins that promise by exercising every scoped MCP read tool twice —
+once with the workspace_id parameter omitted and once with it explicitly set
+to ``None`` — and asserting that the call passes ``user.allowed_channel_ids``
+through to the underlying service unchanged. Any drift here means somebody
+sneaked a behaviour change behind the F4-A facade and the gate must trip.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+def _user(allowed: list[str] | None) -> CurrentUser:
+    return CurrentUser(
+        id="00000000-0000-0000-0000-000000000001",
+        name="alice",
+        role="user" if allowed is not None else "admin",
+        allowed_channel_ids=allowed,
+        max_channels=10,
+    )
+
+
+@pg_only
+@pytest.mark.parametrize(
+    "allowed",
+    [None, [], ["ch_a"], ["ch_a", "ch_b", "ch_c"]],
+)
+class TestSearchKnowledgeBaseF4ABackwardCompat:
+    async def test_omitted_workspace_id_preserves_allowed_channels(self, allowed):
+        from tg_parser.mcp_server import search_knowledge_base
+
+        user = _user(allowed)
+        captured: dict = {}
+
+        async def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.search",
+                AsyncMock(side_effect=fake_search),
+            ),
+        ):
+            await search_knowledge_base(query="x")
+        assert captured["allowed_channel_ids"] == allowed
+
+    async def test_explicit_none_matches_omitted(self, allowed):
+        from tg_parser.mcp_server import search_knowledge_base
+
+        user = _user(allowed)
+        captured: dict = {}
+
+        async def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.search",
+                AsyncMock(side_effect=fake_search),
+            ),
+        ):
+            await search_knowledge_base(query="x", workspace_id=None)
+        assert captured["allowed_channel_ids"] == allowed
+
+
+@pg_only
+class TestListChannelsF4ABackwardCompat:
+    @pytest.mark.parametrize("allowed", [None, [], ["ch_a", "ch_b"]])
+    async def test_omitted_workspace_id_preserves_allowed_channels(self, allowed):
+        from tg_parser.mcp_server import list_channels
+
+        user = _user(allowed)
+        captured: dict = {}
+
+        async def fake_stats(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.channel_service.get_all_channel_stats",
+                AsyncMock(side_effect=fake_stats),
+            ),
+        ):
+            await list_channels()
+        assert captured["allowed_channel_ids"] == allowed
+
+
+@pg_only
+class TestAskQuestionF4ABackwardCompat:
+    @pytest.mark.parametrize("allowed", [None, [], ["ch_a"]])
+    async def test_omitted_workspace_id_preserves_allowed_channels(self, allowed):
+        from tg_parser.mcp_server import AnswerResultItem, ask_question
+
+        user = _user(allowed)
+        captured: dict = {}
+
+        async def fake_answer(**kwargs):
+            captured.update(kwargs)
+            return AnswerResultItem(answer="ok", sources=[], model="stub")
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.answer",
+                AsyncMock(side_effect=fake_answer),
+            ),
+        ):
+            await ask_question(question="x")
+        assert captured["allowed_channel_ids"] == allowed
+
+
+@pg_only
+class TestGetRelatedTopicsF4ABackwardCompat:
+    async def test_omitted_workspace_id_preserves_allowed_channels(self):
+        from tg_parser.mcp_server import get_related_topics
+
+        user = _user(["ch_a", "ch_b"])
+        captured: dict = {}
+
+        async def fake_linker(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                AsyncMock(side_effect=fake_linker),
+            ),
+        ):
+            await get_related_topics(topic_id="topic:tg:irrelevant")
+        assert captured["allowed_channel_ids"] == ["ch_a", "ch_b"]
+
+
+@pg_only
+class TestGetCrossChannelStatsF4ABackwardCompat:
+    async def test_omitted_workspace_id_preserves_allowed_channels(self):
+        from tg_parser.mcp_server import get_cross_channel_stats
+
+        user = _user(["ch_a"])
+        captured: dict = {}
+
+        async def fake_analytics(**kwargs):
+            captured.update(kwargs)
+            return {
+                "total_documents": 0,
+                "total_topics": 0,
+                "channels": [],
+                "keyword_overlaps": [],
+                "overlap_count": 0,
+            }
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.analytics_service.get_cross_channel_analytics",
+                AsyncMock(side_effect=fake_analytics),
+            ),
+        ):
+            await get_cross_channel_stats()
+        assert captured["allowed_channel_ids"] == ["ch_a"]

--- a/tests/test_f4b_cli_workspace.py
+++ b/tests/test_f4b_cli_workspace.py
@@ -1,0 +1,239 @@
+"""F4-B Core — CLI surface tests (Phase 3).
+
+Pure-mock tests using Typer's ``CliRunner`` so they run without Postgres.
+Validates command wiring + happy / error paths through the service.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.cli.workspace_cmd import app as workspace_app
+from tg_parser.domain.models import Workspace
+from tg_parser.storage.ports import WorkspaceRepo
+
+runner = CliRunner()
+
+
+class _FakeWorkspaceRepo(WorkspaceRepo):
+    """In-memory stub that supports the methods the CLI exercises."""
+
+    def __init__(self) -> None:
+        self.workspaces: dict[str, Workspace] = {}
+        self.channels: dict[str, list[str]] = {}
+
+    async def get(self, workspace_id: str) -> Workspace | None:
+        return self.workspaces.get(workspace_id)
+
+    async def create(
+        self,
+        *,
+        owner_id: str,
+        name: str,
+        description: str | None = None,
+    ) -> Workspace:
+        ws = Workspace(
+            id=str(uuid.uuid4()),
+            owner_id=owner_id,
+            name=name,
+            description=description,
+        )
+        self.workspaces[ws.id] = ws
+        self.channels.setdefault(ws.id, [])
+        return ws
+
+    async def list_by_owner(self, owner_id: str) -> list[Workspace]:
+        return [ws for ws in self.workspaces.values() if ws.owner_id == owner_id]
+
+    async def list_all(self, owner_id: str | None = None) -> list[Workspace]:
+        rows = list(self.workspaces.values())
+        if owner_id is None:
+            return rows
+        return [ws for ws in rows if ws.owner_id == owner_id]
+
+    async def rename(self, workspace_id: str, new_name: str) -> Workspace | None:
+        ws = self.workspaces.get(workspace_id)
+        if ws is None:
+            return None
+        renamed = Workspace(
+            id=ws.id,
+            owner_id=ws.owner_id,
+            name=new_name,
+            description=ws.description,
+        )
+        self.workspaces[workspace_id] = renamed
+        return renamed
+
+    async def delete(self, workspace_id: str) -> bool:
+        return self.workspaces.pop(workspace_id, None) is not None
+
+    async def add_source(self, workspace_id: str, source_id: str) -> bool:
+        members = self.channels.setdefault(workspace_id, [])
+        if source_id in members:
+            return False
+        members.append(source_id)
+        return True
+
+    async def remove_source(self, workspace_id: str, source_id: str) -> bool:
+        members = self.channels.get(workspace_id, [])
+        if source_id not in members:
+            return False
+        members.remove(source_id)
+        return True
+
+    async def list_source_ids(self, workspace_id: str) -> list[str]:
+        return list(self.channels.get(workspace_id, []))
+
+    async def list_channel_ids(self, workspace_id: str) -> list[str]:
+        return list(self.channels.get(workspace_id, []))
+
+    async def resolve_source_id_for_channel(
+        self,
+        *,
+        owner_id: str | None,  # noqa: ARG002
+        channel_id: str,
+    ) -> str | None:
+        return channel_id
+
+
+def _admin(user_id: str = "admin-1") -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name="admin",
+        role="admin",
+        allowed_channel_ids=None,
+        max_channels=100,
+    )
+
+
+def _patch_cli(repo: _FakeWorkspaceRepo, *, user: CurrentUser) -> list[Any]:
+    @asynccontextmanager
+    async def _fake_repo_ctx():
+        yield repo, None
+
+    async def _fake_admin() -> CurrentUser:
+        return user
+
+    async def _fake_close():
+        return None
+
+    return [
+        patch("tg_parser.services.db_context.workspace_repo", lambda: _fake_repo_ctx()),
+        patch("tg_parser.auth.resolvers.get_default_admin", _fake_admin),
+        patch(
+            "tg_parser.storage.sqlalchemy.database.Database.close_instance",
+            classmethod(lambda cls: _fake_close()),
+        ),
+    ]
+
+
+class TestWorkspaceCLI:
+    def test_create_workspace_command(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        with (
+            _patch_cli(repo, user=_admin())[0],
+            _patch_cli(repo, user=_admin())[1],
+            _patch_cli(repo, user=_admin())[2],
+        ):
+            result = runner.invoke(workspace_app, ["create", "--name", "AI/ML"])
+        assert result.exit_code == 0, result.output
+        assert "✅" in result.output or "created" in result.output.lower()
+        assert len(repo.workspaces) == 1
+
+    def test_list_empty(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        with (
+            _patch_cli(repo, user=_admin())[0],
+            _patch_cli(repo, user=_admin())[1],
+            _patch_cli(repo, user=_admin())[2],
+        ):
+            result = runner.invoke(workspace_app, ["list"])
+        assert result.exit_code == 0
+        assert "not found" in result.output.lower() or "⚠️" in result.output
+
+    def test_create_then_list(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            r1 = runner.invoke(workspace_app, ["create", "--name", "Workspace A"])
+            r2 = runner.invoke(workspace_app, ["list"])
+        assert r1.exit_code == 0
+        assert r2.exit_code == 0
+        assert "Workspace A" in r2.output
+
+    def test_create_rejects_blank(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            result = runner.invoke(workspace_app, ["create", "--name", "   "])
+        assert result.exit_code != 0
+
+    def test_add_source_then_list_sources(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            create_r = runner.invoke(workspace_app, ["create", "--name", "mem"])
+        assert create_r.exit_code == 0
+        ws_id = next(iter(repo.workspaces.keys()))
+
+        patches2 = _patch_cli(repo, user=_admin())
+        with patches2[0], patches2[1], patches2[2]:
+            add_r = runner.invoke(workspace_app, ["add-source", ws_id, "--channel", "ch_x"])
+            list_r = runner.invoke(workspace_app, ["list-sources", ws_id])
+        assert add_r.exit_code == 0
+        assert list_r.exit_code == 0
+        assert "ch_x" in list_r.output
+
+    def test_remove_source_no_op(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            runner.invoke(workspace_app, ["create", "--name", "rm"])
+        ws_id = next(iter(repo.workspaces.keys()))
+
+        patches2 = _patch_cli(repo, user=_admin())
+        with patches2[0], patches2[1], patches2[2]:
+            result = runner.invoke(workspace_app, ["remove-source", ws_id, "--channel", "ghost"])
+        assert result.exit_code == 0
+        assert "was not in" in result.output.lower() or "ℹ️" in result.output
+
+    def test_delete_workspace(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            runner.invoke(workspace_app, ["create", "--name", "trash"])
+        ws_id = next(iter(repo.workspaces.keys()))
+
+        patches2 = _patch_cli(repo, user=_admin())
+        with patches2[0], patches2[1], patches2[2]:
+            del_r = runner.invoke(workspace_app, ["delete", ws_id])
+        assert del_r.exit_code == 0
+        assert ws_id not in repo.workspaces
+
+    def test_rename_workspace(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            runner.invoke(workspace_app, ["create", "--name", "old"])
+        ws_id = next(iter(repo.workspaces.keys()))
+
+        patches2 = _patch_cli(repo, user=_admin())
+        with patches2[0], patches2[1], patches2[2]:
+            r = runner.invoke(workspace_app, ["rename", ws_id, "new"])
+        assert r.exit_code == 0
+        assert repo.workspaces[ws_id].name == "new"
+
+    def test_list_all_admin(self) -> None:
+        repo = _FakeWorkspaceRepo()
+        patches = _patch_cli(repo, user=_admin())
+        with patches[0], patches[1], patches[2]:
+            runner.invoke(workspace_app, ["create", "--name", "x"])
+            r = runner.invoke(workspace_app, ["list-all"])
+        assert r.exit_code == 0
+        assert "x" in r.output

--- a/tests/test_f4b_deferred_surface_guard.py
+++ b/tests/test_f4b_deferred_surface_guard.py
@@ -1,0 +1,136 @@
+"""F4-B Core — Phase 5 deferred-feature surface guards.
+
+The start prompt locks Q3 (Bot tools), Q7 (F11 watchlist), Q8 (F6 digest) as
+**deferred**: no ``workspace_id`` parameter on those subscription / tool
+signatures in this sprint. These tests fail loudly if a future commit
+accidentally promotes one of them — at which point the contract should be
+re-evaluated through a planning round-trip, not silently absorbed.
+
+Cheap, signature-only inspections (no DB, no fixtures, no PG gate) so they
+run in the default ``pytest`` mode too.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def _parameter_names(fn) -> list[str]:
+    return list(inspect.signature(fn).parameters.keys())
+
+
+class TestQ3BotToolsNoWorkspaceParam:
+    """Q3 = skip-Bot-MVP — bot tool exec functions must not accept
+    ``workspace_id`` in this sprint (would imply Bot UX work that's
+    deferred until UX-signal accumulates)."""
+
+    def test_bot_exec_functions_do_not_take_workspace_id(self):
+        from tg_parser.bot import tools as bot_tools
+
+        offenders: list[str] = []
+        for name in dir(bot_tools):
+            if not name.startswith("_exec_"):
+                continue
+            fn = getattr(bot_tools, name)
+            if not callable(fn):
+                continue
+            params = _parameter_names(fn)
+            if "workspace_id" in params:
+                offenders.append(f"{name}({', '.join(params)})")
+        assert offenders == [], (
+            "Q3 was locked = skip-Bot-MVP but the following bot exec fns "
+            f"now accept workspace_id: {offenders}. Re-check planning before "
+            "promoting."
+        )
+
+
+class TestQ7WatchlistSignatureUnchanged:
+    """Q7 = C — ``subscribe_watchlist`` MCP tool and ``WatchInterest`` schema
+    must NOT have ``workspace_id`` in F4-B Core."""
+
+    def test_subscribe_watchlist_mcp_tool_has_no_workspace_id(self):
+        from tg_parser.mcp_server import subscribe_watchlist
+
+        params = _parameter_names(subscribe_watchlist)
+        assert "workspace_id" not in params, (
+            "Q7 locked = defer F11 + workspace_id integration; "
+            f"subscribe_watchlist now has params {params}"
+        )
+
+    def test_watch_interest_model_has_no_workspace_id(self):
+        from tg_parser.domain.models import WatchInterest
+
+        fields = set(WatchInterest.model_fields.keys())
+        assert "workspace_id" not in fields, (
+            "Q7 locked = WatchInterest schema must stay workspace-free in F4-B Core; "
+            f"current fields = {sorted(fields)}"
+        )
+
+
+class TestQ8DigestSignatureUnchanged:
+    """Q8 = C — ``subscribe_digest`` MCP tool and ``DigestSubscription``
+    schema keep F4-A shape."""
+
+    def test_subscribe_digest_mcp_tool_has_no_workspace_id(self):
+        from tg_parser.mcp_server import subscribe_digest
+
+        params = _parameter_names(subscribe_digest)
+        assert "workspace_id" not in params, (
+            "Q8 locked = defer F6 + workspace_id integration; "
+            f"subscribe_digest now has params {params}"
+        )
+
+    def test_digest_subscription_model_has_no_workspace_id(self):
+        from tg_parser.domain.models import DigestSubscription
+
+        fields = set(DigestSubscription.model_fields.keys())
+        assert "workspace_id" not in fields, (
+            "Q8 locked = DigestSubscription schema must stay workspace-free in "
+            f"F4-B Core; current fields = {sorted(fields)}"
+        )
+
+
+class TestScopedReadToolsAcceptWorkspaceId:
+    """Positive mirror — Phase 4 promised the 8 scoped read-tools all gain
+    an optional ``workspace_id`` parameter. Pin that surface so a future
+    refactor that drops the parameter from any of them is caught here."""
+
+    SCOPED_TOOLS = (
+        "list_channels",
+        "list_topics",
+        "get_topic_details",
+        "search_knowledge_base",
+        "ask_question",
+        "get_document",
+        "get_cross_channel_stats",
+        "get_related_topics",
+    )
+
+    def test_all_eight_scoped_tools_accept_workspace_id(self):
+        from tg_parser import mcp_server
+
+        missing: list[str] = []
+        for name in self.SCOPED_TOOLS:
+            fn = getattr(mcp_server, name)
+            params = _parameter_names(fn)
+            if "workspace_id" not in params:
+                missing.append(name)
+        assert missing == [], (
+            f"Phase 4 promised workspace_id on every scoped read-tool; missing on: {missing}"
+        )
+
+    def test_workspace_id_parameter_defaults_to_none(self):
+        """The default must be ``None`` so that legacy callers (without the
+        parameter) get bit-for-bit F4-A behaviour (hidden gotcha § 1)."""
+        from tg_parser import mcp_server
+
+        wrong_default: list[str] = []
+        for name in self.SCOPED_TOOLS:
+            fn = getattr(mcp_server, name)
+            sig = inspect.signature(fn)
+            default = sig.parameters["workspace_id"].default
+            if default is not None:
+                wrong_default.append(f"{name}={default!r}")
+        assert wrong_default == [], (
+            f"workspace_id default must be None (F4-A bit-for-bit). Offenders: {wrong_default}"
+        )

--- a/tests/test_f4b_golden_path.py
+++ b/tests/test_f4b_golden_path.py
@@ -1,0 +1,107 @@
+"""F4-B Core — Phase 5 end-to-end golden path test.
+
+Mirror the scenario from the start prompt § "Golden-path test":
+
+1. Create one user.
+2. Create two workspaces ("AI", "Product").
+3. Add three channels into "AI" (one of them also into "Product").
+4. ``list_workspace_sources(workspace_id=AI)`` returns the AI channels.
+5. ``list_workspace_sources(workspace_id=Product)`` returns just the shared channel.
+6. ``effective_channel_ids(user, AI)`` ⊆ ``user.allowed_channel_ids``.
+7. ``effective_channel_ids(user, Product)`` ⊆ ``user.allowed_channel_ids``.
+8. ``effective_channel_ids(user, None)`` is bit-for-bit ``user.allowed_channel_ids``.
+9. ``delete_workspace(AI)`` removes the AI workspace; the shared channel
+   remains visible through ``Product``; ``sources`` rows are untouched.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.services.workspace_service import WorkspaceService
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+@pg_only
+async def test_golden_path_workspace_lifecycle(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        user_repo = SAUserRepo(session)
+        source_repo = SAIngestionStateRepo(session)
+        ws_repo = SAWorkspaceRepo(session)
+        svc = WorkspaceService(ws_repo)
+
+        owner = await user_repo.create_user("golden_alice")
+        user = CurrentUser(
+            id=owner.id,
+            name="golden_alice",
+            role="user",
+            allowed_channel_ids=["ch_g1", "ch_g2", "ch_g3"],
+            max_channels=10,
+        )
+
+        for src_id, channel_id in [
+            ("tg:src_g1", "ch_g1"),
+            ("tg:src_g2", "ch_g2"),
+            ("tg:src_g3", "ch_g3"),
+        ]:
+            await source_repo.upsert_source(
+                Source(
+                    source_id=src_id,
+                    channel_id=channel_id,
+                    status="active",
+                    include_comments=False,
+                    fail_count=0,
+                    comments_unavailable=False,
+                    created_at=datetime.now(UTC),
+                    updated_at=datetime.now(UTC),
+                    owner_id=owner.id,
+                )
+            )
+
+        ai = await svc.create_workspace(user, name="AI", description="AI thinking")
+        product = await svc.create_workspace(user, name="Product", description="Product ops")
+
+        await svc.add_source(user, ai.id, "ch_g1")
+        await svc.add_source(user, ai.id, "ch_g2")
+        await svc.add_source(user, ai.id, "ch_g3")
+        await svc.add_source(user, product.id, "ch_g3")
+
+        ai_channels = sorted(await svc.list_workspace_sources(user, ai.id))
+        product_channels = sorted(await svc.list_workspace_sources(user, product.id))
+        assert ai_channels == ["ch_g1", "ch_g2", "ch_g3"]
+        assert product_channels == ["ch_g3"]
+
+        ai_effective = sorted(await svc.effective_channel_ids(user, ai.id))
+        product_effective = sorted(await svc.effective_channel_ids(user, product.id))
+        null_effective = await svc.effective_channel_ids(user, None)
+        assert ai_effective == ["ch_g1", "ch_g2", "ch_g3"]
+        assert product_effective == ["ch_g3"]
+        assert null_effective == ["ch_g1", "ch_g2", "ch_g3"]
+
+        deleted = await svc.delete_workspace(user, ai.id)
+        assert deleted is True
+
+        remaining_workspaces = await svc.list_workspaces(user)
+        assert [ws.name for ws in remaining_workspaces] == ["Product"]
+
+        product_after_delete = sorted(await svc.list_workspace_sources(user, product.id))
+        assert product_after_delete == ["ch_g3"]
+
+        sources_check = await source_repo.get_source("tg:src_g1")
+        assert sources_check is not None
+        assert sources_check.channel_id == "ch_g1"
+    finally:
+        await session.close()

--- a/tests/test_f4b_mcp_tools.py
+++ b/tests/test_f4b_mcp_tools.py
@@ -1,0 +1,246 @@
+"""F4-B Core — MCP tool surface tests (Phase 3)."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+def _make_user(
+    user_id: str,
+    *,
+    name: str = "alice",
+    role: str = "user",
+    allowed: list[str] | None = None,
+    max_channels: int = 10,
+) -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else (allowed or []),
+        max_channels=max_channels,
+    )
+
+
+@pytest.fixture
+async def _mcp_db(test_db):
+    """Seed minimal users + sources so the MCP tools can resolve ownership."""
+    return test_db
+
+
+@pytest.fixture
+async def user_repo_for_mcp(_mcp_db):
+    session = _mcp_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _seed_source(test_db, source_id: str, channel_id: str, owner_id: str) -> None:
+    session = test_db.ingestion_state_session()
+    try:
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=source_id,
+                channel_id=channel_id,
+                status="active",
+                include_comments=False,
+                fail_count=0,
+                comments_unavailable=False,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                owner_id=owner_id,
+            )
+        )
+    finally:
+        await session.close()
+
+
+@pg_only
+class TestMCPWorkspaceCRUDTools:
+    async def test_create_workspace_returns_workspace(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace
+
+        owner = await user_repo_for_mcp.create_user("alice_mcp_create")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await create_workspace(name="AI/ML", description="Anthropic")
+        assert result.success is True
+        assert result.workspace is not None
+        assert result.workspace.name == "AI/ML"
+        assert result.workspace.owner_id == owner.id
+
+    async def test_create_workspace_rejects_blank(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace
+
+        owner = await user_repo_for_mcp.create_user("alice_mcp_blank")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await create_workspace(name="   ")
+        assert result.success is False
+
+    async def test_create_workspace_rejects_duplicate(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace
+
+        owner = await user_repo_for_mcp.create_user("alice_mcp_dup")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            r1 = await create_workspace(name="dup")
+            r2 = await create_workspace(name="dup")
+        assert r1.success is True
+        assert r2.success is False
+        assert "fail" in r2.message.lower() or "duplicate" in r2.message.lower()
+
+    async def test_list_workspaces_filters_to_caller(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace, list_workspaces
+
+        alice = await user_repo_for_mcp.create_user("alice_mcp_list")
+        bob = await user_repo_for_mcp.create_user("bob_mcp_list")
+        alice_user = _make_user(alice.id, allowed=[])
+        bob_user = _make_user(bob.id, allowed=[])
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            await create_workspace(name="bob_ws")
+            result = await list_workspaces()
+        assert {ws.name for ws in result.workspaces} == {"bob_ws"}
+
+    async def test_rename_workspace_404_on_unknown(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import rename_workspace
+
+        owner = await user_repo_for_mcp.create_user("alice_mcp_rn")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await rename_workspace(
+                workspace_id="00000000-0000-0000-0000-000000000999",
+                new_name="x",
+            )
+        assert result.success is False
+        assert "not found" in result.message.lower()
+
+    async def test_delete_workspace_owner_only_for_non_admin(self, _mcp_db, user_repo_for_mcp):
+        """Foreign workspace must not be deletable by another user."""
+        from tg_parser.mcp_server import create_workspace, delete_workspace
+
+        alice = await user_repo_for_mcp.create_user("alice_del")
+        bob = await user_repo_for_mcp.create_user("bob_del")
+        alice_user = _make_user(alice.id, allowed=[])
+        bob_user = _make_user(bob.id, allowed=[])
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            created = await create_workspace(name="alice_del_ws")
+        assert created.success is True
+        target_id = created.workspace.id
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await delete_workspace(workspace_id=target_id)
+        assert result.success is False
+        assert "not found" in result.message.lower()
+
+
+@pg_only
+class TestMCPWorkspaceMembershipTools:
+    async def test_add_and_remove_source_idempotent(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import (
+            add_workspace_source,
+            create_workspace,
+            list_workspace_sources,
+            remove_workspace_source,
+        )
+
+        owner = await user_repo_for_mcp.create_user("alice_mem")
+        await _seed_source(_mcp_db, "tg:src_mcp", "ch_mcp", owner.id)
+        user = _make_user(owner.id, allowed=["ch_mcp"])
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            ws = (await create_workspace(name="mem_ws")).workspace
+            add_r1 = await add_workspace_source(workspace_id=ws.id, channel_id="ch_mcp")
+            add_r2 = await add_workspace_source(workspace_id=ws.id, channel_id="ch_mcp")
+            listed = await list_workspace_sources(workspace_id=ws.id)
+            rm_r1 = await remove_workspace_source(workspace_id=ws.id, channel_id="ch_mcp")
+            rm_r2 = await remove_workspace_source(workspace_id=ws.id, channel_id="ch_mcp")
+
+        assert add_r1.success is True and add_r1.changed is True
+        assert add_r2.success is True and add_r2.changed is False
+        assert listed.channel_ids == ["ch_mcp"]
+        assert rm_r1.success is True and rm_r1.changed is True
+        assert rm_r2.success is True and rm_r2.changed is False
+
+    async def test_add_source_denies_non_accessible_channel(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import add_workspace_source, create_workspace
+
+        owner = await user_repo_for_mcp.create_user("alice_deny")
+        user = _make_user(owner.id, allowed=["only_this"])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            ws = (await create_workspace(name="deny_ws")).workspace
+            result = await add_workspace_source(workspace_id=ws.id, channel_id="forbidden")
+        assert result.success is False
+        assert "no access" in result.message.lower() or "not found" in result.message.lower()
+
+    async def test_list_workspace_sources_unknown_workspace_returns_empty(
+        self, _mcp_db, user_repo_for_mcp
+    ):
+        from tg_parser.mcp_server import list_workspace_sources
+
+        owner = await user_repo_for_mcp.create_user("alice_emp")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await list_workspace_sources(
+                workspace_id="00000000-0000-0000-0000-000000000999"
+            )
+        assert result.count == 0
+        assert result.channel_ids == []
+
+
+@pg_only
+class TestMCPListAllWorkspaces:
+    async def test_admin_sees_every_workspace(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace, list_all_workspaces
+
+        alice = await user_repo_for_mcp.create_user("alice_la")
+        bob = await user_repo_for_mcp.create_user("bob_la")
+        alice_user = _make_user(alice.id, allowed=[])
+        bob_user = _make_user(bob.id, allowed=[])
+        admin = _make_user(alice.id, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_la_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            await create_workspace(name="bob_la_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=admin)):
+            result = await list_all_workspaces()
+        names = {ws.name for ws in result.workspaces}
+        assert "alice_la_ws" in names
+        assert "bob_la_ws" in names
+
+    async def test_non_admin_gets_empty_list_not_403(self, _mcp_db, user_repo_for_mcp):
+        from tg_parser.mcp_server import create_workspace, list_all_workspaces
+
+        alice = await user_repo_for_mcp.create_user("alice_403")
+        bob = await user_repo_for_mcp.create_user("bob_403")
+        alice_user = _make_user(alice.id, allowed=[])
+        bob_user = _make_user(bob.id, allowed=[])
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_403_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await list_all_workspaces()
+        assert result.count == 0
+        assert result.workspaces == []

--- a/tests/test_f4b_mcp_tools.py
+++ b/tests/test_f4b_mcp_tools.py
@@ -96,16 +96,49 @@ class TestMCPWorkspaceCRUDTools:
         assert result.success is False
 
     async def test_create_workspace_rejects_duplicate(self, _mcp_db, user_repo_for_mcp):
-        from tg_parser.mcp_server import create_workspace
+        """Hidden gotcha § 6 — duplicate ``(owner_id, name)`` is rejected and
+        leaves the DB with exactly one row (no ghost or half-state)."""
+        from tg_parser.mcp_server import create_workspace, list_workspaces
 
         owner = await user_repo_for_mcp.create_user("alice_mcp_dup")
         user = _make_user(owner.id, allowed=[])
         with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
             r1 = await create_workspace(name="dup")
             r2 = await create_workspace(name="dup")
+            after = await list_workspaces()
         assert r1.success is True
         assert r2.success is False
         assert "fail" in r2.message.lower() or "duplicate" in r2.message.lower()
+        # The persistence side-effect — exactly one workspace named "dup".
+        dup_workspaces = [ws for ws in after.workspaces if ws.name == "dup"]
+        assert len(dup_workspaces) == 1
+        assert dup_workspaces[0].id == r1.workspace.id
+
+    async def test_list_all_workspaces_filters_by_owner_id(self, _mcp_db, user_repo_for_mcp):
+        """Q2 EC3 / admin tool — ``list_all_workspaces(owner_id=X)`` narrows
+        to that owner's workspaces and leaves other tenants' rows out."""
+        from tg_parser.mcp_server import create_workspace, list_all_workspaces
+
+        alice = await user_repo_for_mcp.create_user("alice_lala_owner")
+        bob = await user_repo_for_mcp.create_user("bob_lala_owner")
+        alice_user = _make_user(alice.id, allowed=[])
+        bob_user = _make_user(bob.id, allowed=[])
+        admin = _make_user(alice.id, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_lala_a1")
+            await create_workspace(name="alice_lala_a2")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            await create_workspace(name="bob_lala_b1")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=admin)):
+            alice_view = await list_all_workspaces(owner_id=alice.id)
+            bob_view = await list_all_workspaces(owner_id=bob.id)
+
+        alice_names = {ws.name for ws in alice_view.workspaces}
+        bob_names = {ws.name for ws in bob_view.workspaces}
+        assert alice_names == {"alice_lala_a1", "alice_lala_a2"}
+        assert bob_names == {"bob_lala_b1"}
 
     async def test_list_workspaces_filters_to_caller(self, _mcp_db, user_repo_for_mcp):
         from tg_parser.mcp_server import create_workspace, list_workspaces

--- a/tests/test_f4b_metrics.py
+++ b/tests/test_f4b_metrics.py
@@ -1,0 +1,152 @@
+"""F4-B Core — Phase 5 Prometheus metrics tests.
+
+Verifies that ``WorkspaceService`` emits the documented
+``tg_workspace_*`` series on create / delete / resolver paths. We use
+``REGISTRY.get_sample_value`` on a freshly-bumped counter / histogram so
+the test is robust to ordering (other tests in the same suite may have
+already incremented the counters).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from prometheus_client import REGISTRY
+
+from tg_parser.api.metrics import (
+    WORKSPACE_QUERY_TOTAL,
+    WORKSPACE_TOOL_TOTAL,
+    record_workspace_query,
+    record_workspace_tool,
+)
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import WorkspaceNotFound
+from tg_parser.services.workspace_service import WorkspaceService
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+def _user(user_id: str, *, role: str = "user", allowed: list[str] | None = None) -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name="metric_user",
+        role=role,
+        allowed_channel_ids=None if role == "admin" else (allowed or []),
+        max_channels=10,
+    )
+
+
+@pytest.fixture
+async def metric_ws_service(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        yield WorkspaceService(SAWorkspaceRepo(session)), SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+def _query_total(result: str) -> float:
+    return REGISTRY.get_sample_value("tg_workspace_query_total", {"result": result}) or 0.0
+
+
+def _tool_total(tool: str, result: str) -> float:
+    return (
+        REGISTRY.get_sample_value("tg_workspace_tool_total", {"tool": tool, "result": result})
+        or 0.0
+    )
+
+
+def _histogram_count(name: str) -> float:
+    sample = REGISTRY.get_sample_value(name + "_count")
+    return sample or 0.0
+
+
+class TestMetricsRegistration:
+    def test_workspace_query_counter_is_registered(self):
+        names = {m.name for m in REGISTRY.collect() if m.name.startswith("tg_workspace_")}
+        assert "tg_workspace_query" in names
+        assert "tg_workspace_size" in names
+        assert "tg_workspace_effective_size" in names
+        assert "tg_workspace_resolver_seconds" in names
+        assert "tg_workspace_tool" in names
+        assert "tg_workspace_total" in names
+
+    def test_workspace_tool_counter_is_registered(self):
+        assert WORKSPACE_TOOL_TOTAL._name.startswith("tg_workspace_tool")
+
+    def test_record_workspace_query_known_results(self):
+        before = {r: _query_total(r) for r in ("scoped", "null_fallback", "not_found")}
+        record_workspace_query(
+            result="scoped", effective_size=2, workspace_size=3, duration_s=0.001
+        )
+        record_workspace_query(result="null_fallback")
+        record_workspace_query(result="not_found")
+        for r in ("scoped", "null_fallback", "not_found"):
+            assert _query_total(r) == before[r] + 1.0
+
+    def test_record_workspace_tool_outcome(self):
+        WORKSPACE_QUERY_TOTAL  # noqa: B018 — sentinel ensure import side-effect
+        before = _tool_total("create_workspace", "ok")
+        record_workspace_tool(tool="create_workspace", result="ok")
+        assert _tool_total("create_workspace", "ok") == before + 1.0
+
+
+@pg_only
+class TestResolverEmitsMetrics:
+    async def test_null_fallback_increments_null_fallback_counter(self, metric_ws_service):
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_metric_null")
+        user = _user(user_db.id, allowed=["ch_a"])
+        before = _query_total("null_fallback")
+        result = await svc.effective_channel_ids(user, workspace_id=None)
+        assert result == ["ch_a"]
+        assert _query_total("null_fallback") == before + 1.0
+
+    async def test_scoped_resolver_emits_size_histograms(self, metric_ws_service):
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_metric_scoped")
+        user = _user(user_db.id, allowed=[])
+        ws = await svc.create_workspace(user, name="metric_scoped_ws", description=None)
+        before_scoped = _query_total("scoped")
+        before_size_n = _histogram_count("tg_workspace_size")
+        before_eff_n = _histogram_count("tg_workspace_effective_size")
+        before_dur_n = _histogram_count("tg_workspace_resolver_seconds")
+
+        result = await svc.effective_channel_ids(user, workspace_id=ws.id)
+        assert result == []
+        assert _query_total("scoped") == before_scoped + 1.0
+        assert _histogram_count("tg_workspace_size") == before_size_n + 1.0
+        assert _histogram_count("tg_workspace_effective_size") == before_eff_n + 1.0
+        assert _histogram_count("tg_workspace_resolver_seconds") == before_dur_n + 1.0
+
+    async def test_unknown_workspace_id_increments_not_found(self, metric_ws_service):
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_metric_404")
+        user = _user(user_db.id)
+        before = _query_total("not_found")
+        with pytest.raises(WorkspaceNotFound):
+            await svc.effective_channel_ids(
+                user,
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert _query_total("not_found") == before + 1.0
+
+
+@pg_only
+class TestCreateDeleteEmitGauge:
+    async def test_create_workspace_emits_gauge_bump(self, metric_ws_service):
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_metric_gauge")
+        user = _user(user_db.id)
+        before = REGISTRY.get_sample_value("tg_workspace_total") or 0.0
+        ws = await svc.create_workspace(user, name="metric_gauge_ws", description=None)
+        assert REGISTRY.get_sample_value("tg_workspace_total") == before + 1.0
+        deleted = await svc.delete_workspace(user, ws.id)
+        assert deleted is True
+        assert REGISTRY.get_sample_value("tg_workspace_total") == before

--- a/tests/test_f4b_metrics.py
+++ b/tests/test_f4b_metrics.py
@@ -16,7 +16,6 @@ from prometheus_client import REGISTRY
 
 from tg_parser.api.metrics import (
     WORKSPACE_QUERY_TOTAL,
-    WORKSPACE_TOOL_TOTAL,
     record_workspace_query,
     record_workspace_tool,
 )
@@ -77,8 +76,25 @@ class TestMetricsRegistration:
         assert "tg_workspace_tool" in names
         assert "tg_workspace_total" in names
 
-    def test_workspace_tool_counter_is_registered(self):
-        assert WORKSPACE_TOOL_TOTAL._name.startswith("tg_workspace_tool")
+    def test_workspace_tool_counter_carries_expected_labels(self):
+        """Use the public ``REGISTRY`` API instead of poking the private
+        ``_name`` attribute. Asserts the labelset ``{tool, result}`` exists
+        on at least one sample after a recorded outcome — robust against
+        future renames of internal Prometheus attrs."""
+        record_workspace_tool(tool="metric_label_probe", result="ok")
+        samples: list[tuple[str, dict]] = []
+        for family in REGISTRY.collect():
+            if family.name != "tg_workspace_tool":
+                continue
+            for sample in family.samples:
+                samples.append((sample.name, dict(sample.labels)))
+        probe = [
+            labels
+            for name, labels in samples
+            if name == "tg_workspace_tool_total" and labels.get("tool") == "metric_label_probe"
+        ]
+        assert probe, "tg_workspace_tool_total{tool=...} sample not found"
+        assert probe[0]["result"] == "ok"
 
     def test_record_workspace_query_known_results(self):
         before = {r: _query_total(r) for r in ("scoped", "null_fallback", "not_found")}
@@ -91,7 +107,9 @@ class TestMetricsRegistration:
             assert _query_total(r) == before[r] + 1.0
 
     def test_record_workspace_tool_outcome(self):
-        WORKSPACE_QUERY_TOTAL  # noqa: B018 — sentinel ensure import side-effect
+        # Reference the imported counter symbol explicitly so it stays in
+        # the import set even if the test body shrinks.
+        assert WORKSPACE_QUERY_TOTAL is not None
         before = _tool_total("create_workspace", "ok")
         record_workspace_tool(tool="create_workspace", result="ok")
         assert _tool_total("create_workspace", "ok") == before + 1.0
@@ -136,6 +154,48 @@ class TestResolverEmitsMetrics:
                 workspace_id="00000000-0000-0000-0000-000000000999",
             )
         assert _query_total("not_found") == before + 1.0
+
+
+@pg_only
+class TestResolverMetricPaths:
+    """Pin which metric series the resolver emits on each branch — the
+    contract is encoded in :func:`WorkspaceService.effective_channel_ids`
+    and :func:`record_workspace_query`. Drift here would mean dashboards
+    silently lose a signal (e.g. resolver_seconds stops firing on
+    not_found and a slow 404 path is invisible)."""
+
+    async def test_not_found_emits_resolver_seconds_but_not_size(self, metric_ws_service):
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_not_found_dur")
+        user = _user(user_db.id)
+        before_dur = _histogram_count("tg_workspace_resolver_seconds")
+        before_size = _histogram_count("tg_workspace_size")
+        before_eff = _histogram_count("tg_workspace_effective_size")
+        with pytest.raises(WorkspaceNotFound):
+            await svc.effective_channel_ids(
+                user,
+                workspace_id="00000000-0000-0000-0000-000000000111",
+            )
+        # not_found path measures latency (cost of the 404 lookup) but does
+        # NOT observe size histograms — there is no workspace to size.
+        assert _histogram_count("tg_workspace_resolver_seconds") == before_dur + 1.0
+        assert _histogram_count("tg_workspace_size") == before_size
+        assert _histogram_count("tg_workspace_effective_size") == before_eff
+
+    async def test_null_fallback_does_not_emit_size_histograms(self, metric_ws_service):
+        """``workspace_id=None`` short-circuits to F4-A and avoids repo I/O —
+        documented as the cheap fast-path. Size histograms must NOT fire."""
+        svc, user_repo = metric_ws_service
+        user_db = await user_repo.create_user("alice_null_no_size")
+        user = _user(user_db.id, allowed=["ch_a"])
+        before_size = _histogram_count("tg_workspace_size")
+        before_eff = _histogram_count("tg_workspace_effective_size")
+        before_dur = _histogram_count("tg_workspace_resolver_seconds")
+        result = await svc.effective_channel_ids(user, workspace_id=None)
+        assert result == ["ch_a"]
+        assert _histogram_count("tg_workspace_size") == before_size
+        assert _histogram_count("tg_workspace_effective_size") == before_eff
+        assert _histogram_count("tg_workspace_resolver_seconds") == before_dur
 
 
 @pg_only

--- a/tests/test_f4b_schema.py
+++ b/tests/test_f4b_schema.py
@@ -17,6 +17,7 @@ import uuid
 
 import pytest
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 from tg_parser.domain.models import Workspace, WorkspaceSource
 
@@ -105,6 +106,13 @@ class TestWorkspacesSchema:
             assert "idx_workspace_sources_source_id" in idx_names
 
     async def test_workspaces_unique_owner_name(self, test_db) -> None:
+        """Hidden gotcha § 6 — uniqueness PER-OWNER (one owner cannot have two
+        workspaces with the same name).
+
+        Asserts on :class:`IntegrityError` rather than bare ``Exception`` so a
+        future change that swallowed the constraint into a silent ``UPDATE``
+        would surface here.
+        """
         session = test_db.ingestion_state_session()
         try:
             owner_id = str(uuid.uuid4())
@@ -118,17 +126,34 @@ class TestWorkspacesSchema:
             )
             await session.commit()
 
-            with pytest.raises(Exception):  # noqa: B017 - asyncpg integrity errors
+            with pytest.raises(IntegrityError) as exc_info:
                 await session.execute(
                     text("INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name)"),
                     {"owner_id": owner_id, "name": "AI/ML"},
                 )
                 await session.commit()
+            assert (
+                "uq_workspaces_owner_name" in str(exc_info.value)
+                or "unique" in str(exc_info.value).lower()
+            )
             await session.rollback()
+
+            count_rows = await session.execute(
+                text("SELECT COUNT(*) FROM workspaces WHERE owner_id = :oid AND name = :name"),
+                {"oid": owner_id, "name": "AI/ML"},
+            )
+            assert count_rows.scalar() == 1
         finally:
             await session.close()
 
     async def test_workspaces_name_nonempty_check(self, test_db) -> None:
+        """Hidden gotcha § 6 — CHECK constraint rejects whitespace-only names.
+
+        Tightened from bare ``Exception`` to :class:`IntegrityError` and we
+        additionally verify the constraint name appears in the error so a
+        future drop of the check would not be masked by a different error
+        path (e.g. NOT NULL).
+        """
         session = test_db.ingestion_state_session()
         try:
             owner_id = str(uuid.uuid4())
@@ -138,12 +163,16 @@ class TestWorkspacesSchema:
             )
             await session.commit()
 
-            with pytest.raises(Exception):  # noqa: B017
+            with pytest.raises(IntegrityError) as exc_info:
                 await session.execute(
                     text("INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name)"),
                     {"owner_id": owner_id, "name": "   "},
                 )
                 await session.commit()
+            assert (
+                "ck_workspaces_name_nonempty" in str(exc_info.value)
+                or "check" in str(exc_info.value).lower()
+            )
             await session.rollback()
         finally:
             await session.close()

--- a/tests/test_f4b_schema.py
+++ b/tests/test_f4b_schema.py
@@ -1,0 +1,248 @@
+"""F4-B Core — schema + migration smoke tests (Phase 1).
+
+Verifies that the additive ``e9f0a1b2c3d5`` migration creates the
+``workspaces`` and ``workspace_sources`` tables with all expected
+constraints / indexes / FK semantics, and that the matching Pydantic
+domain models enforce the same invariants on the application side.
+
+Postgres-backed tests reuse the ``test_db`` fixture from ``conftest.py``
+(alembic-managed schema, DI-19). They are gated by the same
+``TEST_POSTGRES=1`` mechanism F6 / F11 tests use.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from tg_parser.domain.models import Workspace, WorkspaceSource
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ============================================================================
+# Pure Pydantic — no DB
+# ============================================================================
+
+
+class TestWorkspacePydantic:
+    def test_workspace_strips_whitespace_name(self) -> None:
+        ws = Workspace(
+            id=str(uuid.uuid4()),
+            owner_id=str(uuid.uuid4()),
+            name="  AI/ML research  ",
+        )
+        assert ws.name == "AI/ML research"
+
+    def test_workspace_rejects_blank_name(self) -> None:
+        with pytest.raises(ValueError):
+            Workspace(
+                id=str(uuid.uuid4()),
+                owner_id=str(uuid.uuid4()),
+                name="   ",
+            )
+
+    def test_workspace_rejects_overlong_name(self) -> None:
+        with pytest.raises(ValueError):
+            Workspace(
+                id=str(uuid.uuid4()),
+                owner_id=str(uuid.uuid4()),
+                name="a" * 201,
+            )
+
+    def test_workspace_source_minimal(self) -> None:
+        ws_id = str(uuid.uuid4())
+        ws_source = WorkspaceSource(workspace_id=ws_id, source_id="tg:durov")
+        assert ws_source.workspace_id == ws_id
+        assert ws_source.source_id == "tg:durov"
+
+
+# ============================================================================
+# Schema constraints — Postgres
+# ============================================================================
+
+
+@pg_only
+class TestWorkspacesSchema:
+    async def test_workspaces_table_exists_with_indexes(self, test_db) -> None:
+        async with test_db.ingestion_state_engine.begin() as conn:
+            row = await conn.execute(
+                text(
+                    "SELECT tablename FROM pg_tables "
+                    "WHERE schemaname='public' AND tablename='workspaces'"
+                )
+            )
+            assert row.fetchone() is not None
+            row = await conn.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname='public' AND tablename='workspaces' "
+                    "ORDER BY indexname"
+                )
+            )
+            idx_names = {r[0] for r in row.fetchall()}
+            assert "idx_workspaces_owner_id" in idx_names
+            assert "uq_workspaces_owner_name" in idx_names
+            assert "workspaces_pkey" in idx_names
+
+    async def test_workspace_sources_table_exists_with_composite_pk(self, test_db) -> None:
+        async with test_db.ingestion_state_engine.begin() as conn:
+            row = await conn.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname='public' AND tablename='workspace_sources' "
+                    "ORDER BY indexname"
+                )
+            )
+            idx_names = {r[0] for r in row.fetchall()}
+            assert "pk_workspace_sources" in idx_names
+            assert "idx_workspace_sources_source_id" in idx_names
+
+    async def test_workspaces_unique_owner_name(self, test_db) -> None:
+        session = test_db.ingestion_state_session()
+        try:
+            owner_id = str(uuid.uuid4())
+            await session.execute(
+                text("INSERT INTO users(id, name, role) VALUES (:id, :name, 'user')"),
+                {"id": owner_id, "name": "alice"},
+            )
+            await session.execute(
+                text("INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name)"),
+                {"owner_id": owner_id, "name": "AI/ML"},
+            )
+            await session.commit()
+
+            with pytest.raises(Exception):  # noqa: B017 - asyncpg integrity errors
+                await session.execute(
+                    text("INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name)"),
+                    {"owner_id": owner_id, "name": "AI/ML"},
+                )
+                await session.commit()
+            await session.rollback()
+        finally:
+            await session.close()
+
+    async def test_workspaces_name_nonempty_check(self, test_db) -> None:
+        session = test_db.ingestion_state_session()
+        try:
+            owner_id = str(uuid.uuid4())
+            await session.execute(
+                text("INSERT INTO users(id, name, role) VALUES (:id, :name, 'user')"),
+                {"id": owner_id, "name": "bob"},
+            )
+            await session.commit()
+
+            with pytest.raises(Exception):  # noqa: B017
+                await session.execute(
+                    text("INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name)"),
+                    {"owner_id": owner_id, "name": "   "},
+                )
+                await session.commit()
+            await session.rollback()
+        finally:
+            await session.close()
+
+    async def test_workspace_sources_cascade_on_workspace_delete(self, test_db) -> None:
+        session = test_db.ingestion_state_session()
+        try:
+            owner_id = str(uuid.uuid4())
+            source_id = "tg:carol_test_chan"
+            await session.execute(
+                text("INSERT INTO users(id, name, role) VALUES (:id, :name, 'user')"),
+                {"id": owner_id, "name": "carol"},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO sources(source_id, channel_id, status, include_comments, "
+                    "fail_count, comments_unavailable, created_at, updated_at, owner_id) "
+                    "VALUES (:sid, :sid, 'active', false, 0, false, "
+                    "now()::text, now()::text, :owner)"
+                ),
+                {"sid": source_id, "owner": owner_id},
+            )
+            result = await session.execute(
+                text(
+                    "INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name) RETURNING id"
+                ),
+                {"owner_id": owner_id, "name": "Workspace1"},
+            )
+            ws_id = str(result.fetchone()[0])
+            await session.execute(
+                text(
+                    "INSERT INTO workspace_sources(workspace_id, source_id) "
+                    "VALUES (:ws_id, :source_id)"
+                ),
+                {"ws_id": ws_id, "source_id": source_id},
+            )
+            await session.commit()
+
+            cnt = await session.execute(
+                text("SELECT COUNT(*) FROM workspace_sources WHERE workspace_id = :ws"),
+                {"ws": ws_id},
+            )
+            assert cnt.scalar() == 1
+
+            await session.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+            await session.commit()
+
+            cnt = await session.execute(
+                text("SELECT COUNT(*) FROM workspace_sources WHERE workspace_id = :ws"),
+                {"ws": ws_id},
+            )
+            assert cnt.scalar() == 0
+        finally:
+            await session.close()
+
+    async def test_workspace_sources_composite_pk_idempotent_insert(self, test_db) -> None:
+        session = test_db.ingestion_state_session()
+        try:
+            owner_id = str(uuid.uuid4())
+            source_id = "tg:idem_test_chan"
+            await session.execute(
+                text("INSERT INTO users(id, name, role) VALUES (:id, :name, 'user')"),
+                {"id": owner_id, "name": "dora"},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO sources(source_id, channel_id, status, include_comments, "
+                    "fail_count, comments_unavailable, created_at, updated_at, owner_id) "
+                    "VALUES (:sid, :sid, 'active', false, 0, false, "
+                    "now()::text, now()::text, :owner)"
+                ),
+                {"sid": source_id, "owner": owner_id},
+            )
+            result = await session.execute(
+                text(
+                    "INSERT INTO workspaces(owner_id, name) VALUES (:owner_id, :name) RETURNING id"
+                ),
+                {"owner_id": owner_id, "name": "Workspace_dora"},
+            )
+            ws_id = str(result.fetchone()[0])
+            await session.execute(
+                text(
+                    "INSERT INTO workspace_sources(workspace_id, source_id) "
+                    "VALUES (:ws_id, :source_id) ON CONFLICT DO NOTHING"
+                ),
+                {"ws_id": ws_id, "source_id": source_id},
+            )
+            await session.execute(
+                text(
+                    "INSERT INTO workspace_sources(workspace_id, source_id) "
+                    "VALUES (:ws_id, :source_id) ON CONFLICT DO NOTHING"
+                ),
+                {"ws_id": ws_id, "source_id": source_id},
+            )
+            await session.commit()
+            cnt = await session.execute(
+                text("SELECT COUNT(*) FROM workspace_sources WHERE workspace_id = :ws"),
+                {"ws": ws_id},
+            )
+            assert cnt.scalar() == 1
+        finally:
+            await session.close()

--- a/tests/test_f4b_scoping_read_tools.py
+++ b/tests/test_f4b_scoping_read_tools.py
@@ -277,6 +277,31 @@ class TestAskQuestionScoping:
             await ask_question(question="hi", workspace_id=ws_id)
         assert captured["allowed_channel_ids"] == ["ch_ax"]
 
+    async def test_workspace_empty_passes_empty_list(self, _scope_db, user_repo_for_scope):
+        """Hidden gotcha § 3: empty workspace narrows scope to ``[]`` — NOT
+        silent fallback to user.allowed (which would leak unrelated channels)."""
+        from tg_parser.mcp_server import AnswerResultItem, ask_question
+
+        owner = await user_repo_for_scope.create_user("ask_empty")
+        user = _make_user(owner.id, allowed=["ch_a", "ch_b"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, [], name="ask_empty_ws")
+
+        captured: dict = {}
+
+        async def fake_answer(**kwargs):
+            captured.update(kwargs)
+            return AnswerResultItem(answer="ok", sources=[], model="stub")
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.answer",
+                AsyncMock(side_effect=fake_answer),
+            ),
+        ):
+            await ask_question(question="hi", workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == []
+
 
 # ---------------------------------------------------------------------------
 # list_channels
@@ -329,10 +354,85 @@ class TestListChannelsScoping:
         assert results == []
         stats_mock.assert_not_called()
 
+    async def test_workspace_empty_passes_empty_list(self, _scope_db, user_repo_for_scope):
+        """Hidden gotcha § 3: empty workspace → ``allowed_channel_ids=[]``."""
+        from tg_parser.mcp_server import list_channels
+
+        owner = await user_repo_for_scope.create_user("listch_empty")
+        user = _make_user(owner.id, allowed=["ch_lc1", "ch_lc2"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, [], name="listch_empty_ws")
+
+        captured: dict = {}
+
+        async def fake_stats(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.channel_service.get_all_channel_stats",
+                AsyncMock(side_effect=fake_stats),
+            ),
+        ):
+            await list_channels(workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == []
+
 
 # ---------------------------------------------------------------------------
 # get_topic_details / get_document — Q4 R3 invariant
 # ---------------------------------------------------------------------------
+
+
+def _mock_processing_repos_with_card_and_bundle(card, bundle):
+    """Patch helper mirroring ``tests/test_mcp_server._mock_processing_repos``.
+
+    Returns the context manager that ``tg_parser.services.db_context``
+    .processing_repos`` is patched to so the MCP tool sees our fixture data.
+    """
+    from contextlib import asynccontextmanager
+
+    proc_repo = AsyncMock()
+    topic_card_repo = AsyncMock()
+    topic_bundle_repo = AsyncMock()
+    db_mock = AsyncMock()
+
+    async def get_card(tid):
+        return card if (card and card.id == tid) else None
+
+    async def get_bundle(tid):
+        return bundle if (bundle and bundle.topic_id == tid) else None
+
+    topic_card_repo.get_by_id.side_effect = get_card
+    topic_bundle_repo.get_by_topic_id.side_effect = get_bundle
+
+    @asynccontextmanager
+    async def fake_repos():
+        yield (proc_repo, topic_card_repo, topic_bundle_repo, db_mock)
+
+    return fake_repos
+
+
+def _mock_processing_repos_with_document(doc):
+    """Same idea as the topic helper, but for ``get_document``'s
+    ``proc_repo.get_by_source_ref`` call site."""
+    from contextlib import asynccontextmanager
+
+    proc_repo = AsyncMock()
+    topic_card_repo = AsyncMock()
+    topic_bundle_repo = AsyncMock()
+    db_mock = AsyncMock()
+
+    async def get_doc(ref):
+        return doc if (doc and doc.source_ref == ref) else None
+
+    proc_repo.get_by_source_ref.side_effect = get_doc
+
+    @asynccontextmanager
+    async def fake_repos():
+        yield (proc_repo, topic_card_repo, topic_bundle_repo, db_mock)
+
+    return fake_repos
 
 
 @pg_only
@@ -366,6 +466,242 @@ class TestGetDetailsHonorsQ4R3:
             )
         assert isinstance(result, str)
         assert "not found" in result.lower()
+
+    async def test_get_topic_details_returns_full_bundle_when_workspace_narrower(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """Q4 R3 happy path: bundle items must include channels OUTSIDE the
+        workspace, as long as the caller can see them through their F4-A
+        ``allowed_channel_ids``. Workspace narrows list/search, not get-details.
+
+        Setup: topic spans ``ch_in`` (in workspace) + ``ch_out`` (not in
+        workspace, but still owned by the user). The workspace contains only
+        ``ch_in``. Asserting that ``get_topic_details(topic_id, workspace_id=ws)``
+        returns BOTH bundle items, not just the in-workspace one.
+        """
+        from datetime import datetime
+
+        from tg_parser.domain.models import (
+            Anchor,
+            BundleItem,
+            BundleItemRole,
+            MessageType,
+            TopicBundle,
+            TopicCard,
+            TopicType,
+        )
+        from tg_parser.mcp_server import get_topic_details
+
+        owner = await user_repo_for_scope.create_user("q4r3_topic")
+        await _seed_source(_scope_db, "tg:src_in", "ch_in", owner.id)
+        await _seed_source(_scope_db, "tg:src_out", "ch_out", owner.id)
+        user = _make_user(owner.id, allowed=["ch_in", "ch_out"])
+
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_in"], name="q4r3_topic_ws"
+        )
+
+        topic_id = "topic:tg:ch_in:post:42"
+        now = datetime.now(UTC)
+        card = TopicCard(
+            id=topic_id,
+            title="cross-channel topic",
+            summary="spans ch_in + ch_out",
+            scope_in=["AI/ML news"],
+            scope_out=["other domains"],
+            type=TopicType.CLUSTER,
+            anchors=[
+                Anchor(
+                    channel_id="ch_in",
+                    message_id="42",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_in:post:42",
+                    score=1.0,
+                ),
+                Anchor(
+                    channel_id="ch_out",
+                    message_id="43",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_out:post:43",
+                    score=0.9,
+                ),
+            ],
+            sources=["ch_in", "ch_out"],
+            updated_at=now,
+        )
+        bundle = TopicBundle(
+            topic_id=topic_id,
+            items=[
+                BundleItem(
+                    channel_id="ch_in",
+                    message_id="42",
+                    message_type=MessageType.POST,
+                    source_ref="tg:ch_in:post:42",
+                    role=BundleItemRole.ANCHOR,
+                ),
+                BundleItem(
+                    channel_id="ch_out",
+                    message_id="43",
+                    message_type=MessageType.POST,
+                    source_ref="tg:ch_out:post:43",
+                    role=BundleItemRole.SUPPORTING,
+                ),
+            ],
+            updated_at=now,
+        )
+
+        fake_repos = _mock_processing_repos_with_card_and_bundle(card, bundle)
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            result = await get_topic_details(topic_id=topic_id, workspace_id=ws_id)
+
+        assert not isinstance(result, str), f"Expected TopicDetail, got string: {result}"
+        assert result.id == topic_id
+        assert sorted(result.sources) == ["ch_in", "ch_out"]
+        assert result.items is not None
+        item_channels = sorted({item["channel_id"] for item in result.items})
+        assert item_channels == ["ch_in", "ch_out"]
+
+    async def test_get_topic_details_full_bundle_equals_null_workspace(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """The bundle returned with ``workspace_id=ws`` must be **identical**
+        to the one returned with ``workspace_id=None`` (Q4 R3 — no filtering
+        on get-details). Documents the equivalence the start prompt requires.
+        """
+        from datetime import datetime
+
+        from tg_parser.domain.models import (
+            Anchor,
+            BundleItem,
+            BundleItemRole,
+            MessageType,
+            TopicBundle,
+            TopicCard,
+            TopicType,
+        )
+        from tg_parser.mcp_server import get_topic_details
+
+        owner = await user_repo_for_scope.create_user("q4r3_eq")
+        await _seed_source(_scope_db, "tg:src_eqa", "ch_eqa", owner.id)
+        await _seed_source(_scope_db, "tg:src_eqb", "ch_eqb", owner.id)
+        user = _make_user(owner.id, allowed=["ch_eqa", "ch_eqb"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, ["ch_eqa"], name="q4r3_eq_ws")
+
+        topic_id = "topic:tg:ch_eqa:post:1"
+        now = datetime.now(UTC)
+        card = TopicCard(
+            id=topic_id,
+            title="t",
+            summary="s",
+            scope_in=["focus"],
+            scope_out=["unrelated"],
+            type=TopicType.CLUSTER,
+            anchors=[
+                Anchor(
+                    channel_id="ch_eqa",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_eqa:post:1",
+                    score=1.0,
+                ),
+                Anchor(
+                    channel_id="ch_eqb",
+                    message_id="2",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_eqb:post:2",
+                    score=0.9,
+                ),
+            ],
+            sources=["ch_eqa", "ch_eqb"],
+            updated_at=now,
+        )
+        bundle = TopicBundle(
+            topic_id=topic_id,
+            items=[
+                BundleItem(
+                    channel_id="ch_eqa",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    source_ref="tg:ch_eqa:post:1",
+                    role=BundleItemRole.ANCHOR,
+                ),
+                BundleItem(
+                    channel_id="ch_eqb",
+                    message_id="2",
+                    message_type=MessageType.POST,
+                    source_ref="tg:ch_eqb:post:2",
+                    role=BundleItemRole.SUPPORTING,
+                ),
+            ],
+            updated_at=now,
+        )
+
+        fake_repos = _mock_processing_repos_with_card_and_bundle(card, bundle)
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            scoped = await get_topic_details(topic_id=topic_id, workspace_id=ws_id)
+            unscoped = await get_topic_details(topic_id=topic_id, workspace_id=None)
+
+        assert not isinstance(scoped, str)
+        assert not isinstance(unscoped, str)
+        assert scoped.items == unscoped.items
+        assert scoped.sources == unscoped.sources
+        assert scoped.id == unscoped.id
+
+    async def test_get_document_returns_doc_when_channel_outside_workspace(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """Q4 R3 for ``get_document``: returns the document even if its
+        ``channel_id`` lives outside the workspace, provided the caller has
+        F4-A access to that channel.
+        """
+        from tg_parser.domain.models import ProcessedDocument
+        from tg_parser.mcp_server import get_document
+
+        owner = await user_repo_for_scope.create_user("q4r3_doc")
+        await _seed_source(_scope_db, "tg:src_doc_in", "ch_doc_in", owner.id)
+        await _seed_source(_scope_db, "tg:src_doc_out", "ch_doc_out", owner.id)
+        user = _make_user(owner.id, allowed=["ch_doc_in", "ch_doc_out"])
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_doc_in"], name="q4r3_doc_ws"
+        )
+
+        doc = ProcessedDocument(
+            id="d-out",
+            source_ref="tg:ch_doc_out:post:7",
+            source_message_id="7",
+            channel_id="ch_doc_out",
+            processed_at=datetime.now(UTC),
+            text_clean="hello",
+            summary="s",
+            topics=["topic-x"],
+        )
+        fake_repos = _mock_processing_repos_with_document(doc)
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            result = await get_document(
+                source_ref="tg:ch_doc_out:post:7",
+                workspace_id=ws_id,
+            )
+
+        assert not isinstance(result, str), f"Expected DocumentDetail, got string: {result}"
+        assert result.channel_id == "ch_doc_out"
+        assert result.source_ref == "tg:ch_doc_out:post:7"
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +741,30 @@ class TestAnalyticsScoping:
             await get_cross_channel_stats(workspace_id=ws_id)
         assert captured["allowed_channel_ids"] == ["ch_cc"]
 
+    async def test_get_cross_channel_stats_workspace_unknown_returns_empty(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """404 path for ``get_cross_channel_stats`` — analytics service must
+        NOT be called when the workspace_id is unknown / foreign."""
+        from tg_parser.mcp_server import get_cross_channel_stats
+
+        owner = await user_repo_for_scope.create_user("cc_unk")
+        user = _make_user(owner.id, allowed=["ch_cc"])
+        analytics_mock = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.analytics_service.get_cross_channel_analytics",
+                analytics_mock,
+            ),
+        ):
+            result = await get_cross_channel_stats(
+                workspace_id="00000000-0000-0000-0000-000000000999"
+            )
+        assert result.total_documents == 0
+        assert result.channels == []
+        analytics_mock.assert_not_called()
+
     async def test_get_related_topics_workspace_unknown_returns_empty(
         self, _scope_db, user_repo_for_scope
     ):
@@ -427,6 +787,34 @@ class TestAnalyticsScoping:
         assert results == []
         linker.assert_not_called()
 
+    async def test_get_related_topics_workspace_narrows(self, _scope_db, user_repo_for_scope):
+        """``get_related_topics`` must pass the workspace-narrowed
+        ``allowed_channel_ids`` to the linking service (intersection path)."""
+        from tg_parser.mcp_server import get_related_topics
+
+        owner = await user_repo_for_scope.create_user("rel_narrow")
+        await _seed_source(_scope_db, "tg:src_rn", "ch_rn", owner.id)
+        user = _make_user(owner.id, allowed=["ch_rn", "ch_other"])
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_rn"], name="rel_narrow_ws"
+        )
+
+        captured: dict = {}
+
+        async def fake_linker(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                AsyncMock(side_effect=fake_linker),
+            ),
+        ):
+            await get_related_topics(topic_id="topic:tg:rn", workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == ["ch_rn"]
+
 
 # ---------------------------------------------------------------------------
 # list_topics
@@ -444,3 +832,173 @@ class TestListTopicsScoping:
             result = await list_topics(workspace_id="00000000-0000-0000-0000-000000000999")
         assert result.total == 0
         assert result.items == []
+
+    async def test_workspace_narrows_to_intersection(self, _scope_db, user_repo_for_scope):
+        """``list_topics`` must call ``topic_card_repo.list_by_channels`` with
+        the workspace-narrowed list (not user's full ``allowed_channel_ids``)."""
+        from contextlib import asynccontextmanager
+
+        from tg_parser.mcp_server import list_topics
+
+        owner = await user_repo_for_scope.create_user("lt_narrow")
+        await _seed_source(_scope_db, "tg:src_lt", "ch_lt", owner.id)
+        user = _make_user(owner.id, allowed=["ch_lt", "ch_other"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, ["ch_lt"], name="lt_narrow_ws")
+
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        proc_repo = AsyncMock()
+        topic_card_repo.list_by_channels.return_value = []
+        topic_bundle_repo.list_all.return_value = []
+        captured: dict = {}
+
+        async def fake_list_by_channels(channel_ids):
+            captured["channel_ids"] = channel_ids
+            return []
+
+        topic_card_repo.list_by_channels.side_effect = fake_list_by_channels
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (proc_repo, topic_card_repo, topic_bundle_repo, AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            result = await list_topics(workspace_id=ws_id)
+        assert result.total == 0
+        assert captured["channel_ids"] == ["ch_lt"]
+
+    async def test_q6_cross_channel_topic_visible_via_any_workspace(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """Q6 — topic spanning ch_a + ch_b is visible through whichever
+        workspace contains either of them, **and** through null-workspace.
+
+        Mirrors F4-A ``assert_topic_access`` "any source" semantics.
+        Critical: F4-B must NOT post-filter the cards returned by
+        ``topic_card_repo.list_by_channels`` — that would shrink cross-channel
+        topics out of every workspace that doesn't contain *all* their sources.
+        """
+        from contextlib import asynccontextmanager
+        from datetime import datetime
+
+        from tg_parser.domain.models import (
+            Anchor,
+            MessageType,
+            TopicCard,
+            TopicType,
+        )
+        from tg_parser.mcp_server import list_topics
+
+        owner = await user_repo_for_scope.create_user("q6_any_source")
+        await _seed_source(_scope_db, "tg:src_qa", "ch_qa", owner.id)
+        await _seed_source(_scope_db, "tg:src_qb", "ch_qb", owner.id)
+        user = _make_user(owner.id, allowed=["ch_qa", "ch_qb"])
+        ws_a = await _seed_workspace_with_channels(_scope_db, user, ["ch_qa"], name="q6_ws_a")
+        ws_b = await _seed_workspace_with_channels(_scope_db, user, ["ch_qb"], name="q6_ws_b")
+
+        now = datetime.now(UTC)
+        cross_card = TopicCard(
+            id="topic:tg:qa_qb",
+            title="cross-channel",
+            summary="spans ch_qa + ch_qb",
+            scope_in=["theme"],
+            scope_out=["other"],
+            type=TopicType.CLUSTER,
+            anchors=[
+                Anchor(
+                    channel_id="ch_qa",
+                    message_id="1",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_qa:post:1",
+                    score=1.0,
+                ),
+                Anchor(
+                    channel_id="ch_qb",
+                    message_id="2",
+                    message_type=MessageType.POST,
+                    anchor_ref="tg:ch_qb:post:2",
+                    score=0.9,
+                ),
+            ],
+            sources=["ch_qa", "ch_qb"],
+            updated_at=now,
+        )
+
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        proc_repo = AsyncMock()
+        topic_bundle_repo.list_all.return_value = []
+
+        async def fake_list_by_channels(channel_ids):
+            # Stand-in for the F4-A any-source semantics: card is visible
+            # if ANY of its sources is in the queried channel list.
+            if any(src in channel_ids for src in cross_card.sources):
+                return [cross_card]
+            return []
+
+        topic_card_repo.list_by_channels.side_effect = fake_list_by_channels
+        topic_card_repo.list_all.return_value = [cross_card]
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (proc_repo, topic_card_repo, topic_bundle_repo, AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            result_a = await list_topics(workspace_id=ws_a)
+            result_b = await list_topics(workspace_id=ws_b)
+            result_null = await list_topics(workspace_id=None)
+
+        for label, result in (("ws_a", result_a), ("ws_b", result_b), ("null", result_null)):
+            assert result.total == 1, f"{label}: expected 1 topic, got {result.total}"
+            assert result.items[0].id == cross_card.id
+            # CRITICAL: the surface must NOT filter sources down to the workspace.
+            assert sorted(result.items[0].sources) == ["ch_qa", "ch_qb"], (
+                f"{label}: sources were post-filtered, breaking Q6 any-source mirror"
+            )
+
+    async def test_workspace_empty_returns_empty_page_without_repo_call(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """Hidden gotcha § 3: empty workspace must NOT silently widen to
+        all-channels. ``effective=[]`` flows into ``list_by_channels([])``
+        and the result is empty.
+        """
+        from contextlib import asynccontextmanager
+
+        from tg_parser.mcp_server import list_topics
+
+        owner = await user_repo_for_scope.create_user("lt_empty")
+        user = _make_user(owner.id, allowed=["ch_a", "ch_b"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, [], name="lt_empty_ws")
+
+        topic_card_repo = AsyncMock()
+        topic_bundle_repo = AsyncMock()
+        proc_repo = AsyncMock()
+        captured: dict = {}
+
+        async def fake_list_by_channels(channel_ids):
+            captured["channel_ids"] = channel_ids
+            return []
+
+        topic_card_repo.list_by_channels.side_effect = fake_list_by_channels
+        topic_bundle_repo.list_all.return_value = []
+
+        @asynccontextmanager
+        async def fake_repos():
+            yield (proc_repo, topic_card_repo, topic_bundle_repo, AsyncMock())
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.db_context.processing_repos", fake_repos),
+        ):
+            result = await list_topics(workspace_id=ws_id)
+        assert result.total == 0
+        # Critical: explicit empty narrowing, NOT list_all() path.
+        topic_card_repo.list_all.assert_not_called()
+        assert captured["channel_ids"] == []

--- a/tests/test_f4b_scoping_read_tools.py
+++ b/tests/test_f4b_scoping_read_tools.py
@@ -1,0 +1,446 @@
+"""F4-B Core — Phase 4 scoping integration in read MCP/CLI tools.
+
+These tests pin the contract from § "Read tools" of
+``docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md``:
+
+* ``workspace_id=None`` → bit-for-bit F4-A behaviour (regression guard).
+* unknown / foreign ``workspace_id`` → 404-like empty response (no leak).
+* empty workspace → empty result list.
+* valid workspace → ``allowed_channel_ids`` narrowed to intersection.
+* ``get_topic_details`` / ``get_document`` honour Q4 R3 — return FULL bundle
+  items regardless of workspace scope but still 404 on unknown / foreign
+  workspace_id.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+def _make_user(
+    user_id: str,
+    *,
+    name: str = "alice",
+    role: str = "user",
+    allowed: list[str] | None = None,
+    max_channels: int = 10,
+) -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else (allowed or []),
+        max_channels=max_channels,
+    )
+
+
+@pytest.fixture
+async def _scope_db(test_db):
+    return test_db
+
+
+@pytest.fixture
+async def user_repo_for_scope(_scope_db):
+    session = _scope_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _seed_source(test_db, source_id: str, channel_id: str, owner_id: str) -> None:
+    session = test_db.ingestion_state_session()
+    try:
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=source_id,
+                channel_id=channel_id,
+                status="active",
+                include_comments=False,
+                fail_count=0,
+                comments_unavailable=False,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                owner_id=owner_id,
+            )
+        )
+    finally:
+        await session.close()
+
+
+async def _seed_workspace_with_channels(
+    db,
+    owner: CurrentUser,
+    channels: list[str],
+    *,
+    name: str = "ws",
+) -> str:
+    """Create a workspace and add the given channels via the service layer."""
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    async with workspace_repo() as (repo, _db):
+        svc = WorkspaceService(repo)
+        ws = await svc.create_workspace(owner, name=name, description=None)
+        for ch in channels:
+            await svc.add_source(owner, ws.id, ch)
+        return ws.id
+
+
+# ---------------------------------------------------------------------------
+# search_knowledge_base
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestSearchKnowledgeBaseScoping:
+    async def test_workspace_none_uses_user_allowed_channels(self, _scope_db, user_repo_for_scope):
+        """workspace_id=None must pass user.allowed_channel_ids unchanged (F4-A parity)."""
+        from tg_parser.mcp_server import search_knowledge_base
+
+        owner = await user_repo_for_scope.create_user("search_none")
+        user = _make_user(owner.id, allowed=["ch_a", "ch_b"])
+
+        captured: dict = {}
+
+        async def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.search", AsyncMock(side_effect=fake_search)
+            ),
+        ):
+            await search_knowledge_base(query="hello")
+        assert captured["allowed_channel_ids"] == ["ch_a", "ch_b"]
+
+    async def test_workspace_unknown_returns_empty_no_service_call(
+        self, _scope_db, user_repo_for_scope
+    ):
+        """Unknown workspace_id must short-circuit to ``[]`` and never reach search()."""
+        from tg_parser.mcp_server import search_knowledge_base
+
+        owner = await user_repo_for_scope.create_user("search_unk")
+        user = _make_user(owner.id, allowed=["ch_a"])
+        search_mock = AsyncMock()
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.retrieval_service.search", search_mock),
+        ):
+            results = await search_knowledge_base(
+                query="hi",
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert results == []
+        search_mock.assert_not_called()
+
+    async def test_workspace_foreign_returns_empty(self, _scope_db, user_repo_for_scope):
+        """Foreign workspace_id must look like 404 (no leak)."""
+        from tg_parser.mcp_server import search_knowledge_base
+
+        alice = await user_repo_for_scope.create_user("alice_search_fg")
+        bob = await user_repo_for_scope.create_user("bob_search_fg")
+        alice_user = _make_user(alice.id, allowed=["ch_a"])
+        bob_user = _make_user(bob.id, allowed=["ch_a"])
+        await _seed_source(_scope_db, "tg:src_fg", "ch_a", alice.id)
+
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, alice_user, ["ch_a"], name="alice_search_fg_ws"
+        )
+
+        search_mock = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)),
+            patch("tg_parser.services.retrieval_service.search", search_mock),
+        ):
+            results = await search_knowledge_base(query="hi", workspace_id=ws_id)
+        assert results == []
+        search_mock.assert_not_called()
+
+    async def test_workspace_empty_passes_empty_list(self, _scope_db, user_repo_for_scope):
+        """Empty workspace narrows scope to ``[]`` (explicit, not None)."""
+        from tg_parser.mcp_server import search_knowledge_base
+
+        owner = await user_repo_for_scope.create_user("search_empty")
+        user = _make_user(owner.id, allowed=["ch_a", "ch_b"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, [], name="empty_ws")
+
+        captured: dict = {}
+
+        async def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.search", AsyncMock(side_effect=fake_search)
+            ),
+        ):
+            await search_knowledge_base(query="hi", workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == []
+
+    async def test_workspace_narrows_to_intersection(self, _scope_db, user_repo_for_scope):
+        """Non-admin: effective = user.allowed ∩ workspace.channel_ids."""
+        from tg_parser.mcp_server import search_knowledge_base
+
+        owner = await user_repo_for_scope.create_user("search_intersect")
+        await _seed_source(_scope_db, "tg:src_a", "ch_a", owner.id)
+        await _seed_source(_scope_db, "tg:src_b", "ch_b", owner.id)
+        user = _make_user(owner.id, allowed=["ch_a", "ch_b", "ch_c"])
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_a", "ch_b"], name="intersect_ws"
+        )
+
+        captured: dict = {}
+
+        async def fake_search(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.search", AsyncMock(side_effect=fake_search)
+            ),
+        ):
+            await search_knowledge_base(query="hi", workspace_id=ws_id)
+        assert sorted(captured["allowed_channel_ids"]) == ["ch_a", "ch_b"]
+
+
+# ---------------------------------------------------------------------------
+# ask_question
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestAskQuestionScoping:
+    async def test_workspace_unknown_returns_benign_answer(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import ask_question
+
+        owner = await user_repo_for_scope.create_user("ask_unk")
+        user = _make_user(owner.id, allowed=["ch_a"])
+        answer_mock = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch("tg_parser.services.retrieval_service.answer", answer_mock),
+        ):
+            res = await ask_question(
+                question="anything?",
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert "not found" in res.answer.lower()
+        assert res.sources == []
+        answer_mock.assert_not_called()
+
+    async def test_workspace_narrows_retrieval(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import AnswerResultItem, ask_question
+
+        owner = await user_repo_for_scope.create_user("ask_narrow")
+        await _seed_source(_scope_db, "tg:src_ax", "ch_ax", owner.id)
+        user = _make_user(owner.id, allowed=["ch_ax", "ch_other"])
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_ax"], name="ask_narrow_ws"
+        )
+
+        captured: dict = {}
+
+        async def fake_answer(**kwargs):
+            captured.update(kwargs)
+            return AnswerResultItem(answer="ok", sources=[], model="stub")
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.retrieval_service.answer",
+                AsyncMock(side_effect=fake_answer),
+            ),
+        ):
+            await ask_question(question="hi", workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == ["ch_ax"]
+
+
+# ---------------------------------------------------------------------------
+# list_channels
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestListChannelsScoping:
+    async def test_workspace_narrows_channel_list(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import list_channels
+
+        owner = await user_repo_for_scope.create_user("listch_narrow")
+        await _seed_source(_scope_db, "tg:src_lc1", "ch_lc1", owner.id)
+        await _seed_source(_scope_db, "tg:src_lc2", "ch_lc2", owner.id)
+        user = _make_user(owner.id, allowed=["ch_lc1", "ch_lc2"])
+        ws_id = await _seed_workspace_with_channels(
+            _scope_db, user, ["ch_lc1"], name="listch_narrow_ws"
+        )
+
+        captured: dict = {}
+
+        async def fake_stats(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.channel_service.get_all_channel_stats",
+                AsyncMock(side_effect=fake_stats),
+            ),
+        ):
+            await list_channels(workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == ["ch_lc1"]
+
+    async def test_workspace_unknown_returns_empty(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import list_channels
+
+        owner = await user_repo_for_scope.create_user("listch_unk")
+        user = _make_user(owner.id, allowed=["ch_lc1"])
+        stats_mock = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.channel_service.get_all_channel_stats",
+                stats_mock,
+            ),
+        ):
+            results = await list_channels(workspace_id="00000000-0000-0000-0000-000000000999")
+        assert results == []
+        stats_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_topic_details / get_document — Q4 R3 invariant
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestGetDetailsHonorsQ4R3:
+    async def test_get_topic_details_unknown_workspace_returns_not_found(
+        self, _scope_db, user_repo_for_scope
+    ):
+        from tg_parser.mcp_server import get_topic_details
+
+        owner = await user_repo_for_scope.create_user("getdet_unk")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await get_topic_details(
+                topic_id="topic:tg:irrelevant",
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert isinstance(result, str)
+        assert "not found" in result.lower()
+
+    async def test_get_document_unknown_workspace_returns_not_found(
+        self, _scope_db, user_repo_for_scope
+    ):
+        from tg_parser.mcp_server import get_document
+
+        owner = await user_repo_for_scope.create_user("getdoc_unk")
+        user = _make_user(owner.id, allowed=[])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await get_document(
+                source_ref="tg:ch:post:1",
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert isinstance(result, str)
+        assert "not found" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cross-channel + related — narrow scope
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestAnalyticsScoping:
+    async def test_get_cross_channel_stats_workspace_narrows(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import get_cross_channel_stats
+
+        owner = await user_repo_for_scope.create_user("cc_narrow")
+        await _seed_source(_scope_db, "tg:src_cc", "ch_cc", owner.id)
+        user = _make_user(owner.id, allowed=["ch_cc"])
+        ws_id = await _seed_workspace_with_channels(_scope_db, user, ["ch_cc"], name="cc_narrow_ws")
+
+        captured: dict = {}
+
+        async def fake_analytics(**kwargs):
+            captured.update(kwargs)
+            return {
+                "total_documents": 0,
+                "total_topics": 0,
+                "channels": [],
+                "keyword_overlaps": [],
+                "overlap_count": 0,
+            }
+
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.analytics_service.get_cross_channel_analytics",
+                AsyncMock(side_effect=fake_analytics),
+            ),
+        ):
+            await get_cross_channel_stats(workspace_id=ws_id)
+        assert captured["allowed_channel_ids"] == ["ch_cc"]
+
+    async def test_get_related_topics_workspace_unknown_returns_empty(
+        self, _scope_db, user_repo_for_scope
+    ):
+        from tg_parser.mcp_server import get_related_topics
+
+        owner = await user_repo_for_scope.create_user("rel_unk")
+        user = _make_user(owner.id, allowed=["ch_a"])
+        linker = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)),
+            patch(
+                "tg_parser.services.topic_linking_service.get_related_topics_for",
+                linker,
+            ),
+        ):
+            results = await get_related_topics(
+                topic_id="topic:tg:irrelevant",
+                workspace_id="00000000-0000-0000-0000-000000000999",
+            )
+        assert results == []
+        linker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list_topics
+# ---------------------------------------------------------------------------
+
+
+@pg_only
+class TestListTopicsScoping:
+    async def test_workspace_unknown_returns_empty_page(self, _scope_db, user_repo_for_scope):
+        from tg_parser.mcp_server import list_topics
+
+        owner = await user_repo_for_scope.create_user("lt_unk")
+        user = _make_user(owner.id, allowed=["ch_a"])
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=user)):
+            result = await list_topics(workspace_id="00000000-0000-0000-0000-000000000999")
+        assert result.total == 0
+        assert result.items == []

--- a/tests/test_f4b_workspace_isolation.py
+++ b/tests/test_f4b_workspace_isolation.py
@@ -1,0 +1,199 @@
+"""F4-B Core — Phase 5 multi-user workspace isolation tests.
+
+Verifies that:
+
+* user A cannot see user B's workspaces via ``list_workspaces``;
+* user A passing user B's ``workspace_id`` through any scoped read tool
+  receives a 404-like empty response (no leak via differentiating error
+  messages — see Q2 edge case 2 of the start prompt);
+* admin can see every workspace through ``list_all_workspaces`` but
+  non-admin callers get an empty list, not 403;
+* deleting user A's workspace does not affect user B's parallel workspaces.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+def _make_user(
+    user_id: str,
+    *,
+    name: str = "user",
+    role: str = "user",
+    allowed: list[str] | None = None,
+) -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else (allowed or []),
+        max_channels=10,
+    )
+
+
+@pytest.fixture
+async def _iso_db(test_db):
+    return test_db
+
+
+@pytest.fixture
+async def user_repo_for_iso(_iso_db):
+    session = _iso_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _seed_source(test_db, source_id: str, channel_id: str, owner_id: str) -> None:
+    session = test_db.ingestion_state_session()
+    try:
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=source_id,
+                channel_id=channel_id,
+                status="active",
+                include_comments=False,
+                fail_count=0,
+                comments_unavailable=False,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                owner_id=owner_id,
+            )
+        )
+    finally:
+        await session.close()
+
+
+@pg_only
+class TestWorkspaceCrossUserIsolation:
+    async def test_list_workspaces_does_not_leak_other_users(self, _iso_db, user_repo_for_iso):
+        from tg_parser.mcp_server import create_workspace, list_workspaces
+
+        alice = await user_repo_for_iso.create_user("alice_iso_list")
+        bob = await user_repo_for_iso.create_user("bob_iso_list")
+        alice_user = _make_user(alice.id)
+        bob_user = _make_user(bob.id)
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_iso_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await list_workspaces()
+        assert {ws.name for ws in result.workspaces} == set()
+
+    async def test_foreign_workspace_id_via_search_returns_empty_no_leak(
+        self, _iso_db, user_repo_for_iso
+    ):
+        """Cross-user workspace_id MUST look identical to an unknown UUID."""
+        from tg_parser.mcp_server import create_workspace, search_knowledge_base
+
+        alice = await user_repo_for_iso.create_user("alice_iso_search")
+        bob = await user_repo_for_iso.create_user("bob_iso_search")
+        alice_user = _make_user(alice.id, allowed=["ch_x"])
+        bob_user = _make_user(bob.id, allowed=["ch_x"])
+        await _seed_source(_iso_db, "tg:src_iso", "ch_x", alice.id)
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            ws = (await create_workspace(name="alice_iso_search_ws")).workspace
+
+        search_mock = AsyncMock()
+        with (
+            patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)),
+            patch("tg_parser.services.retrieval_service.search", search_mock),
+        ):
+            results = await search_knowledge_base(query="x", workspace_id=ws.id)
+
+        assert results == []
+        search_mock.assert_not_called()
+
+    async def test_foreign_workspace_id_via_list_topics_returns_empty(
+        self, _iso_db, user_repo_for_iso
+    ):
+        from tg_parser.mcp_server import create_workspace, list_topics
+
+        alice = await user_repo_for_iso.create_user("alice_iso_lt")
+        bob = await user_repo_for_iso.create_user("bob_iso_lt")
+        alice_user = _make_user(alice.id)
+        bob_user = _make_user(bob.id, allowed=["ch_z"])
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            ws = (await create_workspace(name="alice_iso_lt_ws")).workspace
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await list_topics(workspace_id=ws.id)
+        assert result.total == 0
+        assert result.items == []
+
+    async def test_admin_sees_every_workspace_via_list_all(self, _iso_db, user_repo_for_iso):
+        from tg_parser.mcp_server import create_workspace, list_all_workspaces
+
+        alice = await user_repo_for_iso.create_user("alice_iso_admin")
+        bob = await user_repo_for_iso.create_user("bob_iso_admin")
+        alice_user = _make_user(alice.id)
+        bob_user = _make_user(bob.id)
+        admin = _make_user(alice.id, role="admin")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_iso_admin_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            await create_workspace(name="bob_iso_admin_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=admin)):
+            result = await list_all_workspaces()
+
+        names = {ws.name for ws in result.workspaces}
+        assert "alice_iso_admin_ws" in names
+        assert "bob_iso_admin_ws" in names
+
+    async def test_non_admin_list_all_returns_empty_not_403(self, _iso_db, user_repo_for_iso):
+        from tg_parser.mcp_server import create_workspace, list_all_workspaces
+
+        alice = await user_repo_for_iso.create_user("alice_iso_403")
+        bob = await user_repo_for_iso.create_user("bob_iso_403")
+        alice_user = _make_user(alice.id)
+        bob_user = _make_user(bob.id)
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await create_workspace(name="alice_iso_403_ws")
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await list_all_workspaces()
+        assert result.count == 0
+
+    async def test_delete_workspace_does_not_affect_other_user(self, _iso_db, user_repo_for_iso):
+        from tg_parser.mcp_server import (
+            create_workspace,
+            delete_workspace,
+            list_workspaces,
+        )
+
+        alice = await user_repo_for_iso.create_user("alice_iso_del")
+        bob = await user_repo_for_iso.create_user("bob_iso_del")
+        alice_user = _make_user(alice.id)
+        bob_user = _make_user(bob.id)
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            alice_ws = (await create_workspace(name="alice_iso_del_ws")).workspace
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            await create_workspace(name="bob_iso_del_ws")
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=alice_user)):
+            await delete_workspace(workspace_id=alice_ws.id)
+
+        with patch("tg_parser.mcp_server.resolve_mcp_user", AsyncMock(return_value=bob_user)):
+            result = await list_workspaces()
+        assert {ws.name for ws in result.workspaces} == {"bob_iso_del_ws"}

--- a/tests/test_f4b_workspace_repo.py
+++ b/tests/test_f4b_workspace_repo.py
@@ -1,0 +1,220 @@
+"""F4-B Core — :class:`SAWorkspaceRepo` CRUD + idempotency suite (Phase 2)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+
+from tg_parser.storage.ports import Source
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+@pytest.fixture
+async def workspace_repo(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        yield SAWorkspaceRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def user_repo_for_ws(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _create_source(test_db, source_id: str, channel_id: str, owner_id: str) -> None:
+    """Insert a row into ``sources`` for FK-aware workspace_sources tests."""
+    session = test_db.ingestion_state_session()
+    try:
+        from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=source_id,
+                channel_id=channel_id,
+                status="active",
+                include_comments=False,
+                fail_count=0,
+                comments_unavailable=False,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                owner_id=owner_id,
+            )
+        )
+    finally:
+        await session.close()
+
+
+@pg_only
+class TestSAWorkspaceRepoCRUD:
+    async def test_create_returns_workspace_with_server_defaults(
+        self, workspace_repo, user_repo_for_ws
+    ):
+        owner = await user_repo_for_ws.create_user("alice")
+        ws = await workspace_repo.create(
+            owner_id=owner.id,
+            name="AI/ML",
+            description="Anthropic + OpenAI",
+        )
+        assert ws.id
+        assert ws.owner_id == owner.id
+        assert ws.name == "AI/ML"
+        assert ws.description == "Anthropic + OpenAI"
+        assert ws.created_at is not None
+        assert ws.updated_at is not None
+
+    async def test_get_returns_none_for_unknown(self, workspace_repo):
+        result = await workspace_repo.get(str(uuid.uuid4()))
+        assert result is None
+
+    async def test_unique_owner_name_blocks_duplicate(self, workspace_repo, user_repo_for_ws):
+        owner = await user_repo_for_ws.create_user("alice2")
+        await workspace_repo.create(owner_id=owner.id, name="dup")
+        with pytest.raises(Exception):  # noqa: B017
+            await workspace_repo.create(owner_id=owner.id, name="dup")
+
+    async def test_two_users_can_share_workspace_name(self, workspace_repo, user_repo_for_ws):
+        alice = await user_repo_for_ws.create_user("alice_share")
+        bob = await user_repo_for_ws.create_user("bob_share")
+        await workspace_repo.create(owner_id=alice.id, name="AI/ML")
+        await workspace_repo.create(owner_id=bob.id, name="AI/ML")
+        alice_ws = await workspace_repo.list_by_owner(alice.id)
+        bob_ws = await workspace_repo.list_by_owner(bob.id)
+        assert len(alice_ws) == 1
+        assert len(bob_ws) == 1
+
+    async def test_list_by_owner_filters_foreign_workspaces(self, workspace_repo, user_repo_for_ws):
+        alice = await user_repo_for_ws.create_user("alice_filter")
+        bob = await user_repo_for_ws.create_user("bob_filter")
+        await workspace_repo.create(owner_id=alice.id, name="alice_ws_1")
+        await workspace_repo.create(owner_id=alice.id, name="alice_ws_2")
+        await workspace_repo.create(owner_id=bob.id, name="bob_ws")
+        alice_ws = await workspace_repo.list_by_owner(alice.id)
+        assert {ws.name for ws in alice_ws} == {"alice_ws_1", "alice_ws_2"}
+
+    async def test_list_all_admin_returns_every_workspace(self, workspace_repo, user_repo_for_ws):
+        alice = await user_repo_for_ws.create_user("alice_all")
+        bob = await user_repo_for_ws.create_user("bob_all")
+        await workspace_repo.create(owner_id=alice.id, name="a")
+        await workspace_repo.create(owner_id=bob.id, name="b")
+        all_ws = await workspace_repo.list_all()
+        assert len(all_ws) >= 2
+
+    async def test_list_all_with_owner_filter(self, workspace_repo, user_repo_for_ws):
+        alice = await user_repo_for_ws.create_user("alice_lo")
+        bob = await user_repo_for_ws.create_user("bob_lo")
+        await workspace_repo.create(owner_id=alice.id, name="a1")
+        await workspace_repo.create(owner_id=alice.id, name="a2")
+        await workspace_repo.create(owner_id=bob.id, name="b1")
+        alice_only = await workspace_repo.list_all(owner_id=alice.id)
+        assert {ws.name for ws in alice_only} == {"a1", "a2"}
+
+    async def test_rename_returns_updated_row(self, workspace_repo, user_repo_for_ws):
+        owner = await user_repo_for_ws.create_user("alice_rn")
+        ws = await workspace_repo.create(owner_id=owner.id, name="old_name")
+        renamed = await workspace_repo.rename(ws.id, "new_name")
+        assert renamed is not None
+        assert renamed.id == ws.id
+        assert renamed.name == "new_name"
+
+    async def test_rename_unknown_returns_none(self, workspace_repo):
+        result = await workspace_repo.rename(str(uuid.uuid4()), "whatever")
+        assert result is None
+
+    async def test_delete_returns_true_if_existed(self, workspace_repo, user_repo_for_ws):
+        owner = await user_repo_for_ws.create_user("alice_del")
+        ws = await workspace_repo.create(owner_id=owner.id, name="trash")
+        existed = await workspace_repo.delete(ws.id)
+        assert existed is True
+        existed_again = await workspace_repo.delete(ws.id)
+        assert existed_again is False
+
+
+@pg_only
+class TestSAWorkspaceRepoMembership:
+    async def test_add_source_idempotent_returns_false_on_duplicate(
+        self, workspace_repo, user_repo_for_ws, test_db
+    ):
+        owner = await user_repo_for_ws.create_user("alice_add")
+        ws = await workspace_repo.create(owner_id=owner.id, name="add_ws")
+        await _create_source(test_db, "tg:src_add_1", "ch_add_1", owner.id)
+        inserted = await workspace_repo.add_source(ws.id, "tg:src_add_1")
+        assert inserted is True
+        again = await workspace_repo.add_source(ws.id, "tg:src_add_1")
+        assert again is False
+
+    async def test_remove_source_returns_true_if_existed(
+        self, workspace_repo, user_repo_for_ws, test_db
+    ):
+        owner = await user_repo_for_ws.create_user("alice_rm")
+        ws = await workspace_repo.create(owner_id=owner.id, name="rm_ws")
+        await _create_source(test_db, "tg:src_rm_1", "ch_rm_1", owner.id)
+        await workspace_repo.add_source(ws.id, "tg:src_rm_1")
+        removed = await workspace_repo.remove_source(ws.id, "tg:src_rm_1")
+        assert removed is True
+        again = await workspace_repo.remove_source(ws.id, "tg:src_rm_1")
+        assert again is False
+
+    async def test_list_source_ids_returns_sorted_set(
+        self, workspace_repo, user_repo_for_ws, test_db
+    ):
+        owner = await user_repo_for_ws.create_user("alice_ls")
+        ws = await workspace_repo.create(owner_id=owner.id, name="ls_ws")
+        await _create_source(test_db, "tg:b_src", "chB", owner.id)
+        await _create_source(test_db, "tg:a_src", "chA", owner.id)
+        await workspace_repo.add_source(ws.id, "tg:b_src")
+        await workspace_repo.add_source(ws.id, "tg:a_src")
+        sources = await workspace_repo.list_source_ids(ws.id)
+        assert sources == ["tg:a_src", "tg:b_src"]
+
+    async def test_list_channel_ids_joins_sources_and_skips_soft_deleted(
+        self, workspace_repo, user_repo_for_ws, test_db
+    ):
+        owner = await user_repo_for_ws.create_user("alice_ch")
+        ws = await workspace_repo.create(owner_id=owner.id, name="ch_ws")
+        await _create_source(test_db, "tg:src_active", "ch_active", owner.id)
+        await _create_source(test_db, "tg:src_dead", "ch_dead", owner.id)
+        await workspace_repo.add_source(ws.id, "tg:src_active")
+        await workspace_repo.add_source(ws.id, "tg:src_dead")
+
+        session = test_db.ingestion_state_session()
+        try:
+            await session.execute(
+                text("UPDATE sources SET deleted_at = NOW() WHERE source_id = :sid"),
+                {"sid": "tg:src_dead"},
+            )
+            await session.commit()
+        finally:
+            await session.close()
+
+        channels = await workspace_repo.list_channel_ids(ws.id)
+        assert channels == ["ch_active"]
+
+    async def test_same_source_in_multiple_workspaces_of_one_owner(
+        self, workspace_repo, user_repo_for_ws, test_db
+    ):
+        """Q5 = A: M2M shared inside one owner."""
+        owner = await user_repo_for_ws.create_user("alice_q5")
+        ws_a = await workspace_repo.create(owner_id=owner.id, name="AI")
+        ws_b = await workspace_repo.create(owner_id=owner.id, name="Product")
+        await _create_source(test_db, "tg:src_shared", "ch_shared", owner.id)
+        await workspace_repo.add_source(ws_a.id, "tg:src_shared")
+        await workspace_repo.add_source(ws_b.id, "tg:src_shared")
+        assert await workspace_repo.list_source_ids(ws_a.id) == ["tg:src_shared"]
+        assert await workspace_repo.list_source_ids(ws_b.id) == ["tg:src_shared"]

--- a/tests/test_f4b_workspace_repo.py
+++ b/tests/test_f4b_workspace_repo.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 from tg_parser.storage.ports import Source
 from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
@@ -84,20 +85,37 @@ class TestSAWorkspaceRepoCRUD:
         assert result is None
 
     async def test_unique_owner_name_blocks_duplicate(self, workspace_repo, user_repo_for_ws):
+        """Hidden gotcha § 6 — UNIQUE (owner_id, name) is enforced at the DB.
+
+        Tightened from bare ``Exception`` to :class:`IntegrityError` so a
+        future change that swallowed the constraint (e.g. ON CONFLICT DO
+        UPDATE that silently aliases the row) would still trip this test.
+        Also verifies the side-effect — only one workspace named ``dup``
+        remains for this owner. The repo session needs an explicit
+        rollback after the IntegrityError to clear the aborted-transaction
+        state before the follow-up ``list_by_owner`` query.
+        """
         owner = await user_repo_for_ws.create_user("alice2")
         await workspace_repo.create(owner_id=owner.id, name="dup")
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(IntegrityError):
             await workspace_repo.create(owner_id=owner.id, name="dup")
+        await workspace_repo.session.rollback()
+        rows = await workspace_repo.list_by_owner(owner.id)
+        assert [ws.name for ws in rows] == ["dup"]
 
     async def test_two_users_can_share_workspace_name(self, workspace_repo, user_repo_for_ws):
+        """Hidden gotcha § 6 — two different users can both have an "AI/ML" workspace."""
         alice = await user_repo_for_ws.create_user("alice_share")
         bob = await user_repo_for_ws.create_user("bob_share")
-        await workspace_repo.create(owner_id=alice.id, name="AI/ML")
-        await workspace_repo.create(owner_id=bob.id, name="AI/ML")
+        alice_ws_created = await workspace_repo.create(owner_id=alice.id, name="AI/ML")
+        bob_ws_created = await workspace_repo.create(owner_id=bob.id, name="AI/ML")
         alice_ws = await workspace_repo.list_by_owner(alice.id)
         bob_ws = await workspace_repo.list_by_owner(bob.id)
-        assert len(alice_ws) == 1
-        assert len(bob_ws) == 1
+        assert [ws.id for ws in alice_ws] == [alice_ws_created.id]
+        assert [ws.id for ws in bob_ws] == [bob_ws_created.id]
+        assert alice_ws[0].name == "AI/ML"
+        assert bob_ws[0].name == "AI/ML"
+        assert alice_ws[0].owner_id != bob_ws[0].owner_id
 
     async def test_list_by_owner_filters_foreign_workspaces(self, workspace_repo, user_repo_for_ws):
         alice = await user_repo_for_ws.create_user("alice_filter")

--- a/tests/test_f4b_workspace_service.py
+++ b/tests/test_f4b_workspace_service.py
@@ -1,0 +1,352 @@
+"""F4-B Core — :class:`WorkspaceService` tests (Phase 2).
+
+Covers the resolver matrix from
+``docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md`` § Q2/Q4:
+
+* ``workspace_id is None`` → F4-A behavior, no repo I/O.
+* Unknown workspace → :class:`WorkspaceNotFound`.
+* Foreign workspace (different owner, non-admin) → :class:`WorkspaceNotFound`.
+* Valid empty workspace → ``[]`` (NOT ``None``, NOT silent "all").
+* Valid + overlap → intersection list.
+* Admin (``allowed_channel_ids is None``) → workspace channel_ids verbatim.
+
+The Postgres-backed leg exercises CRUD + idempotent ``add_source`` /
+``remove_source`` through the service interface.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import (
+    PermissionDenied,
+    WorkspaceNotFound,
+)
+from tg_parser.domain.models import Workspace
+from tg_parser.services.workspace_service import WorkspaceService
+from tg_parser.storage.ports import Source, WorkspaceRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ============================================================================
+# Pure-logic resolver matrix (in-memory fake repo)
+# ============================================================================
+
+
+class _FakeWorkspaceRepo(WorkspaceRepo):
+    def __init__(
+        self,
+        workspaces: dict[str, Workspace],
+        channels_by_workspace: dict[str, list[str]],
+    ):
+        self._workspaces = workspaces
+        self._channels = channels_by_workspace
+        self.list_channel_ids_calls = 0
+
+    async def get(self, workspace_id: str) -> Workspace | None:
+        return self._workspaces.get(workspace_id)
+
+    async def create(self, **_kw: Any) -> Workspace:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list_by_owner(self, owner_id: str) -> list[Workspace]:
+        return [ws for ws in self._workspaces.values() if ws.owner_id == owner_id]
+
+    async def list_all(self, owner_id: str | None = None) -> list[Workspace]:
+        rows = list(self._workspaces.values())
+        if owner_id is None:
+            return rows
+        return [ws for ws in rows if ws.owner_id == owner_id]
+
+    async def rename(
+        self, workspace_id: str, new_name: str
+    ) -> Workspace | None:  # pragma: no cover
+        ws = self._workspaces.get(workspace_id)
+        if ws is None:
+            return None
+        renamed = Workspace(
+            id=ws.id,
+            owner_id=ws.owner_id,
+            name=new_name,
+            description=ws.description,
+        )
+        self._workspaces[workspace_id] = renamed
+        return renamed
+
+    async def delete(self, workspace_id: str) -> bool:
+        return self._workspaces.pop(workspace_id, None) is not None
+
+    async def add_source(
+        self,
+        workspace_id: str,
+        source_id: str,
+    ) -> bool:
+        members = self._channels.setdefault(workspace_id, [])
+        if source_id in members:
+            return False
+        members.append(source_id)
+        return True
+
+    async def remove_source(self, workspace_id: str, source_id: str) -> bool:
+        members = self._channels.get(workspace_id, [])
+        if source_id not in members:
+            return False
+        members.remove(source_id)
+        return True
+
+    async def list_source_ids(self, workspace_id: str) -> list[str]:
+        return list(self._channels.get(workspace_id, []))
+
+    async def list_channel_ids(self, workspace_id: str) -> list[str]:
+        self.list_channel_ids_calls += 1
+        return list(self._channels.get(workspace_id, []))
+
+    async def resolve_source_id_for_channel(
+        self,
+        *,
+        owner_id: str | None,  # noqa: ARG002
+        channel_id: str,
+    ) -> str | None:
+        return channel_id
+
+
+def _make_user(
+    *,
+    user_id: str | None = None,
+    role: str = "user",
+    allowed: list[str] | None = None,
+) -> CurrentUser:
+    return CurrentUser(
+        id=user_id or str(uuid.uuid4()),
+        name="alice",
+        role=role,
+        allowed_channel_ids=allowed if role != "admin" else None,
+        max_channels=10,
+    )
+
+
+def _make_workspace(owner_id: str, name: str = "ws") -> Workspace:
+    return Workspace(
+        id=str(uuid.uuid4()),
+        owner_id=owner_id,
+        name=name,
+    )
+
+
+class TestEffectiveChannelIdsResolver:
+    async def test_none_workspace_returns_user_allowed_channel_ids(self) -> None:
+        user = _make_user(allowed=["ch1", "ch2"])
+        repo = _FakeWorkspaceRepo({}, {})
+        service = WorkspaceService(repo)
+        result = await service.effective_channel_ids(user, None)
+        assert result == ["ch1", "ch2"]
+        assert repo.list_channel_ids_calls == 0  # no repo I/O on F4-A fallback
+
+    async def test_unknown_workspace_raises_not_found(self) -> None:
+        user = _make_user(allowed=["ch1"])
+        repo = _FakeWorkspaceRepo({}, {})
+        service = WorkspaceService(repo)
+        with pytest.raises(WorkspaceNotFound):
+            await service.effective_channel_ids(user, str(uuid.uuid4()))
+
+    async def test_foreign_workspace_raises_not_found(self) -> None:
+        owner_id = str(uuid.uuid4())
+        other_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        user = _make_user(user_id=other_id, allowed=["ch1"])
+        repo = _FakeWorkspaceRepo({ws.id: ws}, {ws.id: ["ch1"]})
+        service = WorkspaceService(repo)
+        with pytest.raises(WorkspaceNotFound):
+            await service.effective_channel_ids(user, ws.id)
+
+    async def test_empty_workspace_returns_explicit_empty_not_none(self) -> None:
+        owner_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        user = _make_user(user_id=owner_id, allowed=["ch1", "ch2"])
+        repo = _FakeWorkspaceRepo({ws.id: ws}, {ws.id: []})
+        service = WorkspaceService(repo)
+        result = await service.effective_channel_ids(user, ws.id)
+        assert result == []
+        assert result is not None  # hidden gotcha § 3: NOT silent fallback
+
+    async def test_intersection_filters_out_non_owned_channels(self) -> None:
+        owner_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        user = _make_user(user_id=owner_id, allowed=["ch1", "ch2"])
+        repo = _FakeWorkspaceRepo({ws.id: ws}, {ws.id: ["ch1", "ch_foreign"]})
+        service = WorkspaceService(repo)
+        result = await service.effective_channel_ids(user, ws.id)
+        assert result == ["ch1"]
+
+    async def test_admin_returns_workspace_channels_verbatim(self) -> None:
+        owner_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        admin = _make_user(role="admin")
+        repo = _FakeWorkspaceRepo({ws.id: ws}, {ws.id: ["ch1", "ch2"]})
+        service = WorkspaceService(repo)
+        result = await service.effective_channel_ids(admin, ws.id)
+        assert result == ["ch1", "ch2"]
+
+
+class TestServiceCreateAndOwnership:
+    async def test_create_strips_name(self) -> None:
+        owner_id = str(uuid.uuid4())
+        user = _make_user(user_id=owner_id, allowed=[])
+
+        captured: dict[str, Any] = {}
+
+        class _StubRepo(_FakeWorkspaceRepo):
+            async def create(  # type: ignore[override]
+                self,
+                *,
+                owner_id: str,
+                name: str,
+                description: str | None = None,
+            ) -> Workspace:
+                captured["name"] = name
+                captured["owner_id"] = owner_id
+                return Workspace(
+                    id=str(uuid.uuid4()),
+                    owner_id=owner_id,
+                    name=name,
+                    description=description,
+                )
+
+        service = WorkspaceService(_StubRepo({}, {}))
+        await service.create_workspace(user, name="  AI/ML  ")
+        assert captured["name"] == "AI/ML"
+        assert captured["owner_id"] == owner_id
+
+    async def test_create_rejects_blank_name(self) -> None:
+        user = _make_user(allowed=[])
+        service = WorkspaceService(_FakeWorkspaceRepo({}, {}))
+        with pytest.raises(ValueError):
+            await service.create_workspace(user, name="   ")
+
+    async def test_list_all_workspaces_requires_admin(self) -> None:
+        user = _make_user(allowed=[])
+        service = WorkspaceService(_FakeWorkspaceRepo({}, {}))
+        with pytest.raises(PermissionDenied):
+            await service.list_all_workspaces(user)
+
+    async def test_admin_can_list_all(self) -> None:
+        admin = _make_user(role="admin")
+        owner_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        service = WorkspaceService(_FakeWorkspaceRepo({ws.id: ws}, {}))
+        result = await service.list_all_workspaces(admin)
+        assert len(result) == 1
+
+    async def test_add_source_requires_user_channel_access(self) -> None:
+        owner_id = str(uuid.uuid4())
+        ws = _make_workspace(owner_id)
+        user = _make_user(user_id=owner_id, allowed=["ch_ok"])
+        repo = _FakeWorkspaceRepo({ws.id: ws}, {})
+        service = WorkspaceService(repo)
+        with pytest.raises(PermissionDenied):
+            await service.add_source(user, ws.id, "ch_foreign")
+
+
+# ============================================================================
+# Postgres integration legs
+# ============================================================================
+
+
+@pytest.fixture
+async def workspace_service_pg(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        yield WorkspaceService(SAWorkspaceRepo(session)), test_db
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def user_repo_pg(test_db):
+    session = test_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _create_source(test_db, source_id: str, channel_id: str, owner_id: str) -> None:
+    session = test_db.ingestion_state_session()
+    try:
+        from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
+
+        repo = SAIngestionStateRepo(session)
+        await repo.upsert_source(
+            Source(
+                source_id=source_id,
+                channel_id=channel_id,
+                status="active",
+                include_comments=False,
+                fail_count=0,
+                comments_unavailable=False,
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                owner_id=owner_id,
+            )
+        )
+    finally:
+        await session.close()
+
+
+@pg_only
+class TestWorkspaceServicePostgresE2E:
+    async def test_create_get_rename_delete_roundtrip(self, workspace_service_pg, user_repo_pg):
+        service, _ = workspace_service_pg
+        db_user = await user_repo_pg.create_user("alice_svc")
+        user = CurrentUser(
+            id=db_user.id,
+            name="alice",
+            role="user",
+            allowed_channel_ids=[],
+            max_channels=10,
+        )
+        ws = await service.create_workspace(user, name="AI/ML", description="desc")
+        assert ws.name == "AI/ML"
+        fetched = await service.get_workspace(user, ws.id)
+        assert fetched.id == ws.id
+        renamed = await service.rename_workspace(user, ws.id, "AI")
+        assert renamed.name == "AI"
+        existed = await service.delete_workspace(user, ws.id)
+        assert existed is True
+        with pytest.raises(WorkspaceNotFound):
+            await service.get_workspace(user, ws.id)
+
+    async def test_effective_channel_ids_e2e_intersection(
+        self,
+        workspace_service_pg,
+        user_repo_pg,
+    ):
+        service, db = workspace_service_pg
+        db_user = await user_repo_pg.create_user("alice_ec")
+        await _create_source(db, "tg:ch_owned_a", "ch_owned_a", db_user.id)
+        await _create_source(db, "tg:ch_owned_b", "ch_owned_b", db_user.id)
+        user = CurrentUser(
+            id=db_user.id,
+            name="alice",
+            role="user",
+            allowed_channel_ids=["ch_owned_a", "ch_owned_b"],
+            max_channels=10,
+        )
+        ws = await service.create_workspace(user, name="ec_ws")
+        await service.add_source(user, ws.id, "ch_owned_a")
+        effective = await service.effective_channel_ids(user, ws.id)
+        assert effective == ["ch_owned_a"]
+        none_effective = await service.effective_channel_ids(user, None)
+        assert none_effective == user.allowed_channel_ids

--- a/tests/test_f4b_workspace_service.py
+++ b/tests/test_f4b_workspace_service.py
@@ -260,6 +260,73 @@ class TestServiceCreateAndOwnership:
 
 
 # ============================================================================
+# Hidden gotcha § 4 / Q4 R2 — move = non-atomic remove + add
+# ============================================================================
+
+
+class TestMoveSourceComposition:
+    """Hidden gotcha § 4 of the start prompt: ``move_workspace_source`` is NOT
+    a single atomic operation in MVP — clients compose ``remove_source`` +
+    ``add_source``. These tests pin the *compositional* contract so that a
+    future drift in either primitive (e.g. silently turning ``remove_source``
+    into a no-op while leaving the M2M row in place) cannot pass review."""
+
+    async def _make_service_with_two_workspaces(
+        self,
+    ) -> tuple[WorkspaceService, CurrentUser, Workspace, Workspace, _FakeWorkspaceRepo]:
+        owner_id = str(uuid.uuid4())
+        ws_a = _make_workspace(owner_id, name="src_ws")
+        ws_b = _make_workspace(owner_id, name="dst_ws")
+        user = _make_user(user_id=owner_id, allowed=["ch_move"])
+        repo = _FakeWorkspaceRepo(
+            {ws_a.id: ws_a, ws_b.id: ws_b},
+            {ws_a.id: ["ch_move"], ws_b.id: []},
+        )
+        return WorkspaceService(repo), user, ws_a, ws_b, repo
+
+    async def test_remove_then_add_moves_channel_between_workspaces(self) -> None:
+        """After ``remove_source(A) + add_source(B)`` channel must be only in B."""
+        svc, user, ws_a, ws_b, repo = await self._make_service_with_two_workspaces()
+
+        assert await svc.list_workspace_sources(user, ws_a.id) == ["ch_move"]
+        assert await svc.list_workspace_sources(user, ws_b.id) == []
+
+        removed = await svc.remove_source(user, ws_a.id, "ch_move")
+        assert removed is True
+        inserted = await svc.add_source(user, ws_b.id, "ch_move")
+        assert inserted is True
+
+        assert await svc.list_workspace_sources(user, ws_a.id) == []
+        assert await svc.list_workspace_sources(user, ws_b.id) == ["ch_move"]
+
+    async def test_gap_window_makes_channel_invisible_in_both_workspaces(self) -> None:
+        """Between the two calls the channel is in **neither** workspace.
+
+        Pin this — it's the documented non-atomicity (Q4 R2 / O-1). If a
+        future change accidentally introduced an atomic move, this test
+        would fail and the contract would need to be re-evaluated (and the
+        documentation in ``add_workspace_source`` + MCP descriptions
+        updated).
+        """
+        svc, user, ws_a, ws_b, _ = await self._make_service_with_two_workspaces()
+        await svc.remove_source(user, ws_a.id, "ch_move")
+        assert await svc.list_workspace_sources(user, ws_a.id) == []
+        assert await svc.list_workspace_sources(user, ws_b.id) == []
+
+    async def test_effective_channel_ids_observes_move(self) -> None:
+        """End-to-end: resolver flips the effective scope after a move."""
+        svc, user, ws_a, ws_b, _ = await self._make_service_with_two_workspaces()
+        assert await svc.effective_channel_ids(user, ws_a.id) == ["ch_move"]
+        assert await svc.effective_channel_ids(user, ws_b.id) == []
+
+        await svc.remove_source(user, ws_a.id, "ch_move")
+        await svc.add_source(user, ws_b.id, "ch_move")
+
+        assert await svc.effective_channel_ids(user, ws_a.id) == []
+        assert await svc.effective_channel_ids(user, ws_b.id) == ["ch_move"]
+
+
+# ============================================================================
 # Postgres integration legs
 # ============================================================================
 

--- a/tests/test_migrations_runtime_upgrade.py
+++ b/tests/test_migrations_runtime_upgrade.py
@@ -58,6 +58,8 @@ EXPECTED_TABLES: dict[str, set[str]] = {
         "digest_subscriptions",
         "watch_interests",
         "watch_matches",
+        "workspaces",
+        "workspace_sources",
         "alembic_version_ingestion",
     },
     "raw": {

--- a/tg_parser/api/metrics.py
+++ b/tg_parser/api/metrics.py
@@ -541,3 +541,108 @@ def record_bot_gemini_empty_parts(*, model: str, finish_reason: str) -> None:
         model=model or "unknown",
         finish_reason=finish_reason or "none",
     ).inc()
+
+
+# F4-B Core Workspaces — Karpathy 7-checklist principle 6 (observability)
+#
+# Cardinality notes:
+# * ``tg_workspace_total`` is a Gauge without labels — single global
+#   counter incremented on create, decremented on delete. ``owner_id``
+#   is intentionally *not* used as a label (would be unbounded).
+# * ``tg_workspace_query_total`` ``result`` ∈ {scoped, null_fallback,
+#   not_found}; cardinality fixed at 3.
+# * ``tg_workspace_tool_total`` ``tool`` ∈ the 8 scoped MCP tools +
+#   8 workspace CRUD/membership tools = bounded at 16; ``result`` ∈
+#   {ok, not_found, denied, validation_error}.
+WORKSPACE_TOTAL = Gauge(
+    "tg_workspace_total",
+    "Currently existing workspaces across all tenants.",
+)
+
+WORKSPACE_SIZE = Histogram(
+    "tg_workspace_size",
+    "Number of channels (workspace_sources rows) per workspace at resolve time.",
+    buckets=(0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144),
+)
+
+WORKSPACE_QUERY_TOTAL = Counter(
+    "tg_workspace_query_total",
+    "effective_channel_ids resolver outcomes.",
+    ["result"],
+)
+
+WORKSPACE_EFFECTIVE_SIZE = Histogram(
+    "tg_workspace_effective_size",
+    "Size of the intersection (user.allowed_channel_ids ∩ workspace.channel_ids).",
+    buckets=(0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144),
+)
+
+WORKSPACE_RESOLVER_SECONDS = Histogram(
+    "tg_workspace_resolver_seconds",
+    "End-to-end latency of WorkspaceService.effective_channel_ids in seconds.",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
+)
+
+WORKSPACE_TOOL_TOTAL = Counter(
+    "tg_workspace_tool_total",
+    "Per-tool usage counter for MCP/CLI workspace surface.",
+    ["tool", "result"],
+)
+
+
+def record_workspace_query(
+    *,
+    result: str,
+    effective_size: int | None = None,
+    workspace_size: int | None = None,
+    duration_s: float | None = None,
+) -> None:
+    """Record one ``effective_channel_ids`` resolver outcome.
+
+    ``result`` ∈ {``scoped``, ``null_fallback``, ``not_found``}:
+
+    * ``scoped`` — caller passed a valid ``workspace_id``; ``effective_size``
+      and ``workspace_size`` carry the intersection / membership counts.
+    * ``null_fallback`` — ``workspace_id=None`` short-circuited to
+      ``user.allowed_channel_ids`` (F4-A behaviour, no repo I/O).
+    * ``not_found`` — workspace did not exist or was not owned by the
+      caller; resolver raised ``WorkspaceNotFound``.
+    """
+    WORKSPACE_QUERY_TOTAL.labels(result=result).inc()
+    if effective_size is not None:
+        WORKSPACE_EFFECTIVE_SIZE.observe(max(effective_size, 0))
+    if workspace_size is not None:
+        WORKSPACE_SIZE.observe(max(workspace_size, 0))
+    if duration_s is not None and duration_s >= 0:
+        WORKSPACE_RESOLVER_SECONDS.observe(duration_s)
+
+
+def record_workspace_tool(*, tool: str, result: str) -> None:
+    """Record one MCP/CLI workspace-tool invocation outcome.
+
+    ``tool`` is the public tool name (e.g. ``create_workspace``,
+    ``search_knowledge_base``); ``result`` ∈ {``ok``, ``not_found``,
+    ``denied``, ``validation_error``}.
+    """
+    WORKSPACE_TOOL_TOTAL.labels(tool=tool, result=result).inc()
+
+
+def set_workspace_total(count: int) -> None:
+    """Set the global ``tg_workspace_total`` gauge.
+
+    Refreshed by ``WorkspaceService.list_all_workspaces`` and on every
+    create / delete via :func:`bump_workspace_total`.
+    """
+    WORKSPACE_TOTAL.set(max(count, 0))
+
+
+def bump_workspace_total(delta: int) -> None:
+    """Increment / decrement the workspace gauge by ``delta``.
+
+    Used by create / delete paths so the gauge stays in sync without a
+    full refresh sweep on every mutation.
+    """
+    if delta > 0:
+        WORKSPACE_TOTAL.inc(delta)
+    elif delta < 0:
+        WORKSPACE_TOTAL.dec(-delta)

--- a/tg_parser/auth/ownership.py
+++ b/tg_parser/auth/ownership.py
@@ -4,13 +4,34 @@ Ownership and permission helpers for F4 Multi-Tenancy (Phase 3).
 Centralizes ownership checks used by API, Bot, and MCP layers.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from tg_parser.auth.models import CurrentUser
+
+if TYPE_CHECKING:
+    from tg_parser.domain.models import Workspace
+    from tg_parser.storage.ports import WorkspaceRepo
 
 
 class PermissionDenied(Exception):
     """Raised when user lacks required permission."""
 
     def __init__(self, message: str = "Permission denied"):
+        self.message = message
+        super().__init__(message)
+
+
+class WorkspaceNotFound(Exception):
+    """Raised when a workspace cannot be found OR cannot be accessed by the caller.
+
+    F4-B Core Q2 edge case 2: foreign / unknown workspace_ids share the
+    same exception class so that error responses never leak the existence
+    of a workspace owned by another user (404-like semantics, not 403).
+    """
+
+    def __init__(self, message: str = "Workspace not found"):
         self.message = message
         super().__init__(message)
 
@@ -44,6 +65,33 @@ async def assert_topic_access(user: CurrentUser, topic_sources: list[str]) -> No
         return
     if not any(src in user.allowed_channel_ids for src in topic_sources):
         raise PermissionDenied(f"No access to topic with sources={topic_sources}")
+
+
+async def assert_workspace_access(
+    user: CurrentUser,
+    workspace_id: str,
+    *,
+    repo: WorkspaceRepo,
+) -> Workspace:
+    """Raise :class:`WorkspaceNotFound` unless the user can access the workspace.
+
+    F4-B Core ownership boundary:
+
+    * Admin (``user.is_admin``) passes through to ANY workspace (parity with
+      F4-A: admin sees everything).
+    * Non-admin: workspace must exist AND ``workspace.owner_id == user.id``.
+      Both ``missing`` and ``foreign`` map to :class:`WorkspaceNotFound`
+      (Q2 edge case 2 — 404-like, never leak existence as a hard 403).
+
+    Returns the loaded :class:`Workspace` on success so that callers can
+    avoid a second ``repo.get`` round-trip.
+    """
+    workspace = await repo.get(workspace_id)
+    if workspace is None:
+        raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+    if not user.is_admin and workspace.owner_id != user.id:
+        raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+    return workspace
 
 
 def assert_admin(user: CurrentUser) -> None:

--- a/tg_parser/cli/app.py
+++ b/tg_parser/cli/app.py
@@ -11,6 +11,7 @@ from tg_parser.cli.db_cmd import app as db_app
 from tg_parser.cli.scheduler_cmd import app as scheduler_app
 from tg_parser.cli.topic_cmd import app as topic_app
 from tg_parser.cli.watchlist_cmd import app as watchlist_app
+from tg_parser.cli.workspace_cmd import app as workspace_app
 
 app = typer.Typer(
     name="tg_parser",
@@ -23,6 +24,7 @@ app.add_typer(db_app, name="db")
 app.add_typer(scheduler_app, name="scheduler")
 app.add_typer(topic_app, name="topic")
 app.add_typer(watchlist_app, name="watchlist")
+app.add_typer(workspace_app, name="workspace")
 
 
 @app.command()

--- a/tg_parser/cli/app.py
+++ b/tg_parser/cli/app.py
@@ -611,11 +611,51 @@ def embed(
         raise typer.Exit(code=1) from e
 
 
+async def _resolve_workspace_scope_cli(
+    user_arg: str | None,
+    workspace_id: str | None,
+) -> tuple[list[str] | None, bool]:
+    """CLI helper — resolve ``--user`` + ``--workspace-id`` to scope.
+
+    Returns ``(effective_channel_ids, ok)``. ``ok`` is ``False`` when the
+    workspace is unknown / foreign (caller prints a friendly message and
+    exits without dumping a stack trace).
+    """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+    from tg_parser.cli.workspace_cmd import _resolve_acting_user
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    if workspace_id is None and user_arg is None:
+        return None, True
+
+    acting = await _resolve_acting_user(user_arg)
+    if workspace_id is None:
+        return acting.allowed_channel_ids, True
+
+    async with workspace_repo() as (repo, _db):
+        service = WorkspaceService(repo)
+        try:
+            return await service.effective_channel_ids(acting, workspace_id), True
+        except WorkspaceNotFound:
+            return None, False
+
+
 @app.command()
 def search(
     query: str = typer.Option(..., help="Поисковый запрос"),
     channel: str = typer.Option(None, help="Фильтр по каналу"),
     limit: int = typer.Option(10, help="Количество результатов"),
+    workspace_id: str = typer.Option(
+        None,
+        "--workspace-id",
+        help="F4-B: narrow search scope to channels in this workspace",
+    ),
+    user: str = typer.Option(
+        None,
+        "--user",
+        help="Act as this user UUID (required if --workspace-id is set)",
+    ),
 ):
     """
     Семантический поиск по embedded документам (P5 RAG).
@@ -625,11 +665,25 @@ def search(
     typer.echo(f'🔍 Поиск: "{query}"\n')
     if channel:
         typer.echo(f"   Фильтр: канал={channel}")
+    if workspace_id:
+        typer.echo(f"   Workspace: {workspace_id}")
 
     try:
+        effective, ok = asyncio.run(_resolve_workspace_scope_cli(user, workspace_id))
+        if not ok:
+            typer.echo("\n⚠️  Workspace не найден")
+            raise typer.Exit(code=1)
+
         from tg_parser.services.retrieval_service import search as do_search
 
-        results = asyncio.run(do_search(query=query, channel_id=channel, limit=limit))
+        results = asyncio.run(
+            do_search(
+                query=query,
+                channel_id=channel,
+                limit=limit,
+                allowed_channel_ids=effective,
+            )
+        )
 
         if not results:
             typer.echo("\n⚠️  Ничего не найдено")
@@ -645,6 +699,8 @@ def search(
                 typer.echo(f"      {title[:120]}")
             typer.echo()
 
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"\n❌ Ошибка: {e}", err=True)
         raise typer.Exit(code=1) from e
@@ -654,6 +710,16 @@ def search(
 def ask(
     question: str = typer.Option(..., help="Вопрос на естественном языке"),
     channel: str = typer.Option(None, help="Фильтр по каналу"),
+    workspace_id: str = typer.Option(
+        None,
+        "--workspace-id",
+        help="F4-B: narrow retrieval scope to channels in this workspace",
+    ),
+    user: str = typer.Option(
+        None,
+        "--user",
+        help="Act as this user UUID (required if --workspace-id is set)",
+    ),
 ):
     """
     Q&A по содержимому каналов с использованием RAG (P5).
@@ -663,11 +729,24 @@ def ask(
     typer.echo(f'❓ Вопрос: "{question}"\n')
     if channel:
         typer.echo(f"   Фильтр: канал={channel}")
+    if workspace_id:
+        typer.echo(f"   Workspace: {workspace_id}")
 
     try:
+        effective, ok = asyncio.run(_resolve_workspace_scope_cli(user, workspace_id))
+        if not ok:
+            typer.echo("\n⚠️  Workspace не найден")
+            raise typer.Exit(code=1)
+
         from tg_parser.services.retrieval_service import answer as do_answer
 
-        result = asyncio.run(do_answer(question=question, channel_id=channel))
+        result = asyncio.run(
+            do_answer(
+                question=question,
+                channel_id=channel,
+                allowed_channel_ids=effective,
+            )
+        )
 
         typer.echo("\n💬 Ответ:\n")
         typer.echo(result.answer)
@@ -681,6 +760,8 @@ def ask(
         if result.model:
             typer.echo(f"\n🤖 Model: {result.model}")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"\n❌ Ошибка: {e}", err=True)
         raise typer.Exit(code=1) from e

--- a/tg_parser/cli/workspace_cmd.py
+++ b/tg_parser/cli/workspace_cmd.py
@@ -1,0 +1,380 @@
+"""CLI for F4-B Core Workspaces.
+
+Mirrors the MCP surface for power users + on-call ops:
+
+    tg-parser workspace list
+    tg-parser workspace create --name "AI/ML" --description "Anthropic, OpenAI"
+    tg-parser workspace rename <ws_id> "new name"
+    tg-parser workspace delete <ws_id>
+    tg-parser workspace add-source <ws_id> --channel <channel_id>
+    tg-parser workspace remove-source <ws_id> --channel <channel_id>
+    tg-parser workspace list-sources <ws_id>
+    tg-parser workspace list-all [--owner-id <user_id>]   # admin only
+
+Notes
+-----
+``--user <uuid>`` is the F4-A convention for "act on behalf of this user"
+(default: system admin) — same shape as :mod:`watchlist_cmd`. Move between
+workspaces = ``remove-source`` + ``add-source`` (non-atomic — O-1
+deferred to Wave 1 step 3 / Wave 2).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import typer
+
+app = typer.Typer(
+    name="workspace",
+    help="Manage F4-B workspaces (thematic channel collections).",
+)
+
+
+async def _resolve_acting_user(user_arg: str | None) -> Any:
+    """Return the ``CurrentUser`` to act as (mirror of watchlist_cmd helper)."""
+    from tg_parser.auth.models import CurrentUser
+    from tg_parser.auth.resolvers import get_default_admin
+    from tg_parser.config import settings as app_settings
+    from tg_parser.services.db_context import user_repo
+
+    if not user_arg:
+        return await get_default_admin()
+    async with user_repo() as (repo, _db):
+        user = await repo.get_by_id(user_arg)
+    if user is None:
+        raise typer.BadParameter(f"user {user_arg!r} not found")
+    allowed: list[str] | None
+    if user.role == "admin":
+        allowed = None
+    else:
+        async with user_repo() as (repo2, _db2):
+            allowed = await repo2.get_owned_channel_ids(user.id)
+    return CurrentUser(
+        id=user.id,
+        name=user.name,
+        role=user.role,
+        allowed_channel_ids=allowed,
+        max_channels=user.max_channels
+        if user.max_channels is not None
+        else app_settings.default_max_channels,
+    )
+
+
+def _print_workspace(ws: Any) -> None:
+    typer.echo(f"  • {ws.id}")
+    typer.echo(f"      name:        {ws.name}")
+    typer.echo(f"      owner_id:    {ws.owner_id}")
+    if ws.description:
+        typer.echo(f"      description: {ws.description}")
+    if ws.created_at:
+        created_str = (
+            ws.created_at.isoformat() if hasattr(ws.created_at, "isoformat") else str(ws.created_at)
+        )
+        typer.echo(f"      created_at:  {created_str}")
+
+
+@app.command("list")
+def list_workspaces(
+    user: str = typer.Option(
+        None,
+        "--user",
+        help="UUID of the user to list workspaces for (default: caller / admin)",
+    ),
+) -> None:
+    """List workspaces owned by ``--user`` (or by the default admin)."""
+
+    async def _run() -> list[Any]:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.list_workspaces(acting)
+        finally:
+            await Database.close_instance()
+
+    try:
+        workspaces = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if not workspaces:
+        typer.echo("⚠️  Workspaces not found")
+        return
+
+    typer.echo(f"📁 Workspaces ({len(workspaces)}):\n")
+    for ws in workspaces:
+        _print_workspace(ws)
+        typer.echo()
+
+
+@app.command("create")
+def create_workspace(
+    name: str = typer.Option(..., "--name", help="Workspace name (unique per owner)"),
+    description: str = typer.Option(
+        "",
+        "--description",
+        help="Optional free-form description",
+    ),
+    user: str = typer.Option(
+        None,
+        "--user",
+        help="UUID of the owner (default: admin)",
+    ),
+) -> None:
+    """Create a new workspace."""
+    description_arg = description.strip() or None
+
+    async def _run() -> Any:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.create_workspace(
+                    acting,
+                    name=name,
+                    description=description_arg,
+                )
+        finally:
+            await Database.close_instance()
+
+    try:
+        ws = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo("✅ Workspace создан:")
+    _print_workspace(ws)
+
+
+@app.command("rename")
+def rename_workspace(
+    workspace_id: str = typer.Argument(..., help="Workspace UUID to rename"),
+    new_name: str = typer.Argument(..., help="New name (unique per owner)"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """Rename a workspace."""
+
+    async def _run() -> Any:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.rename_workspace(acting, workspace_id, new_name)
+        finally:
+            await Database.close_instance()
+
+    try:
+        ws = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo("✅ Workspace renamed:")
+    _print_workspace(ws)
+
+
+@app.command("delete")
+def delete_workspace(
+    workspace_id: str = typer.Argument(..., help="Workspace UUID to delete"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """Delete a workspace (M2M membership cascades; sources are preserved)."""
+
+    async def _run() -> bool:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.delete_workspace(acting, workspace_id)
+        finally:
+            await Database.close_instance()
+
+    try:
+        existed = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if existed:
+        typer.echo(f"✅ Workspace {workspace_id} deleted")
+    else:
+        typer.echo(f"⚠️  Workspace {workspace_id} delete had no effect")
+
+
+@app.command("add-source")
+def add_source(
+    workspace_id: str = typer.Argument(..., help="Workspace UUID"),
+    channel: str = typer.Option(..., "--channel", help="channel_id (or @username)"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """Attach a channel to a workspace (idempotent — duplicates are no-op)."""
+
+    async def _run() -> bool:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+        from tg_parser.utils.channel_id import normalize_channel_id
+
+        acting = await _resolve_acting_user(user)
+        normalized = normalize_channel_id(channel) or channel
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.add_source(acting, workspace_id, normalized)
+        finally:
+            await Database.close_instance()
+
+    try:
+        inserted = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if inserted:
+        typer.echo(f"✅ Channel {channel} added to workspace {workspace_id}")
+    else:
+        typer.echo(f"ℹ️  Channel {channel} was already in workspace {workspace_id}")
+
+
+@app.command("remove-source")
+def remove_source(
+    workspace_id: str = typer.Argument(..., help="Workspace UUID"),
+    channel: str = typer.Option(..., "--channel", help="channel_id (or @username) to detach"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """Detach a channel from a workspace (M2M row only; source remains).
+
+    To move a channel between workspaces: ``remove-source`` + ``add-source``.
+    Per Q4 R2 / O-1 the move is **not** atomic in MVP.
+    """
+
+    async def _run() -> bool:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+        from tg_parser.utils.channel_id import normalize_channel_id
+
+        acting = await _resolve_acting_user(user)
+        normalized = normalize_channel_id(channel) or channel
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.remove_source(acting, workspace_id, normalized)
+        finally:
+            await Database.close_instance()
+
+    try:
+        removed = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if removed:
+        typer.echo(f"✅ Channel {channel} removed from workspace {workspace_id}")
+    else:
+        typer.echo(f"ℹ️  Channel {channel} was not in workspace {workspace_id}")
+
+
+@app.command("list-sources")
+def list_sources(
+    workspace_id: str = typer.Argument(..., help="Workspace UUID"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """List channel_ids attached to a workspace."""
+
+    async def _run() -> list[str]:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.list_workspace_sources(acting, workspace_id)
+        finally:
+            await Database.close_instance()
+
+    try:
+        channels = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if not channels:
+        typer.echo("⚠️  Workspace has no channels")
+        return
+    typer.echo(f"📺 Channels in workspace {workspace_id} ({len(channels)}):")
+    for ch in channels:
+        typer.echo(f"  • {ch}")
+
+
+@app.command("list-all")
+def list_all(
+    owner_id: str = typer.Option(None, "--owner-id", help="Optional owner filter"),
+    user: str = typer.Option(None, "--user", help="UUID of the actor (default: admin)"),
+) -> None:
+    """Admin-only: list every workspace in the system."""
+
+    async def _run() -> list[Any]:
+        from tg_parser.services.db_context import workspace_repo
+        from tg_parser.services.workspace_service import WorkspaceService
+        from tg_parser.storage.sqlalchemy.database import Database
+
+        acting = await _resolve_acting_user(user)
+        try:
+            async with workspace_repo() as (repo, _db):
+                service = WorkspaceService(repo)
+                return await service.list_all_workspaces(acting, owner_id=owner_id)
+        finally:
+            await Database.close_instance()
+
+    try:
+        workspaces = asyncio.run(_run())
+    except typer.BadParameter:
+        raise
+    except Exception as exc:
+        typer.echo(f"\n❌ Ошибка: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if not workspaces:
+        typer.echo("⚠️  No workspaces found")
+        return
+    typer.echo(f"📁 All workspaces ({len(workspaces)}):\n")
+    for ws in workspaces:
+        _print_workspace(ws)
+        typer.echo()

--- a/tg_parser/domain/models.py
+++ b/tg_parser/domain/models.py
@@ -527,6 +527,89 @@ class KnowledgeBaseEntry(BaseModel):
 
 
 # ============================================================================
+# Workspace / WorkspaceSource (F4-B Core)
+# ============================================================================
+
+
+class Workspace(BaseModel):
+    """Thematic collection of channels inside one user (F4-B Core).
+
+    Persisted in ``workspaces`` (ingestion DB). Each workspace is owned by
+    exactly one user (``owner_id``); the M2M membership of channels lives
+    in ``workspace_sources`` (Q5 = A: one channel can be in N workspaces
+    of the same owner). Workspaces narrow the existing F4-A
+    ``allowed_channel_ids`` scope at the surface layer — service-layer
+    signatures are unchanged.
+
+    See ``docs/contracts/workspace.schema.json`` for the contract.
+    """
+
+    id: str = Field(description="Workspace UUID")
+    owner_id: str = Field(description="User UUID owning the workspace")
+    name: str = Field(
+        min_length=1,
+        max_length=200,
+        description="Human label, unique within (owner_id, name)",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Free-form description; not used in scoping logic",
+    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now())
+    updated_at: datetime = Field(default_factory=lambda: datetime.now())
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty_trimmed(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("name must contain at least one non-whitespace character")
+        if len(trimmed) > 200:
+            raise ValueError("name must be at most 200 characters")
+        return trimmed
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000020",
+                    "owner_id": "00000000-0000-0000-0000-000000000002",
+                    "name": "AI/ML research",
+                    "description": "Anthropic, OpenAI, DeepMind blogs",
+                }
+            ]
+        }
+    )
+
+
+class WorkspaceSource(BaseModel):
+    """M2M membership of a channel in a workspace (F4-B Core).
+
+    Persisted in ``workspace_sources`` with composite PK
+    ``(workspace_id, source_id)``. The same ``source_id`` may appear in
+    multiple workspaces of one owner (Q5). Removing a source from a
+    workspace only deletes the M2M row — the underlying source remains in
+    ``sources`` and is still visible through the null-workspace scope.
+    """
+
+    workspace_id: str = Field(description="Workspace UUID")
+    source_id: str = Field(description="Channel source_id (matches sources.source_id)")
+    added_at: datetime = Field(default_factory=lambda: datetime.now())
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "workspace_id": "00000000-0000-0000-0000-000000000020",
+                    "source_id": "tg:durov",
+                    "added_at": "2026-05-13T12:00:00Z",
+                }
+            ]
+        }
+    )
+
+
+# ============================================================================
 # DigestSubscription (F6 Scheduled Digests)
 # ============================================================================
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -116,6 +116,22 @@ _MCP_INSTRUCTIONS = (
     "status='locked'). The scheduler hook itself runs after every "
     "incremental tick when new_items_since_last_summary >= "
     "RESUMMARIZE_TRIGGER_N.\n\n"
+    "Workspaces (F4-B Core): thematic collections of the caller's channels. "
+    "list_workspaces / create_workspace(name, description?) / "
+    "rename_workspace(workspace_id, new_name) / delete_workspace(workspace_id) "
+    "manage workspaces (UNIQUE per (owner_id, name); ON DELETE CASCADE drops "
+    "the M2M membership). add_workspace_source(workspace_id, channel_id) and "
+    "remove_workspace_source(workspace_id, channel_id) manage membership; "
+    "list_workspace_sources(workspace_id) lists the channels in a workspace. "
+    "To move a channel between workspaces issue remove_workspace_source + "
+    "add_workspace_source — the move is NOT atomic in MVP (O-1 deferred). "
+    "Read tools (list_channels, list_topics, search_knowledge_base, "
+    "ask_question, get_topic_details, get_document, get_cross_channel_stats, "
+    "get_related_topics) accept optional workspace_id to narrow the scope; "
+    "workspace_id=None or omitted preserves F4-A behavior bit-for-bit. "
+    "Unknown / foreign workspace_id raises a 404-like error (existence is "
+    "never leaked). Admin tool list_all_workspaces(owner_id?) cross-inspects "
+    "every workspace in the system.\n\n"
     "Prompt Management: reload_prompts to reload YAML prompt files without restart. "
     "Prompts live in prompts/ directory (processing, topicization, rag, bot, merge, "
     "incremental_discover, resummarize). Each YAML has system.prompt, user.template, "
@@ -2830,6 +2846,398 @@ async def get_watchlist_matches(
         count=len(matches),
         interest_id=target_id,
         matches=[_watch_match_to_info(m) for m in matches],
+    )
+
+
+# ---------------------------------------------------------------------------
+# F4-B Core: Workspaces — result models
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceInfo(BaseModel):
+    """Public projection of a :class:`Workspace`."""
+
+    id: str
+    owner_id: str
+    name: str
+    description: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class ListWorkspacesResult(BaseModel):
+    """Result of ``list_workspaces`` / ``list_all_workspaces``."""
+
+    count: int
+    workspaces: list[WorkspaceInfo]
+
+
+class CreateWorkspaceResult(BaseModel):
+    """Result of ``create_workspace``."""
+
+    success: bool
+    workspace: WorkspaceInfo | None = None
+    message: str
+
+
+class RenameWorkspaceResult(BaseModel):
+    """Result of ``rename_workspace``."""
+
+    success: bool
+    workspace: WorkspaceInfo | None = None
+    message: str
+
+
+class DeleteWorkspaceResult(BaseModel):
+    """Result of ``delete_workspace``."""
+
+    success: bool
+    workspace_id: str
+    message: str
+
+
+class WorkspaceSourceOpResult(BaseModel):
+    """Result of ``add_workspace_source`` / ``remove_workspace_source``."""
+
+    success: bool
+    workspace_id: str
+    channel_id: str
+    changed: bool
+    message: str
+
+
+class ListWorkspaceSourcesResult(BaseModel):
+    """Result of ``list_workspace_sources``."""
+
+    workspace_id: str
+    count: int
+    channel_ids: list[str]
+
+
+def _workspace_to_info(ws: Any) -> WorkspaceInfo:
+    return WorkspaceInfo(
+        id=ws.id,
+        owner_id=ws.owner_id,
+        name=ws.name,
+        description=ws.description,
+        created_at=ws.created_at.isoformat() if ws.created_at else None,
+        updated_at=ws.updated_at.isoformat() if ws.updated_at else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# F4-B Core: Workspaces — MCP tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def list_workspaces(ctx: Context | None = None) -> ListWorkspacesResult:
+    """List the caller's workspaces (F4-B Core).
+
+    Admins see only their own here; cross-user inspection happens via
+    :func:`list_all_workspaces`.
+    """
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    async with workspace_repo() as (repo, _db):
+        service = WorkspaceService(repo)
+        workspaces = await service.list_workspaces(user)
+    return ListWorkspacesResult(
+        count=len(workspaces),
+        workspaces=[_workspace_to_info(ws) for ws in workspaces],
+    )
+
+
+@mcp.tool()
+async def create_workspace(
+    name: str,
+    description: str | None = None,
+    ctx: Context | None = None,
+) -> CreateWorkspaceResult:
+    """Create a new workspace owned by the caller (F4-B Core).
+
+    ``name`` must be unique within the caller's workspaces (UNIQUE
+    ``(owner_id, name)`` — per-owner namespace). Returns a structured error
+    on duplicates or whitespace-only names; never raises.
+    """
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            ws = await service.create_workspace(user, name=name, description=description)
+    except ValueError as exc:
+        return CreateWorkspaceResult(success=False, workspace=None, message=str(exc))
+    except SQLAlchemyError as exc:
+        logger.exception("mcp_create_workspace_failed")
+        return CreateWorkspaceResult(
+            success=False,
+            workspace=None,
+            message=f"failed to create workspace: {exc}",
+        )
+    logger.info("mcp_workspace_created", workspace_id=ws.id, owner_id=ws.owner_id)
+    return CreateWorkspaceResult(
+        success=True,
+        workspace=_workspace_to_info(ws),
+        message=f"Workspace {ws.name!r} created.",
+    )
+
+
+@mcp.tool()
+async def rename_workspace(
+    workspace_id: str,
+    new_name: str,
+    ctx: Context | None = None,
+) -> RenameWorkspaceResult:
+    """Rename an owned workspace (F4-B Core)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            ws = await service.rename_workspace(user, workspace_id, new_name)
+    except WorkspaceNotFound:
+        return RenameWorkspaceResult(
+            success=False,
+            workspace=None,
+            message=f"Workspace {workspace_id} not found",
+        )
+    except ValueError as exc:
+        return RenameWorkspaceResult(success=False, workspace=None, message=str(exc))
+    except SQLAlchemyError as exc:
+        logger.exception("mcp_rename_workspace_failed")
+        return RenameWorkspaceResult(
+            success=False,
+            workspace=None,
+            message=f"failed to rename workspace: {exc}",
+        )
+    return RenameWorkspaceResult(
+        success=True,
+        workspace=_workspace_to_info(ws),
+        message=f"Workspace {ws.id} renamed to {ws.name!r}.",
+    )
+
+
+@mcp.tool()
+async def delete_workspace(
+    workspace_id: str,
+    ctx: Context | None = None,
+) -> DeleteWorkspaceResult:
+    """Delete an owned workspace (F4-B Core).
+
+    The workspace's M2M membership rows are removed via
+    ``ON DELETE CASCADE``; the underlying ``sources`` themselves are
+    preserved and remain visible through the null-workspace scope.
+    """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            existed = await service.delete_workspace(user, workspace_id)
+    except WorkspaceNotFound:
+        return DeleteWorkspaceResult(
+            success=False,
+            workspace_id=workspace_id,
+            message=f"Workspace {workspace_id} not found",
+        )
+    return DeleteWorkspaceResult(
+        success=existed,
+        workspace_id=workspace_id,
+        message=(
+            f"Workspace {workspace_id} deleted."
+            if existed
+            else f"Workspace {workspace_id} delete failed."
+        ),
+    )
+
+
+@mcp.tool()
+async def add_workspace_source(
+    workspace_id: str,
+    channel_id: str,
+    ctx: Context | None = None,
+) -> WorkspaceSourceOpResult:
+    """Attach a channel to a workspace (F4-B Core).
+
+    Idempotent via ``ON CONFLICT DO NOTHING``: ``changed=False`` means the
+    channel was already in the workspace. To move a channel between
+    workspaces use ``remove_workspace_source`` + ``add_workspace_source``
+    (the move is NOT atomic in MVP — O-1 deferred to Wave 1 step 3 / Wave 2).
+    """
+    from tg_parser.auth.ownership import PermissionDenied, WorkspaceNotFound
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import (
+        WorkspaceService,
+        WorkspaceSourceNotFound,
+    )
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    normalized = normalize_channel_id(channel_id) or channel_id
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            inserted = await service.add_source(user, workspace_id, normalized)
+    except WorkspaceNotFound:
+        return WorkspaceSourceOpResult(
+            success=False,
+            workspace_id=workspace_id,
+            channel_id=normalized,
+            changed=False,
+            message=f"Workspace {workspace_id} not found",
+        )
+    except WorkspaceSourceNotFound:
+        return WorkspaceSourceOpResult(
+            success=False,
+            workspace_id=workspace_id,
+            channel_id=normalized,
+            changed=False,
+            message=f"Channel {normalized} not found",
+        )
+    except PermissionDenied as exc:
+        return WorkspaceSourceOpResult(
+            success=False,
+            workspace_id=workspace_id,
+            channel_id=normalized,
+            changed=False,
+            message=exc.message,
+        )
+    return WorkspaceSourceOpResult(
+        success=True,
+        workspace_id=workspace_id,
+        channel_id=normalized,
+        changed=inserted,
+        message=(
+            f"Channel {normalized} added to workspace {workspace_id}."
+            if inserted
+            else f"Channel {normalized} already in workspace {workspace_id}."
+        ),
+    )
+
+
+@mcp.tool()
+async def remove_workspace_source(
+    workspace_id: str,
+    channel_id: str,
+    ctx: Context | None = None,
+) -> WorkspaceSourceOpResult:
+    """Detach a channel from a workspace (F4-B Core).
+
+    Removes only the M2M row; the underlying ``sources`` row is preserved
+    and remains visible via the null-workspace scope. To move a channel
+    between workspaces this is the first call of the documented
+    ``remove + add`` pair (Q4 R2 / O-1 deferred — non-atomic gap window).
+    """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import (
+        WorkspaceService,
+        WorkspaceSourceNotFound,
+    )
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    normalized = normalize_channel_id(channel_id) or channel_id
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            removed = await service.remove_source(user, workspace_id, normalized)
+    except WorkspaceNotFound:
+        return WorkspaceSourceOpResult(
+            success=False,
+            workspace_id=workspace_id,
+            channel_id=normalized,
+            changed=False,
+            message=f"Workspace {workspace_id} not found",
+        )
+    except WorkspaceSourceNotFound:
+        return WorkspaceSourceOpResult(
+            success=False,
+            workspace_id=workspace_id,
+            channel_id=normalized,
+            changed=False,
+            message=f"Channel {normalized} not found",
+        )
+    return WorkspaceSourceOpResult(
+        success=True,
+        workspace_id=workspace_id,
+        channel_id=normalized,
+        changed=removed,
+        message=(
+            f"Channel {normalized} removed from workspace {workspace_id}."
+            if removed
+            else f"Channel {normalized} was not in workspace {workspace_id}."
+        ),
+    )
+
+
+@mcp.tool()
+async def list_workspace_sources(
+    workspace_id: str,
+    ctx: Context | None = None,
+) -> ListWorkspaceSourcesResult:
+    """List channel_ids attached to a workspace (F4-B Core).
+
+    Returns ``channel_id`` values (not raw ``source_id``) so the result is
+    drop-in usable in any F4-A scoped tool's ``channel_id`` parameter.
+    """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            channels = await service.list_workspace_sources(user, workspace_id)
+    except WorkspaceNotFound:
+        return ListWorkspaceSourcesResult(
+            workspace_id=workspace_id,
+            count=0,
+            channel_ids=[],
+        )
+    return ListWorkspaceSourcesResult(
+        workspace_id=workspace_id,
+        count=len(channels),
+        channel_ids=channels,
+    )
+
+
+@mcp.tool()
+async def list_all_workspaces(
+    owner_id: str | None = None,
+    ctx: Context | None = None,
+) -> ListWorkspacesResult:
+    """Admin-only: list every workspace in the system (F4-B Core, Q2 EC3).
+
+    Returns the unscoped view. Non-admin callers receive an empty list
+    with no error — the surface deliberately mirrors how
+    ``list_workspaces`` reports zero rows so that probing the tool name
+    cannot reveal whether admin access exists.
+    """
+    from tg_parser.auth.ownership import PermissionDenied
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+    try:
+        async with workspace_repo() as (repo, _db):
+            service = WorkspaceService(repo)
+            workspaces = await service.list_all_workspaces(user, owner_id=owner_id)
+    except PermissionDenied:
+        return ListWorkspacesResult(count=0, workspaces=[])
+    return ListWorkspacesResult(
+        count=len(workspaces),
+        workspaces=[_workspace_to_info(ws) for ws in workspaces],
     )
 
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -754,6 +754,37 @@ class GetWatchlistMatchesResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+async def _resolve_workspace_scope(
+    user: Any,
+    workspace_id: str | None,
+) -> list[str] | None:
+    """Resolve ``workspace_id`` to the effective channel scope for a read tool.
+
+    F4-B Core surface helper:
+
+    * ``workspace_id is None`` → ``user.allowed_channel_ids`` verbatim
+      (bit-for-bit F4-A behavior, no repo I/O).
+    * unknown / foreign workspace_id → :class:`WorkspaceNotFound`
+      (404-like; callers translate to ``[]`` result or empty list of
+      summaries — never leak existence).
+    * valid workspace → intersection list (may be ``[]``; explicit
+      empty, hidden gotcha § 3).
+
+    Callers that want F4-A semantics for get-details (Q4 R3 —
+    ``get_topic_details`` / ``get_document``) should still call this for
+    existence validation but pass ``user.allowed_channel_ids`` (not the
+    return value) downstream.
+    """
+    if workspace_id is None:
+        return user.allowed_channel_ids
+    from tg_parser.services.db_context import workspace_repo
+    from tg_parser.services.workspace_service import WorkspaceService
+
+    async with workspace_repo() as (repo, _db):
+        service = WorkspaceService(repo)
+        return await service.effective_channel_ids(user, workspace_id)
+
+
 def _validate_search_mode(mode: str) -> str:
     """Validate ``mode`` against ``SearchMode`` literal from retrieval_service.
 
@@ -819,6 +850,7 @@ async def search_knowledge_base(
     channel_id: str | None = None,
     limit: int = 10,
     mode: str = "hybrid",
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> list[SearchResultItem]:
     """Hybrid search across the Telegram knowledge base.
@@ -831,7 +863,13 @@ async def search_knowledge_base(
         limit: Maximum number of results (default 10).
         mode: Retrieval strategy — 'semantic' (pgvector cosine), 'keyword'
             (FTS ts_rank_cd), or 'hybrid' (RRF fusion). Defaults to 'hybrid'.
+        workspace_id: Optional F4-B workspace UUID to narrow the search to
+            channels in that workspace. Omitted / None preserves F4-A
+            behavior bit-for-bit. Unknown / foreign workspace_id returns
+            an empty result (404-like, never leaks existence).
     """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+
     _validate_search_mode(mode)
     if not query or not query.strip():
         return []
@@ -839,13 +877,18 @@ async def search_knowledge_base(
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
     channel_id = normalize_channel_id(channel_id)
 
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return []
+
     from tg_parser.services.retrieval_service import search
 
     results = await search(
         query=query,
         channel_id=channel_id,
         limit=limit,
-        allowed_channel_ids=user.allowed_channel_ids,
+        allowed_channel_ids=effective,
         mode=mode,
     )
     items: list[SearchResultItem] = []
@@ -868,6 +911,7 @@ async def ask_question(
     question: str,
     channel_id: str | None = None,
     mode: str = "hybrid",
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> AnswerResultItem:
     """Ask a question about Telegram channel content.
@@ -878,7 +922,13 @@ async def ask_question(
         question: Question in natural language.
         channel_id: Optional channel filter.
         mode: Retrieval strategy — 'semantic', 'keyword', or 'hybrid' (default).
+        workspace_id: Optional F4-B workspace UUID to narrow retrieval to
+            channels in that workspace. Omitted / None preserves F4-A
+            behavior bit-for-bit. Unknown / foreign workspace_id returns
+            a benign no-context answer (404-like, never leaks existence).
     """
+    from tg_parser.auth.ownership import WorkspaceNotFound
+
     _validate_search_mode(mode)
     if not question or not question.strip():
         return AnswerResultItem(
@@ -888,12 +938,21 @@ async def ask_question(
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
     channel_id = normalize_channel_id(channel_id)
 
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return AnswerResultItem(
+            answer="Workspace not found.",
+            sources=[],
+            model=None,
+        )
+
     from tg_parser.services.retrieval_service import answer
 
     result = await answer(
         question=question,
         channel_id=channel_id,
-        allowed_channel_ids=user.allowed_channel_ids,
+        allowed_channel_ids=effective,
         mode=mode,
     )
     sources = [
@@ -924,6 +983,7 @@ async def list_topics(
     topic_type: str | None = None,
     offset: int = 0,
     limit: int = 50,
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> TopicListResult:
     """List topics (knowledge themes) extracted from channel content.
@@ -938,18 +998,40 @@ async def list_topics(
         channel_id: Optional channel filter.
         topic_type: Optional type filter ('singleton' or 'cluster').
         offset: Number of topics to skip (default 0). Use for pagination.
-        limit: Maximum topics to return per page (default 50)."""
+        limit: Maximum topics to return per page (default 50).
+        workspace_id: Optional F4-B workspace UUID to narrow listing to
+            channels in that workspace. Omitted / None preserves F4-A
+            behavior. Unknown / foreign workspace_id returns an empty
+            page (404-like, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.db_context import processing_repos
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
     channel_id = normalize_channel_id(channel_id)
 
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return TopicListResult(
+            total=0,
+            offset=offset,
+            limit=limit,
+            has_more=False,
+            items=[],
+            available_channel_ids=None,
+            suggestion=None,
+        )
+
     async with processing_repos() as (proc_repo, topic_card_repo, topic_bundle_repo, _db):
         if channel_id:
-            cards = await topic_card_repo.list_by_channel(channel_id)
-            bundles = await topic_bundle_repo.list_by_channel(channel_id)
-        elif user.allowed_channel_ids is not None:
-            cards = await topic_card_repo.list_by_channels(user.allowed_channel_ids)
+            if effective is not None and channel_id not in effective:
+                cards = []
+                bundles = []
+            else:
+                cards = await topic_card_repo.list_by_channel(channel_id)
+                bundles = await topic_bundle_repo.list_by_channel(channel_id)
+        elif effective is not None:
+            cards = await topic_card_repo.list_by_channels(effective)
             bundles = await topic_bundle_repo.list_all()
         else:
             cards = await topic_card_repo.list_all()
@@ -982,7 +1064,7 @@ async def list_topics(
     suggestion: str | None = None
     if total == 0 and channel_id:
         available_channel_ids, suggestion = await _build_no_results_suggestion_mcp(
-            channel_id, user.allowed_channel_ids
+            channel_id, effective
         )
 
     return TopicListResult(
@@ -997,16 +1079,32 @@ async def list_topics(
 
 
 @mcp.tool()
-async def get_topic_details(topic_id: str, ctx: Context | None = None) -> TopicDetail | str:
+async def get_topic_details(
+    topic_id: str,
+    workspace_id: str | None = None,
+    ctx: Context | None = None,
+) -> TopicDetail | str:
     """Get full details of a topic: scope, anchors, related topics, and bundle items.
     Use this after list_topics to dive deeper into a specific topic.
 
     Args:
-        topic_id: The topic ID (e.g. 'topic:tg:channel:post:123')."""
+        topic_id: The topic ID (e.g. 'topic:tg:channel:post:123').
+        workspace_id: Optional F4-B workspace UUID. Per Q4 R3 the bundle
+            is returned in full regardless of workspace scope (workspaces
+            narrow list/search, not access-control on get-details). Unknown
+            / foreign workspace_id is treated as 404 (returns a 'not found'
+            message, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.db_context import processing_repos
     from tg_parser.services.topic_linking_service import get_related_topics_for
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+
+    if workspace_id is not None:
+        try:
+            await _resolve_workspace_scope(user, workspace_id)
+        except WorkspaceNotFound:
+            return f"Topic not found: {topic_id}"
 
     async with processing_repos() as (_proc_repo, topic_card_repo, topic_bundle_repo, _db):
         card = await topic_card_repo.get_by_id(topic_id)
@@ -1055,13 +1153,29 @@ async def get_topic_details(topic_id: str, ctx: Context | None = None) -> TopicD
 
 
 @mcp.tool()
-async def list_channels(ctx: Context | None = None) -> list[ChannelSummary]:
+async def list_channels(
+    workspace_id: str | None = None,
+    ctx: Context | None = None,
+) -> list[ChannelSummary]:
     """List all connected Telegram channels with statistics.
-    Shows raw/processed message counts, topics, and coverage percentage."""
+    Shows raw/processed message counts, topics, and coverage percentage.
+
+    Args:
+        workspace_id: Optional F4-B workspace UUID to narrow the listing
+            to channels in that workspace. Omitted / None preserves F4-A
+            behavior. Unknown / foreign workspace_id returns an empty
+            list (404-like, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.channel_service import get_all_channel_stats
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
-    all_stats = await get_all_channel_stats(allowed_channel_ids=user.allowed_channel_ids)
+
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return []
+
+    all_stats = await get_all_channel_stats(allowed_channel_ids=effective)
     return [
         ChannelSummary(
             channel_id=s["channel_id"],
@@ -1077,15 +1191,31 @@ async def list_channels(ctx: Context | None = None) -> list[ChannelSummary]:
 
 
 @mcp.tool()
-async def get_document(source_ref: str, ctx: Context | None = None) -> DocumentDetail | str:
+async def get_document(
+    source_ref: str,
+    workspace_id: str | None = None,
+    ctx: Context | None = None,
+) -> DocumentDetail | str:
     """Get the full content of a processed document by its source reference.
     Source refs have format: tg:channel_id:post:123 or tg:channel_id:comment:456.
 
     Args:
-        source_ref: Document source reference."""
+        source_ref: Document source reference.
+        workspace_id: Optional F4-B workspace UUID. Per Q4 R3 the document
+            is returned in full regardless of workspace scope (workspaces
+            narrow list/search, not access-control on get-details). Unknown
+            / foreign workspace_id is treated as 404 (returns a 'not found'
+            message, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.db_context import processing_repos
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+
+    if workspace_id is not None:
+        try:
+            await _resolve_workspace_scope(user, workspace_id)
+        except WorkspaceNotFound:
+            return f"Document not found: {source_ref}"
 
     async with processing_repos() as (proc_repo, _tc, _tb, _db):
         doc = await proc_repo.get_by_source_ref(source_ref)
@@ -1112,20 +1242,35 @@ async def get_document(source_ref: str, ctx: Context | None = None) -> DocumentD
 
 
 @mcp.tool()
-async def get_related_topics(topic_id: str, ctx: Context | None = None) -> list[RelatedTopicItem]:
+async def get_related_topics(
+    topic_id: str,
+    workspace_id: str | None = None,
+    ctx: Context | None = None,
+) -> list[RelatedTopicItem]:
     """Get topics from other channels that are related to the given topic.
 
     Requires link-topics to have been run first (CLI: tg-parser link-topics).
     Returns related topics sorted by similarity score.
 
     Args:
-        topic_id: The topic ID to find related topics for."""
+        topic_id: The topic ID to find related topics for.
+        workspace_id: Optional F4-B workspace UUID to narrow the related-topic
+            search to channels in that workspace. Omitted / None preserves
+            F4-A behavior. Unknown / foreign workspace_id returns an empty
+            list (404-like, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.topic_linking_service import get_related_topics_for
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
+
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return []
+
     related = await get_related_topics_for(
         topic_id,
-        allowed_channel_ids=user.allowed_channel_ids,
+        allowed_channel_ids=effective,
     )
     return [
         RelatedTopicItem(
@@ -1142,6 +1287,7 @@ async def get_related_topics(topic_id: str, ctx: Context | None = None) -> list[
 @mcp.tool()
 async def get_cross_channel_stats(
     channel_id: str | None = None,
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> CrossChannelStatsResult:
     """Get cross-channel analytics: topic counts, coverage, and keyword overlaps.
@@ -1153,14 +1299,31 @@ async def get_cross_channel_stats(
     all keywords and related channels by shared keywords.
 
     Args:
-        channel_id: Optional channel filter for single-channel detail view."""
+        channel_id: Optional channel filter for single-channel detail view.
+        workspace_id: Optional F4-B workspace UUID to narrow analytics to
+            channels in that workspace. Omitted / None preserves F4-A
+            behavior. Unknown / foreign workspace_id returns an empty
+            analytics result (404-like, never leaks existence)."""
+    from tg_parser.auth.ownership import WorkspaceNotFound
     from tg_parser.services.analytics_service import get_cross_channel_analytics
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
     channel_id = normalize_channel_id(channel_id)
+
+    try:
+        effective = await _resolve_workspace_scope(user, workspace_id)
+    except WorkspaceNotFound:
+        return CrossChannelStatsResult(
+            total_documents=0,
+            total_topics=0,
+            channels=[],
+            keyword_overlaps=[],
+            overlap_count=0,
+        )
+
     result = await get_cross_channel_analytics(
         channel_id=channel_id,
-        allowed_channel_ids=user.allowed_channel_ids,
+        allowed_channel_ids=effective,
     )
     return CrossChannelStatsResult(**result)
 

--- a/tg_parser/services/db_context.py
+++ b/tg_parser/services/db_context.py
@@ -32,6 +32,7 @@ from tg_parser.storage.sqlalchemy.topic_link_repo import SATopicLinkRepo
 from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
 from tg_parser.storage.sqlalchemy.watch_interest_repo import SAWatchInterestRepo
 from tg_parser.storage.sqlalchemy.watch_match_repo import SAWatchMatchRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -130,6 +131,17 @@ async def digest_subscription_repo() -> "AsyncIterator[tuple[SADigestSubscriptio
     session = db.ingestion_state_session()
     try:
         yield SADigestSubscriptionRepo(session), db
+    finally:
+        await session.close()
+
+
+@asynccontextmanager
+async def workspace_repo() -> "AsyncIterator[tuple[SAWorkspaceRepo, Database]]":
+    """Context manager for WorkspaceRepo (F4-B Core)."""
+    db = await _get_db()
+    session = db.ingestion_state_session()
+    try:
+        yield SAWorkspaceRepo(session), db
     finally:
         await session.close()
 

--- a/tg_parser/services/workspace_service.py
+++ b/tg_parser/services/workspace_service.py
@@ -21,8 +21,14 @@ Hard invariants (Q1 + Q2 locked semantics, see
 
 from __future__ import annotations
 
+import time
+
 import structlog
 
+from tg_parser.api.metrics import (
+    bump_workspace_total,
+    record_workspace_query,
+)
 from tg_parser.auth.models import CurrentUser
 from tg_parser.auth.ownership import (
     PermissionDenied,
@@ -93,11 +99,19 @@ class WorkspaceService:
             description=description,
         )
         cleaned_name = name.strip()
-        return await self.repo.create(
+        workspace = await self.repo.create(
             owner_id=user.id,
             name=cleaned_name,
             description=description,
         )
+        bump_workspace_total(+1)
+        logger.info(
+            "workspace_created",
+            user_id=user.id,
+            workspace_id=workspace.id,
+            name=cleaned_name,
+        )
+        return workspace
 
     async def get_workspace(self, user: CurrentUser, workspace_id: str) -> Workspace:
         """Return the workspace if ``user`` can see it, else raise."""
@@ -144,7 +158,15 @@ class WorkspaceService:
 
     async def delete_workspace(self, user: CurrentUser, workspace_id: str) -> bool:
         await assert_workspace_access(user, workspace_id, repo=self.repo)
-        return await self.repo.delete(workspace_id)
+        deleted = await self.repo.delete(workspace_id)
+        if deleted:
+            bump_workspace_total(-1)
+            logger.info(
+                "workspace_deleted",
+                user_id=user.id,
+                workspace_id=workspace_id,
+            )
+        return deleted
 
     # ------------------------------------------------------------------
     # M2M membership
@@ -246,9 +268,19 @@ class WorkspaceService:
         possibly empty.
         """
         if workspace_id is None:
+            record_workspace_query(result="null_fallback")
             return user.allowed_channel_ids
 
-        workspace = await assert_workspace_access(user, workspace_id, repo=self.repo)
+        started = time.perf_counter()
+        try:
+            workspace = await assert_workspace_access(user, workspace_id, repo=self.repo)
+        except WorkspaceNotFound:
+            record_workspace_query(
+                result="not_found",
+                duration_s=time.perf_counter() - started,
+            )
+            raise
+
         workspace_channel_ids = await self.repo.list_channel_ids(workspace.id)
 
         if user.allowed_channel_ids is None:
@@ -257,11 +289,19 @@ class WorkspaceService:
             allowed_set = set(user.allowed_channel_ids)
             effective = [c for c in workspace_channel_ids if c in allowed_set]
 
+        duration_s = time.perf_counter() - started
+        record_workspace_query(
+            result="scoped",
+            effective_size=len(effective),
+            workspace_size=len(workspace_channel_ids),
+            duration_s=duration_s,
+        )
         logger.debug(
             "workspace_effective_channel_ids",
             user_id=user.id,
             workspace_id=workspace.id,
             workspace_size=len(workspace_channel_ids),
             effective_count=len(effective),
+            resolver_seconds=round(duration_s, 4),
         )
         return effective

--- a/tg_parser/services/workspace_service.py
+++ b/tg_parser/services/workspace_service.py
@@ -1,0 +1,267 @@
+"""F4-B Core — :class:`WorkspaceService`.
+
+Owner-scoped CRUD for ``workspaces`` plus the ``effective_channel_ids``
+resolver — the single point where F4-A ``allowed_channel_ids`` is
+intersected with F4-B workspace channel-membership.
+
+Hard invariants (Q1 + Q2 locked semantics, see
+``docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md``):
+
+* ``workspace_id is None`` → bit-for-bit F4-A behavior
+  (``return user.allowed_channel_ids`` — no repo I/O).
+* Unknown / foreign ``workspace_id`` → :class:`WorkspaceNotFound`
+  (404-like, never leak existence).
+* Valid workspace with empty M2M → ``[]`` (explicit empty list — **NOT**
+  ``None``, **NOT** silent fallback to "all channels"; that would be a
+  data leak — see hidden gotcha § 3).
+* Admin (``user.allowed_channel_ids is None``) → workspace
+  channel_ids verbatim (no intersection — admin has no user-scope to
+  intersect with).
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import (
+    PermissionDenied,
+    WorkspaceNotFound,
+    assert_workspace_access,
+)
+from tg_parser.domain.models import Workspace
+from tg_parser.storage.ports import WorkspaceRepo
+
+logger = structlog.get_logger(__name__)
+
+
+class WorkspaceSourceNotFound(Exception):
+    """Raised when a channel cannot be resolved to a ``sources`` row.
+
+    Surfaces both ``unknown channel_id`` and ``foreign channel_id``
+    (channel belongs to another owner) as a single 404-like error so the
+    MCP / CLI surface never leaks existence.
+    """
+
+    def __init__(self, message: str = "Channel not found"):
+        self.message = message
+        super().__init__(message)
+
+
+class WorkspaceService:
+    """Thin service on top of :class:`WorkspaceRepo`.
+
+    All mutating methods enforce ownership via
+    :func:`assert_workspace_access`. Admins can target any user's
+    workspace (Q2 edge case 3 — mirrors F4-A admin semantics).
+
+    Channel-id translation: the MCP / CLI surface speaks in
+    ``channel_id`` (the identifier living in
+    ``CurrentUser.allowed_channel_ids``), while ``workspace_sources``
+    is FK'd to ``sources.source_id``. The service translates
+    ``channel_id`` → ``source_id`` via
+    :meth:`WorkspaceRepo.resolve_source_id_for_channel` so the storage
+    layer never sees the user-facing identifier.
+    """
+
+    def __init__(self, repo: WorkspaceRepo):
+        self.repo = repo
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def create_workspace(
+        self,
+        user: CurrentUser,
+        *,
+        name: str,
+        description: str | None = None,
+    ) -> Workspace:
+        """Create a workspace owned by ``user``.
+
+        The :class:`Workspace` Pydantic model already strips + length-checks
+        the ``name`` (gotcha § 6). We bounce the request through Pydantic
+        first so the service-layer error message is identical regardless of
+        whether the rejection came from the schema CheckConstraint or the
+        domain validator.
+        """
+        Workspace(
+            id="00000000-0000-0000-0000-000000000000",
+            owner_id=user.id,
+            name=name,
+            description=description,
+        )
+        cleaned_name = name.strip()
+        return await self.repo.create(
+            owner_id=user.id,
+            name=cleaned_name,
+            description=description,
+        )
+
+    async def get_workspace(self, user: CurrentUser, workspace_id: str) -> Workspace:
+        """Return the workspace if ``user`` can see it, else raise."""
+        return await assert_workspace_access(user, workspace_id, repo=self.repo)
+
+    async def list_workspaces(self, user: CurrentUser) -> list[Workspace]:
+        """List the caller's own workspaces.
+
+        Admin tooling reaches :meth:`list_all_workspaces` instead; this
+        method is consciously user-scoped (Q2 edge case 3 — admin acts as a
+        regular user on their own workspaces and uses a dedicated tool for
+        cross-user inspection).
+        """
+        return await self.repo.list_by_owner(user.id)
+
+    async def list_all_workspaces(
+        self,
+        user: CurrentUser,
+        *,
+        owner_id: str | None = None,
+    ) -> list[Workspace]:
+        """Admin-only: list every workspace in the system."""
+        if not user.is_admin:
+            raise PermissionDenied("list_all_workspaces requires admin role")
+        return await self.repo.list_all(owner_id=owner_id)
+
+    async def rename_workspace(
+        self,
+        user: CurrentUser,
+        workspace_id: str,
+        new_name: str,
+    ) -> Workspace:
+        """Rename a workspace after ownership + name validation."""
+        Workspace(
+            id="00000000-0000-0000-0000-000000000000",
+            owner_id=user.id,
+            name=new_name,
+        )
+        await assert_workspace_access(user, workspace_id, repo=self.repo)
+        renamed = await self.repo.rename(workspace_id, new_name.strip())
+        if renamed is None:
+            raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+        return renamed
+
+    async def delete_workspace(self, user: CurrentUser, workspace_id: str) -> bool:
+        await assert_workspace_access(user, workspace_id, repo=self.repo)
+        return await self.repo.delete(workspace_id)
+
+    # ------------------------------------------------------------------
+    # M2M membership
+    # ------------------------------------------------------------------
+
+    async def add_source(
+        self,
+        user: CurrentUser,
+        workspace_id: str,
+        channel_id: str,
+    ) -> bool:
+        """Attach a channel to a workspace.
+
+        The caller must own the workspace AND have F4-A access to the
+        channel (``channel_id`` ∈ ``user.allowed_channel_ids`` or admin).
+        Returns True for a newly-inserted membership row, False if the
+        channel was already in the workspace (idempotent ``ON CONFLICT``).
+        """
+        ws = await assert_workspace_access(user, workspace_id, repo=self.repo)
+        if not user.is_admin and (
+            user.allowed_channel_ids is None or channel_id not in user.allowed_channel_ids
+        ):
+            raise PermissionDenied(f"No access to channel {channel_id}")
+        source_id = await self._resolve_source_id(ws.owner_id, channel_id, admin=user.is_admin)
+        return await self.repo.add_source(workspace_id, source_id)
+
+    async def remove_source(
+        self,
+        user: CurrentUser,
+        workspace_id: str,
+        channel_id: str,
+    ) -> bool:
+        ws = await assert_workspace_access(user, workspace_id, repo=self.repo)
+        source_id = await self._resolve_source_id(ws.owner_id, channel_id, admin=user.is_admin)
+        return await self.repo.remove_source(workspace_id, source_id)
+
+    async def list_workspace_sources(
+        self,
+        user: CurrentUser,
+        workspace_id: str,
+    ) -> list[str]:
+        """Return channels (channel_id list) in a workspace — surface-friendly.
+
+        We deliberately return channel_ids rather than source_ids so the
+        MCP / CLI surface stays consistent with F4-A
+        ``allowed_channel_ids`` semantics.
+        """
+        await assert_workspace_access(user, workspace_id, repo=self.repo)
+        return await self.repo.list_channel_ids(workspace_id)
+
+    async def _resolve_source_id(
+        self,
+        owner_id: str,
+        channel_id: str,
+        *,
+        admin: bool,
+    ) -> str:
+        """Translate a user-facing ``channel_id`` into the underlying ``source_id``.
+
+        Scopes the lookup to ``owner_id`` for non-admin callers so that two
+        users with the same ``channel_id`` (legacy F4-A behavior) never
+        clash. Admin callers fall through to a global lookup.
+        """
+        source_id = await self.repo.resolve_source_id_for_channel(
+            owner_id=None if admin else owner_id,
+            channel_id=channel_id,
+        )
+        if source_id is None:
+            raise WorkspaceSourceNotFound(f"Channel {channel_id} not found")
+        return source_id
+
+    # ------------------------------------------------------------------
+    # Resolver (the core invariant)
+    # ------------------------------------------------------------------
+
+    async def effective_channel_ids(
+        self,
+        user: CurrentUser,
+        workspace_id: str | None,
+    ) -> list[str] | None:
+        """Resolve the surface-level scope for a workspace-aware read tool.
+
+        Semantics matrix:
+
+        ===========================================  =================================
+        ``workspace_id``                              return value
+        ===========================================  =================================
+        ``None``                                      ``user.allowed_channel_ids`` (F4-A)
+        unknown / foreign UUID                        raises :class:`WorkspaceNotFound`
+        valid + empty workspace                       ``[]`` (explicit empty, NOT None)
+        valid + non-empty, admin caller               workspace's ``channel_ids``
+        valid + non-empty, non-admin caller           intersection list (may be ``[]``)
+        ===========================================  =================================
+
+        ``user.allowed_channel_ids is None`` means F4-A admin scope ("see
+        every channel"); for admin we therefore return the workspace's
+        channel_ids verbatim (no intersection — there is no user-scope to
+        intersect with). Non-admins always get a deterministic list,
+        possibly empty.
+        """
+        if workspace_id is None:
+            return user.allowed_channel_ids
+
+        workspace = await assert_workspace_access(user, workspace_id, repo=self.repo)
+        workspace_channel_ids = await self.repo.list_channel_ids(workspace.id)
+
+        if user.allowed_channel_ids is None:
+            effective = list(workspace_channel_ids)
+        else:
+            allowed_set = set(user.allowed_channel_ids)
+            effective = [c for c in workspace_channel_ids if c in allowed_set]
+
+        logger.debug(
+            "workspace_effective_channel_ids",
+            user_id=user.id,
+            workspace_id=workspace.id,
+            workspace_size=len(workspace_channel_ids),
+            effective_count=len(effective),
+        )
+        return effective

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -23,6 +23,7 @@ from tg_parser.domain.models import (
     TopicLink,
     WatchInterest,
     WatchMatch,
+    Workspace,
 )
 
 # ============================================================================
@@ -1481,4 +1482,118 @@ class WatchMatchRepo(ABC):
     @abstractmethod
     async def mark_notified(self, match_ids: list[int]) -> None:
         """Flip ``notified = true`` for the given match ids (post-send)."""
+        pass
+
+
+# ============================================================================
+# Workspaces (F4-B Core)
+# ============================================================================
+
+
+class WorkspaceRepo(ABC):
+    """Repository for thematic workspace collections (F4-B Core).
+
+    Storage: PostgreSQL (``workspaces`` + ``workspace_sources`` in
+    ingestion DB). Each workspace is owned by exactly one user
+    (``owner_id``); the M2M ``workspace_sources`` table holds channel
+    membership with composite PK ``(workspace_id, source_id)``.
+    """
+
+    @abstractmethod
+    async def create(
+        self,
+        *,
+        owner_id: str,
+        name: str,
+        description: str | None = None,
+    ) -> Workspace:
+        """Insert a new workspace. Raises on UNIQUE (owner_id, name) conflict."""
+        pass
+
+    @abstractmethod
+    async def get(self, workspace_id: str) -> Workspace | None:
+        """Look up a workspace by id; returns None if absent."""
+        pass
+
+    @abstractmethod
+    async def list_by_owner(self, owner_id: str) -> list[Workspace]:
+        """All workspaces owned by ``owner_id`` ordered by ``created_at``."""
+        pass
+
+    @abstractmethod
+    async def list_all(self, owner_id: str | None = None) -> list[Workspace]:
+        """Every workspace in the system (admin scope), optional owner filter.
+
+        Sorted by ``created_at`` ascending for deterministic CLI / MCP output.
+        """
+        pass
+
+    @abstractmethod
+    async def rename(self, workspace_id: str, new_name: str) -> Workspace | None:
+        """Update the workspace name. Returns the refreshed row, or None if absent."""
+        pass
+
+    @abstractmethod
+    async def delete(self, workspace_id: str) -> bool:
+        """Delete the workspace. Returns True if a row was removed.
+
+        ON DELETE CASCADE on ``workspace_sources.workspace_id`` cleans up M2M
+        rows automatically; the underlying ``sources`` are preserved.
+        """
+        pass
+
+    @abstractmethod
+    async def add_source(self, workspace_id: str, source_id: str) -> bool:
+        """Attach a channel to a workspace.
+
+        Returns True when a new M2M row was inserted, False when the channel
+        was already in the workspace (``ON CONFLICT DO NOTHING``).
+        """
+        pass
+
+    @abstractmethod
+    async def remove_source(self, workspace_id: str, source_id: str) -> bool:
+        """Detach a channel from a workspace. Returns True if a row existed."""
+        pass
+
+    @abstractmethod
+    async def list_source_ids(self, workspace_id: str) -> list[str]:
+        """Return the ``source_id`` list for a workspace (sorted).
+
+        Powers introspection / MCP ``list_workspace_sources`` — kept
+        lightweight (single SELECT on the M2M table).
+        """
+        pass
+
+    @abstractmethod
+    async def list_channel_ids(self, workspace_id: str) -> list[str]:
+        """Return ``sources.channel_id`` list for a workspace (sorted).
+
+        Joins ``workspace_sources`` → ``sources`` so that the result lives
+        in the same identifier space as ``CurrentUser.allowed_channel_ids``
+        (which is a list of ``channel_id``s, not ``source_id``s). Soft-deleted
+        sources are excluded — they no longer participate in F4-A scope and
+        F4-B mirrors that contract. Powers the ``effective_channel_ids``
+        resolver in ``WorkspaceService``.
+        """
+        pass
+
+    @abstractmethod
+    async def resolve_source_id_for_channel(
+        self,
+        *,
+        owner_id: str | None,
+        channel_id: str,
+    ) -> str | None:
+        """Translate a user-facing ``channel_id`` to the underlying ``source_id``.
+
+        Looks up an **active** (``deleted_at IS NULL``) row in ``sources``
+        matching ``channel_id``. When ``owner_id`` is provided the lookup
+        is scoped to that owner — required by the F4-B surface so that two
+        users with the same ``channel_id`` (legacy F4-A behavior) never
+        clash. ``owner_id=None`` means admin scope.
+
+        Returns ``None`` when no matching source exists; the service layer
+        translates that to a :class:`WorkspaceSourceNotFound`.
+        """
         pass

--- a/tg_parser/storage/sqlalchemy/_metadata.py
+++ b/tg_parser/storage/sqlalchemy/_metadata.py
@@ -53,7 +53,7 @@ PROCESSING_METADATA = MetaData()
 
 
 # ============================================================================
-# Ingestion branch (head: d7e8f9a0b1c4)
+# Ingestion branch (head: e9f0a1b2c3d5)
 # ============================================================================
 
 # sources — initial 89f91e768b9b + owner_id added in b2c3d4e5f6a7
@@ -229,6 +229,73 @@ Table(
         "is_active",
         postgresql_where=text("is_active = true"),
     ),
+)
+
+# workspaces — created via raw SQL in e9f0a1b2c3d5 (F4-B Core)
+Table(
+    "workspaces",
+    INGESTION_METADATA,
+    Column("id", UUID(as_uuid=True), nullable=False, server_default=text("gen_random_uuid()")),
+    Column("owner_id", UUID(as_uuid=True), nullable=False),
+    Column("name", String(length=200), nullable=False),
+    Column("description", Text(), nullable=True),
+    Column(
+        "created_at",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    ),
+    Column(
+        "updated_at",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    ),
+    PrimaryKeyConstraint("id", name="workspaces_pkey"),
+    ForeignKeyConstraint(
+        ["owner_id"],
+        ["users.id"],
+        ondelete="CASCADE",
+        name="workspaces_owner_id_fkey",
+    ),
+    UniqueConstraint("owner_id", "name", name="uq_workspaces_owner_name"),
+    CheckConstraint(
+        "length(trim(name)) > 0",
+        name="ck_workspaces_name_nonempty",
+    ),
+    CheckConstraint(
+        "length(name) <= 200",
+        name="ck_workspaces_name_length",
+    ),
+    Index("idx_workspaces_owner_id", "owner_id"),
+)
+
+# workspace_sources — created via raw SQL in e9f0a1b2c3d5 (F4-B Core)
+Table(
+    "workspace_sources",
+    INGESTION_METADATA,
+    Column("workspace_id", UUID(as_uuid=True), nullable=False),
+    Column("source_id", String(), nullable=False),
+    Column(
+        "added_at",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    ),
+    PrimaryKeyConstraint("workspace_id", "source_id", name="pk_workspace_sources"),
+    ForeignKeyConstraint(
+        ["workspace_id"],
+        ["workspaces.id"],
+        ondelete="CASCADE",
+        name="workspace_sources_workspace_id_fkey",
+    ),
+    ForeignKeyConstraint(
+        ["source_id"],
+        ["sources.source_id"],
+        ondelete="CASCADE",
+        name="workspace_sources_source_id_fkey",
+    ),
+    Index("idx_workspace_sources_source_id", "source_id"),
 )
 
 # watch_interests — created via raw SQL in c8e9f0a1b2c3 (F11)

--- a/tg_parser/storage/sqlalchemy/workspace_repo.py
+++ b/tg_parser/storage/sqlalchemy/workspace_repo.py
@@ -1,0 +1,178 @@
+"""SQLAlchemy implementation of WorkspaceRepo (F4-B Core)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tg_parser.domain.models import Workspace
+from tg_parser.storage.ports import WorkspaceRepo
+
+_SELECT_COLUMNS = "id, owner_id, name, description, created_at, updated_at"
+
+
+class SAWorkspaceRepo(WorkspaceRepo):
+    """PostgreSQL-backed workspace repository (ingestion DB).
+
+    Mirrors the structure of :class:`SADigestSubscriptionRepo` — short
+    SQL strings via :func:`sqlalchemy.text`, explicit ``commit`` after each
+    write so callers can rely on the row being visible to subsequent
+    sessions.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(
+        self,
+        *,
+        owner_id: str,
+        name: str,
+        description: str | None = None,
+    ) -> Workspace:
+        query = text(
+            f"""
+            INSERT INTO workspaces (owner_id, name, description)
+            VALUES (:owner_id, :name, :description)
+            RETURNING {_SELECT_COLUMNS}
+            """
+        )
+        result = await self.session.execute(
+            query,
+            {"owner_id": owner_id, "name": name, "description": description},
+        )
+        row = result.fetchone()
+        await self.session.commit()
+        return self._row_to_model(row)
+
+    async def get(self, workspace_id: str) -> Workspace | None:
+        result = await self.session.execute(
+            text(f"SELECT {_SELECT_COLUMNS} FROM workspaces WHERE id = :id"),
+            {"id": workspace_id},
+        )
+        row = result.fetchone()
+        return self._row_to_model(row) if row else None
+
+    async def list_by_owner(self, owner_id: str) -> list[Workspace]:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM workspaces "
+                f"WHERE owner_id = :owner_id ORDER BY created_at"
+            ),
+            {"owner_id": owner_id},
+        )
+        return [self._row_to_model(row) for row in result.fetchall()]
+
+    async def list_all(self, owner_id: str | None = None) -> list[Workspace]:
+        if owner_id is not None:
+            return await self.list_by_owner(owner_id)
+        result = await self.session.execute(
+            text(f"SELECT {_SELECT_COLUMNS} FROM workspaces ORDER BY created_at"),
+        )
+        return [self._row_to_model(row) for row in result.fetchall()]
+
+    async def rename(self, workspace_id: str, new_name: str) -> Workspace | None:
+        result = await self.session.execute(
+            text(
+                f"UPDATE workspaces SET name = :name, updated_at = NOW() "
+                f"WHERE id = :id RETURNING {_SELECT_COLUMNS}"
+            ),
+            {"id": workspace_id, "name": new_name},
+        )
+        row = result.fetchone()
+        await self.session.commit()
+        return self._row_to_model(row) if row else None
+
+    async def delete(self, workspace_id: str) -> bool:
+        result = await self.session.execute(
+            text("DELETE FROM workspaces WHERE id = :id"),
+            {"id": workspace_id},
+        )
+        await self.session.commit()
+        return (result.rowcount or 0) > 0
+
+    async def add_source(self, workspace_id: str, source_id: str) -> bool:
+        result = await self.session.execute(
+            text(
+                "INSERT INTO workspace_sources (workspace_id, source_id) "
+                "VALUES (:workspace_id, :source_id) ON CONFLICT DO NOTHING"
+            ),
+            {"workspace_id": workspace_id, "source_id": source_id},
+        )
+        await self.session.commit()
+        return (result.rowcount or 0) > 0
+
+    async def remove_source(self, workspace_id: str, source_id: str) -> bool:
+        result = await self.session.execute(
+            text(
+                "DELETE FROM workspace_sources "
+                "WHERE workspace_id = :workspace_id AND source_id = :source_id"
+            ),
+            {"workspace_id": workspace_id, "source_id": source_id},
+        )
+        await self.session.commit()
+        return (result.rowcount or 0) > 0
+
+    async def list_source_ids(self, workspace_id: str) -> list[str]:
+        result = await self.session.execute(
+            text(
+                "SELECT source_id FROM workspace_sources "
+                "WHERE workspace_id = :workspace_id ORDER BY source_id"
+            ),
+            {"workspace_id": workspace_id},
+        )
+        return [row.source_id for row in result.fetchall()]
+
+    async def list_channel_ids(self, workspace_id: str) -> list[str]:
+        result = await self.session.execute(
+            text(
+                "SELECT s.channel_id FROM workspace_sources ws "
+                "JOIN sources s ON s.source_id = ws.source_id "
+                "WHERE ws.workspace_id = :workspace_id "
+                "AND s.deleted_at IS NULL "
+                "ORDER BY s.channel_id"
+            ),
+            {"workspace_id": workspace_id},
+        )
+        return [row.channel_id for row in result.fetchall()]
+
+    async def resolve_source_id_for_channel(
+        self,
+        *,
+        owner_id: str | None,
+        channel_id: str,
+    ) -> str | None:
+        if owner_id is not None:
+            result = await self.session.execute(
+                text(
+                    "SELECT source_id FROM sources "
+                    "WHERE channel_id = :channel_id AND owner_id = :owner_id "
+                    "AND deleted_at IS NULL "
+                    "ORDER BY source_id LIMIT 1"
+                ),
+                {"channel_id": channel_id, "owner_id": owner_id},
+            )
+        else:
+            result = await self.session.execute(
+                text(
+                    "SELECT source_id FROM sources "
+                    "WHERE channel_id = :channel_id AND deleted_at IS NULL "
+                    "ORDER BY source_id LIMIT 1"
+                ),
+                {"channel_id": channel_id},
+            )
+        row = result.fetchone()
+        return row.source_id if row else None
+
+    @staticmethod
+    def _row_to_model(row: Any) -> Workspace:
+        return Workspace(
+            id=str(row.id),
+            owner_id=str(row.owner_id),
+            name=row.name,
+            description=row.description,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )


### PR DESCRIPTION
## Summary

Wave 1 step 2 per [`PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md` § 5.1](docs/notes/PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md): thematic workspace collections layered over F4-A multi-tenancy. Single PR + **6 atomic commits** (5 sprint phases + 1 self-review), +134 new F4-B tests. Source of truth: [`START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md`](docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md).

## What landed

| # | Commit | What |
|---|---|---|
| 1/6 | `010bab1 feat(F4-B): schema for workspaces` | `workspaces` + `workspace_sources` (alembic `e9f0a1b2c3d5`), Pydantic models, JSON Schema contract, 10 schema tests. |
| 2/6 | `375936e feat(F4-B): service + repo + ownership` | `WorkspaceRepo` / `SAWorkspaceRepo`, `WorkspaceNotFound` / `assert_workspace_access`, `WorkspaceService` with `effective_channel_ids` resolver + channel_id → source_id translation, 32 tests. |
| 3/6 | `3674c72 feat(F4-B): MCP + CLI surface` | 8 MCP tools (CRUD + membership + admin list) + `tg-parser workspace` Typer-app with 8 subcommands, 20 surface tests. |
| 4/6 | `6893b13 feat(F4-B): scoping integration in read-tools` | `workspace_id: str \| None = None` on 8 read MCP tools + `--workspace-id` on `tg-parser search` / `ask`; `_resolve_workspace_scope` helper; Q4 R3 invariant for `get_topic_details` / `get_document`; 14 scoping tests. |
| 5/6 | `179d6ee test(F4-B): regression guards + observability + docs` | Backward-compat (12) + isolation (6) + metrics (8) + golden-path (1) tests; `tg_workspace_*` Prometheus series; structlog + metric instrumentation; CHANGELOG / FUTURE_FEATURES / ROADMAP updates. |
| 6/6 | `14f9f1b test(F4-B): self-review fixes for workspace test suite` | Self-review pass: +27 new tests, 4 strengthened, ~10 logical/observability gaps closed (Q4 R3 happy paths, Q6 any-source mirror, G3 explicit-empty vs null, G4 non-atomic move composition, full read-tool matrix, resolver metric-path discrimination, Q3/Q7/Q8 deferred-surface regression guards). New file `test_f4b_deferred_surface_guard.py`. 0 production bugs discovered. |

## Hard invariants (locked Q1–Q8 + Karpathy 7-checklist)

- `workspace_id=None` → bit-for-bit F4-A behaviour (regression-guarded across all 8 scoped tools).
- Unknown / foreign `workspace_id` → 404-like empty (`WorkspaceNotFound` caught at surface; never leaks existence).
- Empty workspace → `effective_channel_ids=[]` (explicit, not silent "all channels" — hidden gotcha § 3).
- `get_topic_details` / `get_document` return FULL bundle items regardless of workspace (Q4 R3 — workspace narrows list / search, not access control for get-details).
- Service-layer signatures (`retrieval_service.search` and friends) UNCHANGED — narrowing lives on the surface level via `_resolve_workspace_scope`.

## Observability

- `tg_workspace_total` (Gauge), `tg_workspace_size` / `tg_workspace_effective_size` (Histograms), `tg_workspace_resolver_seconds` (Histogram), `tg_workspace_query_total{result=scoped|null_fallback|not_found}` (Counter), `tg_workspace_tool_total{tool, result}` (Counter).
- structlog binds `user_id` / `workspace_id` / `resolver_seconds` in every resolve event.

## Pre-flight gate-1 (back-filled SSH check on `tg_parser_bot`)

| Check | Result |
|---|---|
| Prometheus `up{service="bot"}` | `1` ✅ |
| `confirm_flow_mismatch` 72h | `0` ✅ |
| `gemini_(empty\|no_candidates\|blocked\|api_error)` 72h | `0` ✅ |
| Local stack + alembic + baseline pytest | ✅ |

All gate-1 conditions GREEN.

## Test plan

- [x] `ruff format --check .` clean (311 files).
- [x] `ruff check .` clean.
- [x] `TEST_POSTGRES=1 TEST_TESTCONTAINERS=1 pytest -q` → **2347 passed, 0 skipped, 0 failures** (baseline 2047 + 134 new F4-B tests + ambient passes + 9 prev-skipped testcontainers tests now enabled).
- [x] Targeted F4-B suite (`tests/test_f4b_*.py`): 134 / 134 pass.
- [x] Targeted regression (F4-A scoped-access + vector-search isolation): 117 / 117 pass.
- [x] Pre-flight gate-1 GREEN back-filled (Prometheus + `confirm_flow_mismatch` + `gemini_*` over 72h on `tg_parser_bot`).
- [x] Self-review pass: production code locked, no false positives uncovered, 0 production bugs.

## Deferred (Wave 1 step 3+ / Wave 2)

- O-1 atomic `move_workspace_source` — non-atomic `remove` + `add` used in MVP, see [`PARITY_DECISION_TRACKING.md` § 3](docs/notes/PARITY_DECISION_TRACKING.md).
- Bot integration (`tg_parser/bot/tools.py`) — locked Q3.
- F11 watchlist `workspace_id` — locked Q7.
- F6 digest `workspace_id` — locked Q8.
- Sharing / audience A2 / A3 — Wave 2+.

Each of the above is actively regression-guarded by `tests/test_f4b_deferred_surface_guard.py` — silent re-addition will fail loudly.

## Post-merge 24h watch

Deploy → 24h watch on `tg_parser_bot` (mirror Session G pattern): `confirm_flow_mismatch` / `gemini_*` counters stable at 0, `tg_workspace_resolver_seconds` p99 not drifting on the bot pipeline. Then close Wave 1 step 2 DONE marker.

Made with [Cursor](https://cursor.com)