### PR TITLE
chore(gitignore): exclude personal Cursor learning notes from project scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ dmypy.json
 
 # Cursor IDE (contains API keys in mcp.json)
 .cursor/
+
+# Personal Cursor learning notes — not part of project scope
+docs/notes/CURSOR_QUICKSTART_2026.md


### PR DESCRIPTION
## Summary

Adds `docs/notes/CURSOR_QUICKSTART_2026.md` to `.gitignore`. It's a personal Cursor IDE learning note (not part of TG_parser project scope) that has been showing up as untracked across multiple `git status` runs. Placed next to existing `.cursor/` entry — both relate to Cursor IDE environment, not project code.

## Test plan

- [x] `git check-ignore -v docs/notes/CURSOR_QUICKSTART_2026.md` confirms the file is now ignored (matches `.gitignore:89`).
- [x] Single-line addition + comment; no other edits.
- [x] No code / tests / contracts / methodology touched.

Made with [Cursor](https://cursor.com)