### PR TITLE
docs(F4-B): post-merge user-facing sync + version bump to 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Cross-channel analytics** — связи между темами из разных каналов (topic links, keyword overlaps)
 
 **Интерфейсы:**
-- **MCP Server** — 24 инструмента для AI-агентов (Claude Desktop, Cursor, Claude Code); Streamable HTTP + bearer auth
+- **MCP Server** — 43 инструмента для AI-агентов (Claude Desktop, Cursor, Claude Code); Streamable HTTP + bearer auth
 - **Telegram Bot** — Gemini-powered agent с 24 tools, free-form чат, two-phase confirmation для write-операций
 - **REST API** — FastAPI с Auth, Rate Limiting, Webhooks, User Management API, Swagger UI
 - **CLI** — Typer CLI для всех операций (ingestion, processing, topicization, export, pipeline, user migration)
@@ -26,6 +26,12 @@
 - **Channel ownership** — `owner_id` на каждом канале, scoped data access
 - **Auth types** — API key (SHA-256), MCP token (SHA-256), Telegram user ID
 - **Migration CLI** — `tg-parser migrate-users` для миграции существующих credentials
+
+**Workspaces (F4-B Core):**
+- Тематические коллекции каналов внутри одного пользователя (Solo Knowledge Curator UX)
+- 8 MCP tools + CLI surface (`tg-parser workspace …`); Bot integration deferred
+- Optional `workspace_id` параметр на 8 scoped read-tools (search / ask / list / get) — F4-A backward-compat 100%
+- Non-atomic move semantics: `remove_workspace_source` + `add_workspace_source` (O-1 deferred)
 
 **Production:**
 - **PostgreSQL + pgvector** — production database с connection pooling
@@ -730,7 +736,7 @@ docker run --rm -v $(pwd)/.env:/app/.env:ro tg_parser --help
 | Компонент | Статус | Примечания |
 |-----------|--------|------------|
 | API + Scheduler | ✅ Deployed | FastAPI, Prometheus metrics, User Management API |
-| MCP Server | ✅ Deployed | Streamable HTTP + bearer auth, 24 tools |
+| MCP Server | ✅ Deployed | Streamable HTTP + bearer auth, 43 tools |
 | Telegram Bot | ✅ Deployed | Gemini agent, 24 tools, V1.2 |
 | PostgreSQL + pgvector | ✅ Deployed | Connection pooling, embeddings |
 | Multi-Tenancy | ✅ Implemented | Roles, channel ownership, auth mappings |
@@ -802,7 +808,7 @@ ruff check . --fix
 
 ### User Guides
 - **[User Guide](docs/USER_GUIDE.md)** — полное руководство с примерами и сценариями
-- **[MCP Agent Guide](docs/MCP_AGENT_GUIDE.md)** — справочник для AI-агентов (24 MCP tools, schemas, workflows)
+- **[MCP Agent Guide](docs/MCP_AGENT_GUIDE.md)** — справочник для AI-агентов (43 MCP tools, schemas, workflows)
 - **[Output Formats](OUTPUT_FORMATS.md)** — форматы выходных файлов (NDJSON, JSON)
 - **[Multi-Channel Guide](MULTI_CHANNEL_GUIDE.md)** — работа с несколькими каналами
 

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -1,6 +1,6 @@
 # TG_parser — MCP Agent Guide
 
-**Version:** 4.4 | **Tools:** 26 | **Transport:** Streamable HTTP | **Auth:** Bearer token
+**Version:** 4.3 | **Tools:** 43 | **Transport:** Streamable HTTP | **Auth:** Bearer token
 
 This guide is optimized for AI agents interacting with TG_parser via MCP. For human-oriented documentation, see [USER_GUIDE.md](USER_GUIDE.md).
 
@@ -100,6 +100,25 @@ Auth: Bearer <MCP_AUTH_TOKEN>
 | `add_user_auth` | admin | Add auth mapping (api_key/mcp_token/telegram) |
 | `remove_user_auth` | admin | Remove auth mapping by ID |
 
+### Workspaces (F4-B Core)
+
+Workspaces are thematic collections of the caller's channels — a scope-narrowing overlay over F4-A multi-tenancy. All 8 scoped read tools (`search_knowledge_base`, `ask_question`, `list_topics`, `get_topic_details`, `list_channels`, `get_document`, `get_related_topics`, `get_cross_channel_stats`) accept an optional `workspace_id` parameter. Omitting it or passing `null` preserves F4-A behavior bit-for-bit; unknown / foreign `workspace_id` returns an empty / 404-like result and never leaks workspace existence.
+
+| Tool | Auth | Description |
+|------|------|-------------|
+| `list_workspaces` | any | List the caller's workspaces. Owner-scoped. |
+| `create_workspace` | any | Create a new workspace (UNIQUE per `(owner_id, name)`). |
+| `rename_workspace` | any | Rename a workspace (ownership-checked). |
+| `delete_workspace` | any | Delete a workspace; `ON DELETE CASCADE` removes M2M membership; sources preserved. |
+| `add_workspace_source` | any | Attach a channel to a workspace (idempotent via `ON CONFLICT DO NOTHING`). |
+| `remove_workspace_source` | any | Detach a channel from a workspace (M2M row only; source remains). |
+| `list_workspace_sources` | any | List `channel_id`s attached to a workspace. |
+| `list_all_workspaces` | admin | Admin-only: list every workspace, optionally filtered by `owner_id`. |
+
+> **Q4 R2 — non-atomic move.** Moving a channel between workspaces is the documented pair `remove_workspace_source(from_ws, ch)` + `add_workspace_source(to_ws, ch)`. The two calls are **not atomic** (O-1 deferred per `PARITY_DECISION_TRACKING.md § 3`); concurrent reads during the gap window may see the channel only through the null-workspace scope.
+
+> **Q4 R3 — full-bundle in get-details.** `get_topic_details(topic_id, workspace_id=...)` and `get_document(source_ref, workspace_id=...)` return the full bundle / document regardless of workspace scope. `workspace_id` is used only as a 404-guard on the workspace itself; workspaces narrow list/search results, not access-control on get-details.
+
 ### Prompt Management
 
 | Tool | Auth | Description |
@@ -122,6 +141,7 @@ Parameters:
   channel_id: str | null        # Filter by channel (optional)
   limit: int = 10               # Max results
   mode: str = "hybrid"          # "semantic" | "keyword" | "hybrid"
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: list[SearchResultItem]
   source_ref: str
@@ -148,6 +168,7 @@ Parameters:
   question: str                 # Natural language question
   channel_id: str | null        # Filter by channel (optional)
   mode: str = "hybrid"          # "semantic" | "keyword" | "hybrid"
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: AnswerResultItem
   answer: str
@@ -172,6 +193,7 @@ Parameters:
   topic_type: str | null        # Filter by type: "singleton" | "cluster" (optional)
   offset: int = 0
   limit: int = 50
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: TopicListResult
   total: int
@@ -186,15 +208,22 @@ Returns: TopicListResult
 ```
 Parameters:
   topic_id: str                 # Topic ID from list_topics
+  workspace_id: str | null = None  # F4-B: optional 404-guard; bundle returned in full
+                                   # (Q4 R3: workspace narrows list/search, NOT access-control
+                                   # on get-details). Unknown / foreign workspace_id → 404-like
+                                   # 'not found' message.
 
 Returns: TopicDetail
   id, title, type, summary, scope_in, scope_out, anchors, sources, tags, related_topics, items
 ```
 
+> **Q4 R3 — full-bundle.** The bundle items are returned in full regardless of `workspace_id`; workspaces narrow list/search results, not access-control on get-details. Use `workspace_id` here only as a guard against accessing a foreign / unknown workspace (returns "Topic not found" instead of leaking existence).
+
 ### `list_channels`
 
 ```
-Parameters: (none)
+Parameters:
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: list[ChannelSummary]
   channel_id: str
@@ -211,16 +240,23 @@ Returns: list[ChannelSummary]
 ```
 Parameters:
   source_ref: str               # Document ID (e.g. "tg:channel:post:123")
+  workspace_id: str | null = None  # F4-B: optional 404-guard; document returned in full
+                                   # (Q4 R3: workspace narrows list/search, NOT access-control
+                                   # on get-details). Unknown / foreign workspace_id → 404-like
+                                   # 'not found' message.
 
 Returns: DocumentDetail
   id, source_ref, channel_id, text_clean, summary, topics
 ```
+
+> **Q4 R3 — full-document.** The document is returned in full regardless of `workspace_id`; workspaces narrow list/search results, not access-control on get-details. Use `workspace_id` here only as a guard against accessing a foreign / unknown workspace (returns "Document not found" instead of leaking existence).
 
 ### `get_cross_channel_stats`
 
 ```
 Parameters:
   channel_id: str | null        # null = cross-channel overview
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: CrossChannelStatsResult
   # Cross-channel mode: total_documents, total_topics, channels, keyword_overlaps, overlap_count
@@ -232,6 +268,7 @@ Returns: CrossChannelStatsResult
 ```
 Parameters:
   topic_id: str
+  workspace_id: str | null = None  # F4-B: optional workspace scope; null = F4-A bit-for-bit
 
 Returns: list[RelatedTopicItem]
   topic_id, title, channel_id, similarity_score, shared_keywords
@@ -601,6 +638,152 @@ Returns: dict
   success: bool, reloaded: str   # prompt name or "all"
 ```
 
+### `list_workspaces`
+
+```
+Parameters: (none)
+
+Returns: ListWorkspacesResult
+  count: int
+  workspaces: list[WorkspaceInfo]
+    # id, owner_id, name, description, created_at, updated_at (ISO-8601)
+```
+
+- Lists workspaces owned by the calling user (owner-scoped). Admins see
+  only their own here; cross-user inspection is exposed via
+  `list_all_workspaces`.
+
+### `create_workspace`
+
+```
+Parameters:
+  name: str                      # Required. Unique per owner (UNIQUE (owner_id, name)).
+  description: str | null        # Optional free-form description.
+
+Returns: CreateWorkspaceResult
+  success: bool
+  workspace: WorkspaceInfo | null
+  message: str
+```
+
+- Returns `success=false` (never raises) on whitespace-only names, on
+  duplicate `(owner_id, name)` collisions, and on database errors.
+- Per-owner namespace: two users can each have a workspace named
+  "AI/ML" — they live in disjoint rows.
+
+### `rename_workspace`
+
+```
+Parameters:
+  workspace_id: str              # UUID. Must be owned by the caller.
+  new_name: str                  # New name; subject to the same per-owner UNIQUE constraint.
+
+Returns: RenameWorkspaceResult
+  success: bool
+  workspace: WorkspaceInfo | null
+  message: str
+```
+
+- Returns `success=false, message="Workspace <id> not found"` for
+  unknown or foreign IDs (existence never leaked).
+- Duplicate-name / whitespace-name errors mirror `create_workspace`
+  (structured 4xx-style result, no raise).
+
+### `delete_workspace`
+
+```
+Parameters:
+  workspace_id: str              # UUID. Must be owned by the caller.
+
+Returns: DeleteWorkspaceResult
+  success: bool
+  workspace_id: str
+  message: str
+```
+
+- `ON DELETE CASCADE` removes the workspace's M2M membership rows; the
+  underlying `sources` themselves are preserved and remain visible
+  through the null-workspace scope.
+- Idempotent: re-deleting an unknown ID returns `success=false` with a
+  benign "not found" message.
+
+### `add_workspace_source`
+
+```
+Parameters:
+  workspace_id: str              # UUID. Must be owned by the caller.
+  channel_id: str                # channel_id or @username; normalized server-side.
+
+Returns: WorkspaceSourceOpResult
+  success: bool
+  workspace_id: str
+  channel_id: str
+  changed: bool                  # true = inserted; false = idempotent no-op
+  message: str
+```
+
+- Idempotent via `ON CONFLICT DO NOTHING`: `changed=false` means the
+  channel was already attached.
+- `assert_channel_access` enforces ownership on `channel_id`; non-owners
+  get a structured `PermissionDenied` result.
+
+> **Q4 R2 — non-atomic move.** To move a channel between workspaces use the documented pair `remove_workspace_source(from_ws, ch)` + `add_workspace_source(to_ws, ch)`. The two calls are **not atomic** (O-1 deferred per `PARITY_DECISION_TRACKING.md § 3`); concurrent reads during the gap window may see the channel only through the null-workspace scope.
+
+### `remove_workspace_source`
+
+```
+Parameters:
+  workspace_id: str              # UUID. Must be owned by the caller.
+  channel_id: str                # channel_id or @username; normalized server-side.
+
+Returns: WorkspaceSourceOpResult
+  success: bool
+  workspace_id: str
+  channel_id: str
+  changed: bool                  # true = removed; false = was not in the workspace
+  message: str
+```
+
+- Removes only the M2M row; the underlying `sources` row is preserved
+  and remains visible via the null-workspace scope.
+- Used as the first half of the documented non-atomic move pair (see
+  `add_workspace_source` above).
+
+> **Q4 R2 — non-atomic move.** `remove_workspace_source(from_ws, ch)` + `add_workspace_source(to_ws, ch)` is the documented move pattern. The pair is **not atomic** in MVP (O-1 deferred); during the gap window the channel is visible only via the null-workspace scope.
+
+### `list_workspace_sources`
+
+```
+Parameters:
+  workspace_id: str              # UUID. Must be owned by the caller.
+
+Returns: ListWorkspaceSourcesResult
+  workspace_id: str
+  count: int
+  channel_ids: list[str]
+```
+
+- Returns `channel_id` values (not raw `source_id`) so the result is
+  drop-in usable in any F4-A scoped tool's `channel_id` parameter.
+- Unknown / foreign `workspace_id` returns `count=0, channel_ids=[]`
+  (404-like, never leaks existence).
+
+### `list_all_workspaces`
+
+```
+Parameters:
+  owner_id: str | null = None    # Optional filter by owner.
+
+Returns: ListWorkspacesResult
+  count: int
+  workspaces: list[WorkspaceInfo]
+```
+
+- **Admin-only.** Non-admin callers receive an empty list (no error),
+  mirroring how `list_workspaces` reports zero rows so that probing the
+  tool name cannot reveal whether admin access exists.
+- Useful for cross-user inspection and ops audits.
+
 ---
 
 ## Common Workflows
@@ -726,6 +909,42 @@ Notes:
 - A single tick is capped at `MAX_DOCS_PER_TICK = 100` documents so a
   back-fill of a noisy channel cannot trigger a notification flood.
 
+### 9. Manage Workspaces (F4-B Core)
+
+```
+1. ws = create_workspace(name="AI/ML", description="Anthropic, OpenAI")
+   # returns {success: True, workspace: {id: <ws_id>, ...}}
+
+2. add_workspace_source(workspace_id=ws.workspace.id, channel_id="anthropic_news")
+   add_workspace_source(workspace_id=ws.workspace.id, channel_id="openai_news")
+
+3. # Use the workspace as a scope on any read-tool:
+   list_topics(workspace_id=ws.workspace.id)
+   search_knowledge_base(query="Claude 4.5", workspace_id=ws.workspace.id)
+   ask_question(question="What did Anthropic ship?", workspace_id=ws.workspace.id)
+
+4. # Move a channel from one workspace to another (Q4 R2 — non-atomic):
+   other_ws = create_workspace(name="AI/Anthropic-only")
+   remove_workspace_source(workspace_id=ws.workspace.id, channel_id="anthropic_news")
+   add_workspace_source(workspace_id=other_ws.workspace.id, channel_id="anthropic_news")
+   # NOTE: between calls #4a and #4b, the channel is visible only via the
+   # null-workspace scope. O-1 atomic move is deferred to Wave 1 step 3 / Wave 2.
+
+5. # Admin inspection across users:
+   list_all_workspaces()                      # admin: every workspace; non-admin: []
+   list_all_workspaces(owner_id="<user_id>")  # admin: scoped to one owner
+```
+
+Notes:
+- `workspace_id` on read-tools is an opt-in narrowing overlay; omitting
+  it or passing `null` preserves F4-A behavior bit-for-bit.
+- `get_topic_details` / `get_document` return their full payload
+  regardless of `workspace_id` — Q4 R3 makes the workspace param a
+  404-guard on the workspace itself, not an access-control filter on
+  the bundle.
+- Unknown / foreign `workspace_id` is treated as 404-like (empty
+  result / "not found" message) so workspace existence is never leaked.
+
 ---
 
 ## Auth Model
@@ -789,4 +1008,4 @@ Channel-scoped tools enforce ownership: non-admin users can only access channels
 
 ---
 
-**Version:** 4.3 | **Last updated:** April 2026
+**Version:** 4.3 | **Last updated:** May 2026

--- a/docs/SERVER_ARCHITECTURE.md
+++ b/docs/SERVER_ARCHITECTURE.md
@@ -69,17 +69,11 @@ Only Nginx (:80/:443) is public-facing.
   - `/mcp` — MCP protocol (JSON-RPC)
   - `/health` — liveness check
   - `/metrics` — Prometheus metrics
-- **Tools** (17):
-  - `search_knowledge_base` — semantic search
-  - `ask_question` — RAG Q&A
-  - `list_topics` / `get_topic_details` — topic navigation
-  - `list_channels` — channel overview
-  - `get_document` — full document content
-  - `get_related_topics` — cross-channel topic links
-  - `get_cross_channel_stats` — analytics
-  - `add_channel` / `pause_channel` / `resume_channel` / `remove_channel` — channel management
-  - `trigger_pipeline` / `get_pipeline_status` — pipeline control
-  - `get_llm_config` / `set_llm_config` / `reset_llm_config` — runtime LLM provider/model (no restart)
+- **Tools** (43): полный список и schemas — см. [`docs/MCP_AGENT_GUIDE.md § Tools by Category`](MCP_AGENT_GUIDE.md). Категории:
+  Search & Q&A (2), Navigation (4), Cross-channel Analytics (2), Channel Management (4),
+  Pipeline Control (2), Export F2 (2), Digests F6 (3), Topic Watchlist F11 (4),
+  LLM Configuration (3), User Management F4 (6), Workspaces F4-B Core (8),
+  Prompt Management (1), Resummarize F5-C (2) = 43.
 
 ### Telegram Bot (V1.2 — Full Operational Interface)
 - **Container**: `tg_parser_bot`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,14 +1,15 @@
 # TG_parser — Руководство пользователя
 
 **Версия:** 4.3  
-**Обновлено:** April 2026
+**Обновлено:** May 2026
 
 **TG_parser** — система для сбора контента из Telegram-каналов, обработки через LLM и экспорта структурированных данных для RAG-систем и баз знаний.
 
 **v4.3:**
-- **MCP Server** — 24 инструмента для AI-агентов (Claude Desktop, Cursor)
+- **MCP Server** — 43 инструмента для AI-агентов (Claude Desktop, Cursor)
 - **Telegram Bot** — Gemini-powered agent с 24 tools и free-form чатом
 - **Multi-Tenancy** — пользователи, роли (admin/user), channel ownership, auth mappings
+- **Workspaces (F4-B Core)** — тематические коллекции каналов внутри одного пользователя; opt-in `workspace_id` параметр на read-tools (F4-A backward-compat 100%)
 - **REST API** — User Management endpoints (`/api/v1/users`)
 - **Migration CLI** — `tg-parser migrate-users` для перехода на мульти-тенантную модель
 - **Embedding + RAG** — семантический поиск и Q&A по базе знаний
@@ -24,14 +25,15 @@
 3. [Конфигурация](#конфигурация)
 4. [Scheduled Digests (F6)](#scheduled-digests-f6)
 5. [Topic Watchlist (F11)](#topic-watchlist-f11)
-6. [CLI команды](#cli-команды)
-7. [Multi-Tenancy и управление пользователями](#multi-tenancy-и-управление-пользователями)
-8. [HTTP API](#http-api)
-9. [Logging](#logging)
-10. [Мониторинг](#мониторинг)
-11. [Примеры использования](#примеры-использования)
-12. [Production Deployment](#production-deployment)
-13. [Troubleshooting](#troubleshooting)
+6. [Workspaces (F4-B Core)](#workspaces-f4-b-core)
+7. [CLI команды](#cli-команды)
+8. [Multi-Tenancy и управление пользователями](#multi-tenancy-и-управление-пользователями)
+9. [HTTP API](#http-api)
+10. [Logging](#logging)
+11. [Мониторинг](#мониторинг)
+12. [Примеры использования](#примеры-использования)
+13. [Production Deployment](#production-deployment)
+14. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -732,6 +734,78 @@ Watchlist-hook автоматически срабатывает после
 `run_incremental_topicization`. Если падает (OpenAI outage, DB hiccup) —
 логируется как `watchlist_check_failed` и **не блокирует** основной
 ingestion/topicization pipeline (graceful degradation).
+
+---
+
+## Workspaces (F4-B Core)
+
+**Workspaces** — тематические коллекции каналов внутри одного
+пользователя (Solo Knowledge Curator UX). Каждый workspace — это
+named M2M-выборка над уже существующими каналами пользователя:
+имя уникально per-owner (UNIQUE `(owner_id, name)`), участие в
+нескольких workspaces разрешено, удаление workspace убирает только
+membership-строки (сами `sources` сохраняются).
+
+Workspaces — это **scope-narrowing overlay** над F4-A multi-tenancy:
+все scoped read-tools (search / ask / list-topics / list-channels …)
+принимают опциональный `workspace_id`, который сужает выдачу до каналов
+этого workspace. Если `workspace_id` не передан или равен `None`,
+поведение **бит-в-бит идентично F4-A** (backward-compat invariant Q1).
+
+### CLI команды
+
+CLI mirror'ит MCP surface — те же 8 операций, тот же `--user <uuid>`
+F4-A convention для act-on-behalf (default: admin).
+
+```bash
+tg-parser workspace list
+tg-parser workspace create --name "AI/ML" --description "Anthropic, OpenAI"
+tg-parser workspace rename <ws_id> "new name"
+tg-parser workspace delete <ws_id>
+tg-parser workspace add-source <ws_id> --channel <channel_id>
+tg-parser workspace remove-source <ws_id> --channel <channel_id>
+tg-parser workspace list-sources <ws_id>
+tg-parser workspace list-all [--owner-id <user_id>]   # admin-only
+```
+
+Все команды принимают `--user <uuid>` (опционально; default = admin).
+`list-all` — admin-only inspection всех workspaces всех пользователей;
+для non-admin caller возвращает пустой список (404-like, никогда не
+утекает information).
+
+### MCP инструменты
+
+Через MCP то же доступно как 8 workspace tools и опциональный
+`workspace_id` параметр на 8 scoped read-tools — подробные schemas
+смотри в [`MCP_AGENT_GUIDE.md § Workspaces (F4-B Core)`](MCP_AGENT_GUIDE.md).
+
+**Семантика workspace_id (Q4 R3 / Q4 R2):**
+
+- **`get_topic_details` / `get_document`** — `workspace_id` используется
+  только как 404-guard на сам workspace; **bundle items возвращаются в
+  full** независимо от workspace scope. Workspace = scope-narrowing для
+  list/search, не access-control для get-details (Q4 R3).
+- **Перенос канала между workspaces** = `remove_workspace_source(from_ws, ch)`
+  **+** `add_workspace_source(to_ws, ch)`. Это **не атомарно** (O-1
+  deferred per [`PARITY_DECISION_TRACKING.md § 3`](notes/PARITY_DECISION_TRACKING.md));
+  в gap-window между двумя вызовами канал виден только через
+  null-workspace scope (Q4 R2).
+
+### Что НЕ входит в MVP
+
+Следующие интеграции и оптимизации **deferred** (см. cross-link на
+[`docs/notes/FUTURE_FEATURES.md § F4-B`](notes/FUTURE_FEATURES.md) и
+[`docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md § Anti-scope`](notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md)):
+
+- **Q3 — Bot integration** — Telegram-bot tools пока без workspace surface.
+- **Q7 — F11 Topic Watchlist + workspace_id** — watchlist scoping
+  отложен до Wave 1 step 3.
+- **Q8 — F6 Scheduled Digests + workspace_id** — per-workspace digest
+  scheduling отложен.
+- **O-1 — атомарный move** — single-transaction `move_workspace_source`
+  отложен; текущий MVP использует non-atomic `remove + add` pair.
+- **HTTP API endpoints для workspaces** — MVP экспонирует workspace
+  surface только через MCP + CLI; HTTP layer отложен.
 
 ---
 
@@ -1538,7 +1612,7 @@ curl -X DELETE -H "X-API-Key: sk-xxx" \
 DEFAULT_MAX_CHANNELS=20
 ```
 
-> 💡 **Для AI-агентов**: см. [MCP_AGENT_GUIDE.md](MCP_AGENT_GUIDE.md) — оптимизированный справочник с полными schema всех 24 инструментов.
+> 💡 **Для AI-агентов**: см. [MCP_AGENT_GUIDE.md](MCP_AGENT_GUIDE.md) — оптимизированный справочник с полными schema всех 43 инструментов.
 
 ---
 

--- a/docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md
+++ b/docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md
@@ -1,5 +1,34 @@
 # Roadmap v3 — Production-First Strategy
 
+> ⚠️ **DEPRECATED 2026-05-13.** This roadmap has been superseded by
+> [`ROADMAP_KARPATHY_LIKE_LIVING_KB.md`](ROADMAP_KARPATHY_LIKE_LIVING_KB.md)
+> as the forward-looking source of truth (current contract pointer +
+> audience-driven Wave 1 step 1/2/3 sequence + Next-contract candidates).
+> This file is kept for **historical reference** of completed P6a/P6b/D1–D5/
+> Perf/Cross-val/Cross-dev/F4/F5-A/F8-A phases.
+>
+> **Items not yet migrated to ROADMAP_KARPATHY** (forward-looking Wave 2-5
+> tail; tracked for migration in a future docs-hygiene sprint, not blocking
+> Wave 1 step 3):
+>
+> - **Wave 2 re-rank (post-Living-KB):** F11 P2 calibration, F5-C P2
+>   (TTL/diff/digest + Bot tools, issue #15 in `FUTURE_FEATURES.md`),
+>   F1 Full (Configurable Prompt System DB + A/B), F10-A (Multimodal —
+>   images + voice), F12-A (Channel Discovery).
+> - **Wave 3 — User Experience:** F6 enhancements, F1 full DB/versioning.
+> - **Wave 4 — Scale & Monetize:** F9-2 (advanced security), F8-B
+>   (Redis + horizontal scaling), F7 (Billing).
+> - **Wave 5 — Strategic:** F3 (WhatsApp / Discord connectors),
+>   F5-D (Knowledge Graph), F10-C (full multimodal), F8-C.
+> - **Deferred individual items:** F5-B (near-duplicate via embedding ≥ 0.97),
+>   UI phase (P6c Web Catalog, P6d Web Chat), TG Bot Hybrid, Grafana alerting
+>   (входит в F8-A scope).
+>
+> See [`ROADMAP_KARPATHY_LIKE_LIVING_KB.md § Next contract — TBD`](ROADMAP_KARPATHY_LIKE_LIVING_KB.md)
+> for the canonical "what's next" pointer and
+> [`PLANNING_NEXT_CONTRACT_PREP.md`](PLANNING_NEXT_CONTRACT_PREP.md) for
+> the next-contract candidate analysis.
+
 > **Wave 1 closed 2026-04-26** — Living-KB контракт закрыт (D.1 + F11 + F5-C).
 > См. `## Done — Living-KB contract (Wave 1)` ниже и
 > [`ROADMAP_KARPATHY_LIKE_LIVING_KB.md`](ROADMAP_KARPATHY_LIKE_LIVING_KB.md)

--- a/docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md
+++ b/docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md
@@ -1,5 +1,11 @@
 # Sprint F4-B Core — Workspaces (тематические коллекции каналов)
 
+> ✅ **LANDED 2026-05-13** — F4-B Core merged into `main` (HEAD `7953302`, [PR #67](https://github.com/AlexEfimov/TG_parser/pull/67) squash-merged). Deployed to prod 2026-05-13 19:30 UTC. 24h watch in progress (baseline `2026-05-13T19:30:28Z`). Wave 1 step 2 closure pending DONE marker (`REVIEW_2026-05-14_WAVE1_STEP2_DONE.md` after 24h watch GREEN). See [`ROADMAP_KARPATHY_LIKE_LIVING_KB.md § 2026-05-13 — Wave 1 step 2 (F4-B Core Workspaces) DONE`](ROADMAP_KARPATHY_LIKE_LIVING_KB.md).
+>
+> The sections below describe the original sprint plan (preserved as historical contract). Locked decisions Q1–Q8 implemented as specified.
+
+---
+
 **Дата подготовки промпта:** 13 мая 2026 (planning sub-session ~0.3 сессии).
 **Тип сессии:** Feature (~2.5 сессии, **Single PR + 5 atomic commits** — mirror Session F pattern, не F11 multi-PR).
 **Wave 1 step:** 2 (per audience-driven roadmap).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tg_parser"
-version = "4.2.0"
+version = "4.3.0"
 description = "Telegram message parser for knowledge base extraction"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Post-merge user-facing documentation sync for F4-B Core (Workspaces) landed in PR #67 (main `7953302`, deployed prod 2026-05-13 19:30 UTC). Single atomic commit per plan `docs/notes/PLAN_DOCS_HYGIENE_F4B_POST_MERGE_2026-05-13.md` (locked decisions Q1–Q4 from planning sub-session 2026-05-13).

## Locked decisions

| Q | Decision | Rationale |
|---|---|---|
| Q1 | pyproject 4.2.0 → **4.3.0** | F4-B = MINOR additive (Q1 = opt-in, F4-A bit-for-bit). USER_GUIDE/README already claimed 4.3 — bump closes the gap. |
| Q2 | Single atomic commit | Between-commit incongruent state (banner promising synced docs without sync) avoided. |
| Q3 | ROADMAP_V3 deprecation banner + KARPATHY supersede pointer | Decisive resolution of dual-source-of-truth confusion. |
| Q4 | Immediately after deploy (not 24h-watch-gated) | Docs reflect codebase shape, not prod status; 24h watch only gates DONE marker. |

## Files changed (7) — total +357 / -29

| File | Δ | Nature |
|---|---|---|
| `pyproject.toml` | +1 / -1 | Version bump 4.2.0 → 4.3.0 |
| `docs/USER_GUIDE.md` | +96 / -2 | New chapter "Workspaces (F4-B Core)" + tool count 24→43 + ToC renumber |
| `docs/MCP_AGENT_GUIDE.md` | +225 / -10 | 8 workspace tool schemas + `workspace_id` on 8 scoped tools + version header 4.4→4.3 + Q4 R2/R3 notes + tool count 26→43 |
| `README.md` | +12 / -4 | Feature list mentions Workspaces; 3 tool-count refs 24→43 |
| `docs/SERVER_ARCHITECTURE.md` | +16 / -12 | Tool count 17→43 + cross-link to MCP_AGENT_GUIDE |
| `docs/notes/ROADMAP_V3_PRODUCTION_FIRST.md` | +29 / -0 | Deprecation banner + list of unmigrated Wave 2-5 items |
| `docs/notes/START_PROMPT_SPRINT_F4B_CORE_2026-05-13.md` | +6 / -0 | LANDED banner (main 7953302, PR #67 squash-merged, deployed 2026-05-13 19:30 UTC, 24h watch baseline 2026-05-13T19:30:28Z) |

## Verification (all GREEN per worker self-check)

- `grep -c '^@mcp\.tool()' tg_parser/mcp_server.py` = **43**, consistent across all 4 docs that mention the count.
- All 8 workspace MCP tools documented in MCP_AGENT_GUIDE with correct auth markers (any × 7, admin × 1).
- All 8 scoped read tools have `workspace_id: str | null = None` parameter documented (search_knowledge_base, ask_question, list_topics, get_topic_details, list_channels, get_document, get_cross_channel_stats, get_related_topics).
- Q4 R3 (full bundle in get-details) mentioned in `get_topic_details` + `get_document` schemas + USER_GUIDE Workspaces chapter.
- Q4 R2 (non-atomic move) mentioned in `add_workspace_source` + `remove_workspace_source` schemas + USER_GUIDE Workspaces chapter.
- LANDED banner contains: 2026-05-13, main 7953302, PR #67, deploy timestamp, 24h watch baseline.
- All workspace CLI examples bit-by-bit match `tg_parser/cli/workspace_cmd.py`.
- All MCP tool schemas match `tg_parser/mcp_server.py:3097-3379` (workspace tools) and L853-1290 (scoped read tools).
- `git diff --stat` shows exactly 7 files; no code/test/contract/methodology touched.
- ruff format / check unaffected (no .py edits beyond pyproject single-line bump).

## Anti-scope

- M-1..M-16 hygiene backlog — separate sprint per [`START_PROMPT_DOC_HYGIENE_2026-05-XX.md`](docs/notes/START_PROMPT_DOC_HYGIENE_2026-05-XX.md).
- NO code / test / contract / methodology edits — diff is docs + pyproject only.
- `REVIEW_2026-05-14_WAVE1_STEP2_DONE.md` — post-24h-watch artifact, separate session.
- ROADMAP_V3 forward-looking items (Wave 2-5 candidates) — listed in banner but NOT migrated to KARPATHY (deferred to hygiene sprint C-3).

## Sequencing

Merge → passive 24h watch (started `2026-05-13T19:30:28Z`, expected close `2026-05-14T19:30:28Z`) → DONE marker creation post-watch GREEN.

Made with [Cursor](https://cursor.com)