### PR TITLE
docs(notes): snapshot 2026-05-15 Claude MCP testing session

### DIFF
--- a/docs/notes/mcp_testing/2026-05-15_claude_session/01-bug-report.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/01-bug-report.md
@@ -1,0 +1,439 @@
+# tg-parser — Bug Report
+
+**Period:** 2026-05-14 session
+**Reporter:** alexanderefimov
+**Total issues:** 11 (1 отозван, 10 активных)
+
+---
+
+## Index
+
+| # | Title | Severity | Type |
+|---|---|---|---|
+| 1 | `trigger_pipeline` через MCP — silent no-op | High | Architecture |
+| 2 | Нет observability для silent failure в MCP | Medium | Observability |
+| ~~3~~ | ~~`--skip-topicize` оставлен после mitigation~~ | — | **Retracted (by design)** |
+| 3' | Misleading log message про `--skip-topicize` | Low | UX |
+| 4 | `last_attempt_at` не пишется при работе scheduler | Medium | Observability |
+| 5 | Retry без изменения промпта для JSON-parsing ошибок | Medium | Cost/Reliability |
+| 6 | HTTP 520 errors от Anthropic API без exp.backoff | Low | Reliability |
+| 7 | CLI `topicize` рапортует ✅ при тотальном fail | High | UX/Safety |
+| 8 | `get_cross_channel_stats` не использует `topic_links` | Medium | Data integrity |
+| 9 | Keywords не лемматизированы — дублирование оверлапов | Low | Data quality |
+| 10 | `subscribe_*` не идемпотентны — повторный вызов создаёт дубль | Medium | API contract |
+| 11 | «Topic failed quality criteria, skipping» — отбрасывание без деталей | Low | Observability |
+
+---
+
+## ISSUE-1 (High): `trigger_pipeline` через MCP — silent no-op
+
+### Симптом
+
+`trigger_pipeline(channel_id=...)` через MCP всегда возвращает `{triggered: true}`, но в логах основного контейнера `tg_parser` нет ни одной строки про запрошенный канал. Воспроизведено дважды (~05:43 UTC и ~06:00 UTC, см. investigation log) для канала `profendocrinologist`. Канал был обработан только при штатном тике `incremental_pipeline` в 06:28 UTC.
+
+### Root cause (подтверждён архитектурно)
+
+MCP-сервер живёт в отдельном контейнере `tg_parser_mcp`, шедулер и пайплайн — в контейнере `tg_parser`. У контейнеров нет общего канала связи, через который MCP мог бы триггернуть APScheduler в `tg_parser`. Вероятно `trigger_pipeline` запускает `asyncio.create_task` локально в MCP, но:
+- task гибнет при возврате ответа на MCP-запрос (event loop замыкается)
+- даже если выживает — у MCP нет Telethon-клиента с правильной session
+
+### Suggested fix
+
+`trigger_pipeline` в MCP должен делать HTTP-вызов в API `tg_parser` (`http://tg_parser:8000/...`), который добавляет one-shot job в APScheduler. HTTP API в `tg_parser` уже есть (видно по `docker compose ps`).
+
+### Affected files
+
+- `tg_parser/mcp/tools.py` — handler `trigger_pipeline`
+- `tg_parser/api/main.py` — нужен эндпоинт `POST /pipeline/trigger`
+- `tg_parser/services/scheduler_service.py` — метод для добавления one-shot job
+- `docker-compose.yml` — проверить network reachability
+
+### Acceptance
+
+- После `triggered: true` в логах `tg_parser` в течение 60 сек появляется `Starting ingestion: source=<channel>`
+
+---
+
+## ISSUE-2 (Medium): нет observability для silent failure в MCP
+
+### Симптом
+
+Сейчас `trigger_pipeline` возвращает `triggered: true` без какой-либо гарантии и без логирования. Нет:
+- лога «MCP received trigger_pipeline for X»
+- лога «enqueued / dispatched / failed to dispatch»
+- записи в `sources.last_attempt_at` синхронно до возврата
+
+### Suggested fix
+
+1. Логировать каждый вызов `trigger_pipeline` в MCP с уровнем INFO: `mcp_trigger_pipeline_received {channel_id}`
+2. Логировать результат диспетчеризации: `mcp_trigger_pipeline_dispatched {channel_id, dispatch_method, status}`
+3. Внешний try/except на любой фоновой задаче, которую `trigger_pipeline` создаёт — в `except` писать `last_error` и `fail_count++`
+4. Инвариант: `triggered: true` → в течение 60 сек либо `last_attempt_at IS NOT NULL`, либо `last_error IS NOT NULL`
+
+### Acceptance
+
+- Integration-тест: моком ломаем диспетчеризацию → `last_error` заполнен или `triggered: false`
+
+---
+
+## ISSUE-3 (Retracted)
+
+~~`--skip-topicize` оставлен после mitigation~~
+
+Это не баг. Найден `tg_parser/services/scheduler_service.py:112`:
+```python
+skip_topicize=True,
+```
+
+Хардкод — **архитектурное решение**: топикизация дорогая, шедулер тикает раз в час, делать топикизацию на каждом тике расточительно. Топикизация выводится в отдельный manual workflow через CLI `tg-parser topicize <channel>`.
+
+---
+
+## ISSUE-3' (Low): misleading log message
+
+### Симптом
+
+Шедулер логирует:
+```
+[3/4] Topicization skipped (--skip-topicize)
+```
+
+Звучит как «пользователь передал флаг» (runtime-опция, которую можно поменять). Реальный смысл: «шедулер не делает топикизацию by design». В результате час потрачен на гипотезу «флаг забыли снять после billing incident».
+
+### Suggested fix
+
+Заменить на:
+```
+[3/4] Topicization skipped (scheduler does not auto-topicize by design;
+       run 'tg-parser topicize <channel>' manually)
+```
+
+Или сделать топикизацию опцией шедулера с дефолтом False и env-переменной `SCHEDULER_AUTO_TOPICIZE` — тогда лог-сообщение естественно: `Topicization skipped (SCHEDULER_AUTO_TOPICIZE=false)`.
+
+### Affected files
+
+- `tg_parser/services/pipeline_service.py:236`
+
+---
+
+## ISSUE-4 (Medium): `last_attempt_at` не обновляется при работе шедулера
+
+### Симптом
+
+После успешного прогона `profendocrinologist` шедулером в 06:28-06:30 UTC `get_pipeline_status` показал:
+```json
+{
+  "last_attempt_at": null,
+  "last_success_at": "2026-05-14T06:30:47",
+  "fail_count": 0,
+  "last_error": null
+}
+```
+
+`last_success_at` заполнен, но `last_attempt_at` остался `null`. Логически это невозможно: success без attempt.
+
+Также `last_success_at` фиксирует завершение **первого этапа** (ingest), а не всего пайплайна (4 этапа).
+
+### Root cause hypothesis
+
+Поля обновляются только определёнными code paths (вероятно — только при manual trigger или legacy flow), но не везде.
+
+### Suggested fix
+
+1. Инвариант: при старте любого этапа пайплайна — синхронно пишем `last_attempt_at = now()` **до** первого await
+2. `last_success_at` обновлять только после **всего** пайплайна, не первого этапа
+3. Добавить отдельное `last_stage_*` для отслеживания прогресса по этапам
+
+### Affected files
+
+- `tg_parser/services/scheduler_service.py`
+- `tg_parser/services/pipeline_service.py`
+- `tg_parser/persistence/sources.py`
+
+---
+
+## ISSUE-5 (Medium): retry без изменения промпта при JSON parse errors
+
+### Симптом
+
+При обработке `profendocrinologist` LLM возвращал невалидный JSON:
+```
+post:1799 attempt 1 → "Invalid JSON response from LLM: Expecting ',' delimiter: line 2 column 435"
+post:1799 attempt 2 → тот же error
+post:1799 attempt 3 → тот же error → parallel_message_processing_failed
+```
+
+`max_attempts=3`, но **повторяется тот же промпт без изменений**. Гарантированный детерминированный фейл за 3 попытки и ~18 секунд накладных расходов.
+
+### Suggested fix
+
+Несколько опций (от лёгких к серьёзным):
+1. **Tool use / structured output mode** Anthropic API — гарантирует валидный JSON со стороны провайдера. Самое надёжное.
+2. **Retry с hint'ом**: «previous response had JSON parse error: <error>, please return strictly valid JSON».
+3. **Retry с `temperature=0`** на повторных попытках если изначально использовался t > 0.
+
+### Affected files
+
+- `tg_parser/processing/pipeline.py`
+
+---
+
+## ISSUE-6 (Low): HTTP 520 errors от Anthropic API
+
+### Симптом
+
+В логах в 07:01–07:02 UTC видны `Server error '520 <none>' for url 'https://api.anthropic.com/v1/messages'` для нескольких постов подряд. Cloudflare 520 — обычно временное (downtime/rate-limit на стороне Anthropic). Retry-логика отрабатывает.
+
+### Suggested fix
+
+- Exponential backoff с jitter для 520/529/503 ответов
+- Метрика `anthropic_api_5xx_errors_total{status}` в Prometheus
+
+### Affected files
+
+- `tg_parser/processing/pipeline.py` (или там, где Anthropic client)
+
+---
+
+## ISSUE-7 (High, misleading): CLI `topicize` рапортует успех при тотальном fail
+
+### Симптом
+
+Запущена топикизация `kdl_ru` в 07:33 UTC после пополнения баланса. Все 17 батчей упали с `Your credit balance is too low to access the Anthropic API`. Тем не менее CLI вывел:
+
+```
+✅ Topicization завершён:
+   • Создано тем: 0
+   • Создано подборок: 0
+   • Coverage: 0.0% (0/841 documents)
+
+⚠️  Темы не созданы (возможно, недостаточно данных)
+```
+
+И вернул exit code 0 (предположительно).
+
+### Почему критично
+
+1. **Misleading status:** `✅ завершён` при нулевом результате
+2. **Misleading diagnosis:** «возможно, недостаточно данных» — фактическая причина «все батчи отказали из-за billing-ошибки API»
+3. **Exit code:** скрипт автоматизации будет считать вызов успешным
+4. **Тратится время оператора:** легко не заметить
+
+### Root cause
+
+В `topicization_service.py` (или вызывающем коде) отсутствует проверка, что критическое число батчей упало по системной причине. Logic типа:
+```python
+result = await run_batches(...)  # все упали — но silently
+return TopicizationResult(topic_cards=0, ...)  # ← false success
+```
+
+### Suggested fix
+
+1. **Различать «0 тем» vs «все батчи провалены»**: если `failed_batches / total_batches > threshold` (например > 50%) — failure, не success
+2. **Различать класс ошибки**: billing/auth → exit code 2 (системный фейл), parser errors → exit code 0 с warning
+3. **CLI message** при тотальном fail:
+   ```
+   ❌ Topicization failed: 17/17 batches errored
+   First error: Your credit balance is too low...
+   No topics created. Fix API credentials/billing and retry.
+   ```
+4. **Минимальный фикс:** поднимать non-zero exit code если все батчи провалены
+
+### Affected files
+
+- `tg_parser/services/topicization_service.py`
+- `tg_parser/processing/topicization.py`
+- `tg_parser/cli/app.py` — handler команды `topicize`
+
+### Acceptance
+
+- При billing-ошибке API: non-zero exit code и явное сообщение причины
+- Partial fail (3 из 17): exit code 0, явное указание N успехов / M провалов
+
+---
+
+## ISSUE-8 (Medium): `get_cross_channel_stats` игнорирует `topic_links`
+
+### Симптом
+
+После запуска `link-topics` создаются связи между топиками на основе Jaccard + cosine similarity (создано 746 связей при threshold=0.3). `get_cross_channel_stats` про эти связи не знает и продолжает считать overlap только по keywords.
+
+Воспроизведение: `get_cross_channel_stats` до и после `link-topics` возвращает идентичный JSON.
+
+### Почему важно
+
+Реальная семантическая связность системы недооценена. Из примера: тема `topic:tg:profendocrinologist:post:582` (Микробиота в эндокринологии) связана с 5 темами из 4 каналов через embedding-similarity, при этом у топовой связи `shared_keywords: []` — то есть keyword-overlap ноль, а семантическая связь сильная (0.41).
+
+### Suggested fix
+
+Добавить в `get_cross_channel_stats` секцию `topic_link_stats`:
+```json
+{
+  "topic_link_stats": {
+    "total_links": 746,
+    "avg_similarity": 0.3352,
+    "links_by_channel_pair": [
+      {"channels": ["kdl_ru", "profendocrinologist"], "link_count": 23, "avg_sim": 0.38},
+      ...
+    ],
+    "strongly_connected_components": [...]
+  }
+}
+```
+
+### Affected files
+
+- `tg_parser/services/analytics_service.py` (или эквивалент)
+- `tg_parser/mcp/tools.py` — handler `get_cross_channel_stats`
+
+---
+
+## ISSUE-9 (Low): keywords не лемматизированы — дубли в overlap
+
+### Симптом
+
+В keyword overlaps видны группы:
+- `аллергия` / `аллергии` / `аллергические` — 3 разные формы одного концепта
+- `анализ` / `анализа` / `анализам` / `анализов` / `анализы` — 5 форм
+- `адаптация` / `адаптации` — 2 формы
+
+Каждый создаёт отдельный overlap-record, раздувая `overlap_count` (сейчас 795) и засоряя топ keywords.
+
+### Suggested fix
+
+Применить лемматизацию на этапе keyword extraction:
+- Для русского: `pymorphy3` или `natasha`
+- Для английского: `nltk.WordNetLemmatizer` или `spacy`
+- Хранить и lemma, и оригинальную форму (lemma для overlap, оригинал для display)
+
+### Affected files
+
+- `tg_parser/processing/pipeline.py` (этап keyword extraction)
+- Возможно нужна миграция: пересчёт keywords для существующих документов
+
+### Note
+
+Может быть отнесено к Enhancement, не Bug, в зависимости от того, как организован keyword-extraction в проекте. Если он LLM-based — возможно решается через prompt engineering.
+
+---
+
+## ISSUE-10 (Medium): `subscribe_watchlist` / `subscribe_digest` не идемпотентны
+
+### Симптом
+
+Повторный вызов `subscribe_watchlist` с **теми же параметрами** (title, channel_ids, keywords) создаёт **новую** подписку с новым UUID. Никакой deduplication / merge / update on conflict. То же самое для `subscribe_digest`.
+
+Воспроизведение — реальное наблюдение: после создания 4 watchlist'ов любой повторный запуск того же скрипта создаст ещё 4 (итого 8), хотя смысл этого действия был только один — гарантировать наличие подписок.
+
+### Сравнение с другими MCP
+
+`add_workspace_source` корректно идемпотентно: возвращает `changed: false` если канал уже в workspace. То есть **паттерн «идемпотентность для read-modify-write»** в системе есть, но не применён к subscriptions.
+
+### Почему важно
+
+1. **Опасно для автоматизации:** скрипт-настройщик подписок при повторном запуске создаст дубли. Пользователь получит **двойные пуши** на каждое match.
+2. **Нет защиты от случайной двойной кнопки:** через UI/MCP легко создать 2 идентичные подписки и не заметить.
+3. **Mass-cleanup сложен:** нужно вручную перебирать `list_*` → `unsubscribe_*` для каждой дубликата.
+
+### Suggested fix
+
+Несколько опций:
+
+**A. Strict deduplication.** При `subscribe_*` сначала ищем существующую запись с теми же `(user_id, title, channel_ids hash)`. Если есть — возвращаем её с `created: false`.
+
+**B. Upsert по title.** Title уникален для пользователя. При повторе с тем же title — апдейтим описание/keywords/threshold, возвращаем существующий ID.
+
+**C. Хотя бы warning.** Если за последние 60 секунд от того же user_id уже была subscribe с теми же `title`/`name` — отбить с 409 Conflict и текстом «duplicate, use update instead».
+
+Рекомендация: **B (upsert по title)** — наиболее естественное API для конфигурационных entities.
+
+### Affected files
+
+- `tg_parser/services/watchlist_service.py`
+- `tg_parser/services/digest_service.py`
+- `tg_parser/mcp/tools.py` — handlers `subscribe_*`
+
+### Acceptance
+
+- Повторный `subscribe_watchlist` с теми же параметрами не создаёт второй записи
+- Поведение задокументировано в docstring инструмента
+
+---
+
+## ISSUE-11 (Low): «Topic failed quality criteria, skipping» — недостаточно деталей
+
+### Симптом
+
+При incremental-топикизации в логах нескольких каналов (AgeManagment, labdiagnostica_logical, genotek) появилась строка:
+```
+{"event": "Topic failed quality criteria, skipping"}
+```
+
+Несколько раз за прогон у одного канала (в AgeManagment — 6 раз, в labdiagnostica_logical — 1, в genotek — 1).
+
+### Что не так
+
+Сообщение **не содержит**:
+- Названия предложенной темы
+- Какому quality criterion она не соответствует (минимальный bundle size? дублирование? тональность? content type?)
+- Сырое предложение LLM
+
+В результате нельзя:
+- Понять, теряются ли полезные кандидаты
+- Калибровать quality threshold
+- Воспроизвести «потерянные» темы при ручном анализе
+
+В отличие от других мест (где есть отчёты типа `Phase 2 batch: N assigned, M new topics, K unassignable`), здесь чистая «чёрная дыра».
+
+### Контекст
+
+Quality filter — полезная фича (отбрасывает шумные темы), но без observability невозможно понять, **что именно он считает шумом**. Это особенно важно для каналов вроде `foodf4thought`, где много пограничного контента.
+
+### Suggested fix
+
+1. Логировать **причину skip**: `Topic failed quality criteria (reason=min_items_too_low, title='X', items=1)`
+2. В конце прогона выводить агрегат: `Quality filter rejected 7 topics: 4 by min_items, 2 by duplicate_title, 1 by toxicity`
+3. Опциональный CLI флаг `--show-rejected-topics` для debug
+
+### Affected files
+
+- `tg_parser/processing/topicization.py`
+- `tg_parser/services/topicization_service.py`
+- CLI handler для `topicize`
+
+### Acceptance
+
+После фикса оператор может ответить на вопрос «что система не пропустила и почему», глянув в логи или вывод CLI.
+
+---
+
+## Summary patterns
+
+### Pattern 1: слабая differentiation между «работа выполнена» и «работа не выполнена»
+
+Несколько issue имеют общую природу — система не различает успех / частичный успех / системный fail:
+
+- **ISSUE-1**: silent no-op (`triggered: true` без работы)
+- **ISSUE-2**: нет observability на эту аномалию
+- **ISSUE-3'**: misleading log («skipped» звучит как пользовательский выбор)
+- **ISSUE-4**: `last_attempt_at` не пишется при success
+- **ISSUE-7**: CLI рапортует ✅ при тотальном fail
+- **ISSUE-11**: «failed quality criteria» — отбрасывание без указания причины
+
+Системно решается через:
+- Структурированные результаты со статусом (`success` / `partial` / `failed` / `degraded`)
+- Различение классов ошибок (user error / API error / internal error)
+- Consistent exit codes в CLI
+- Инварианты на состояние БД («triggered → attempt_at within N seconds»)
+
+### Pattern 2: inconsistent API behavior
+
+- **ISSUE-10**: `subscribe_*` не идемпотентны (в отличие от `add_workspace_source`)
+- Возможно есть и другие — стоит провести audit всех write-операций в MCP API на предмет идемпотентности
+
+### Pattern 3: ad-hoc reliability vs systematic retry/backoff
+
+- **ISSUE-5**: retry того же промпта на JSON parse errors (детерминированный fail × 3)
+- **ISSUE-6**: HTTP 520 без exponential backoff
+
+Системно: общая retry-стратегия для всех external API calls с jitter, exponential backoff, classification ошибок (transient vs permanent).

--- a/docs/notes/mcp_testing/2026-05-15_claude_session/02-enhancements.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/02-enhancements.md
@@ -1,0 +1,591 @@
+# tg-parser — Enhancement Proposals
+
+Предложения по улучшениям, выявленные в сессии 2026-05-14. Это **не баги**, а целенаправленные улучшения функциональности и UX.
+
+---
+
+## Index
+
+| # | Title | Priority | Effort |
+|---|---|---|---|
+| ENH-1 | MCP-инструмент `trigger_topicization` | High | S |
+| ENH-2 | MCP-инструмент `trigger_link_topics` | Medium | S |
+| ENH-3 | Health-check для stuck active sources | Medium | S |
+| ENH-4 | `get_cross_channel_stats` — workspace-aware analytics | Medium | M |
+| ENH-5 | Cost-control flag для топикизации | High | M |
+| ENH-6 | Pre-flight check баланса Anthropic перед топикизацией | Medium | S |
+| ENH-7 | Batch-mode для топикизации (50% дешевле) | Medium | M |
+| ENH-8 | Dry-run для `topicize` (оценка стоимости без расхода) | Low | M |
+| ENH-9 | Workspace-bound subscriptions (digest и watchlist) | High | M |
+| ENH-10 | Cross-workspace keyword exclusion list | Low | S |
+| ENH-11 | Topic merge/split UI для дедупликации | Low | L |
+| ENH-12 | Initial backfill scan для новых watchlists | Medium | M |
+| ENH-13 | Watchlist preview / dry-run по историческим данным | Medium | M |
+
+---
+
+## ENH-1 (High): MCP-инструмент `trigger_topicization`
+
+### Контекст
+
+Сейчас MCP API имеет дыру: `trigger_pipeline` есть, но `topicize` — только CLI. После добавления нового канала надо SSH-иться на сервер для запуска топикизации первый раз. Это нарушает workflow «всё через MCP».
+
+Также через MCP можно делать `force_resummarize` (для существующего topic_id), но это не помогает каналам с 0 топиков.
+
+### Предложение
+
+Добавить MCP tool:
+```python
+trigger_topicization(
+    channel_id: str,
+    mode: str = "auto",  # auto | full | incremental | assign-only
+    force: bool = False,
+    cross_channel: bool = True
+) -> {
+    "triggered": bool,
+    "job_id": str,
+    "estimated_cost_usd": float,  # см. ENH-6
+    "estimated_duration_sec": int
+}
+```
+
+Параллельный `get_topicization_job_status(job_id)` для мониторинга прогресса.
+
+### Acceptance
+
+- Канал с 0 топиков можно дотопикизировать без SSH
+- Возвращаемый estimated_cost даёт grand picture перед запуском
+
+---
+
+## ENH-2 (Medium): MCP-инструмент `trigger_link_topics`
+
+### Контекст
+
+`link-topics` — операция бесплатная (только embeddings + Jaccard), но запускается только через CLI. Должна быть в MCP по тем же причинам что и ENH-1.
+
+### Предложение
+
+```python
+trigger_link_topics(
+    threshold: float = 0.3,
+    workspace_id: str | None = None  # если None — глобально
+) -> {
+    "triggered": bool,
+    "links_created": int,
+    "links_cleared": int,
+    "avg_similarity": float
+}
+```
+
+Поскольку операция дешёвая и быстрая (40 секунд для всей системы), можно сделать синхронной без job tracking.
+
+### Acceptance
+
+- После запуска через MCP топологический граф топиков обновляется
+- `get_related_topics` сразу видит новые связи
+
+---
+
+## ENH-3 (Medium): Health-check для stuck active sources
+
+### Контекст
+
+Из сессии расследования: с момента `add_channel` до момента когда стало видно «канал не обработался» прошло 20+ минут. Источник был в состоянии «active, last_attempt_at=null, last_success_at=null». Это **аномалия**, которую можно обнаружить автоматически.
+
+### Предложение
+
+Periodic check (раз в N минут, можно в существующий `health_check` job):
+```sql
+SELECT channel_id FROM sources
+WHERE status = 'active'
+  AND last_attempt_at IS NULL
+  AND created_at < now() - interval '1 hour';
+```
+
+Действие при ненулевом результате:
+- лог уровня WARNING
+- Prometheus metric `sources_stuck_total`
+- Если в системе есть alerting — alert
+
+Логика «1 hour» = дефолтный scheduler interval. Если за час не было попытки — что-то сломано.
+
+### Affected files
+
+- `tg_parser/services/health_check.py` (создать или расширить)
+- `tg_parser/api/metrics.py` — новый Prometheus gauge
+
+---
+
+## ENH-4 (Medium): workspace-aware analytics
+
+### Контекст
+
+`get_cross_channel_stats` принимает `workspace_id`, но возвращает только статистику внутри workspace. Полезное расширение — статистика **между** workspaces. Например: «топики в Эндокринологии, которые связаны с топиками в Longevity».
+
+### Предложение
+
+Новый MCP tool или расширение существующего:
+```python
+get_workspace_overlap(
+    workspace_a: str,
+    workspace_b: str
+) -> {
+    "workspace_a_topics": int,
+    "workspace_b_topics": int,
+    "cross_links": int,
+    "avg_similarity": float,
+    "top_bridging_topics": [  # топики с самыми сильными cross-links
+        {"topic_id": "...", "title": "...", "linked_count": N, "best_score": 0.45}
+    ]
+}
+```
+
+### Use case
+
+В текущей системе:
+- Эндокринология ↔ Лабдиагностика (b12, crispr, аутоиммунные, беременности)
+- Эндокринология ↔ Longevity (GLP-1 агонисты, семаглутид)
+- Лабдиагностика ↔ Longevity (mtor, альцгеймера)
+
+Сейчас эти пересечения видны только косвенно через `get_related_topics` для отдельных топиков. Workspace overlap дал бы big picture.
+
+---
+
+## ENH-5 (High): Cost-control для топикизации
+
+### Контекст
+
+В сессии: топикизация `kdl_ru` стоила $1.67 (841 doc). Для `profendocrinologist` (3440 docs) был только грубый прогноз. У оператора нет встроенного механизма ограничить расходы.
+
+### Предложение
+
+CLI и MCP-параметр:
+```bash
+tg-parser topicize --channel X --max-cost-usd 10.00
+```
+
+Поведение:
+1. Pre-flight estimate (см. ENH-6) — если прогноз > max-cost → отказ с понятным сообщением
+2. Во время выполнения: каждые N батчей пересчитывать накопленную стоимость, при превышении — graceful stop и сохранение уже созданных топиков
+
+### Default
+
+`max-cost-usd` = unset (текущее поведение). Опционально env-var `TOPICIZE_DEFAULT_MAX_COST_USD` как safety net.
+
+---
+
+## ENH-6 (Medium): Pre-flight estimate стоимости
+
+### Контекст
+
+Прогноз стоимости в сессии делался вручную через калибровку на одном канале (kdl_ru дал реальный $1.67 → линейный прогноз для profendocrinologist ~$7). Это можно автоматизировать.
+
+### Предложение
+
+CLI флаг `--estimate-only` (без запуска):
+```bash
+$ tg-parser topicize --channel profendocrinologist --estimate-only
+Channel: profendocrinologist
+  Documents to topicize: 3440
+  Estimated batches: 69
+  Estimated input tokens: 1,254,000
+  Estimated output tokens: 205,000
+  Estimated cost: $6.84 (Sonnet 4.6: $3 in / $15 out per 1M)
+  Estimated duration: ~14 min
+```
+
+Внутри: использовать **средние input/output tokens на документ** из последних N успешных топикизаций. Калибровка по факту.
+
+### Pricing source
+
+Цены за токены брать из конфига или env (не хардкод):
+```
+ANTHROPIC_PRICE_INPUT_PER_MTOK=3.00
+ANTHROPIC_PRICE_OUTPUT_PER_MTOK=15.00
+```
+
+Это позволит легко обновлять при изменении тарифов.
+
+---
+
+## ENH-7 (Medium): Batch API mode для топикизации
+
+### Контекст
+
+Anthropic Batch API даёт **50% скидку** на не-real-time запросы. Топикизация — идеальный кандидат: оператор запускает её осознанно, не критично к latency, занимает минуты.
+
+### Предложение
+
+CLI флаг:
+```bash
+tg-parser topicize --channel X --batch-mode
+```
+
+В batch-mode:
+- Запросы группируются в Batch API jobs (до 10K запросов в job)
+- Возвращается batch job ID
+- Polling статуса либо `tg-parser topicize-status <job_id>` либо webhook
+
+### Trade-off
+
+- ⚡ −50% стоимость
+- 🐢 +до 24 часов latency на ответ от Anthropic (обычно гораздо меньше)
+- ⚙️ +сложность кода (нужна batch-aware logic, persistence batch_id, polling)
+
+### Decision
+
+Стоит ли — зависит от бюджета и темпа добавления каналов. Если каналы добавляются часто и общий cost > $50/мес — окупится за пару итераций.
+
+---
+
+## ENH-8 (Low): Dry-run для `topicize`
+
+### Контекст
+
+Расширение ENH-6: не просто estimate, а полная симуляция, показывающая какие документы попадут в какие батчи, какие keywords будут использованы для группировки и т.д. Полезно для debug сложных кейсов.
+
+### Предложение
+
+```bash
+tg-parser topicize --channel X --dry-run --verbose
+```
+
+Выводит:
+- Список будущих батчей с их составом
+- Топовые keywords каждого батча
+- Прогноз сколько топиков создастся
+- Где будут конфликты (документы попадающие в несколько потенциальных топиков)
+
+### Use case
+
+Помогает понять «почему канал X получил мало топиков» **до** запуска и расхода API. Особенно для слабых каналов типа `foodf4thought` (10 топиков на 308 docs).
+
+---
+
+## ENH-9 (High): Workspace-bound subscriptions (digest и watchlist)
+
+### Контекст — обновлено после фактической работы
+
+**Подтверждено через MCP**:
+- `subscribe_digest(channel_ids: array, ...)` — принимает только список каналов
+- `subscribe_watchlist(channel_ids: array, ...)` — принимает только список каналов
+
+То есть **ни одна из подписок не знает про workspaces**. Чтобы создать «дайджест по эндокринологии» приходится явно перечислять каналы. Для одного канала это не проблема, но:
+1. Если в workspace 4-6 каналов — нужно копировать UUID/ids руками
+2. При добавлении канала в workspace **подписки не обновляются автоматически** — придётся unsubscribe + resubscribe
+
+### Предложение
+
+Расширить API:
+```python
+subscribe_digest(
+    target: {"type": "channels", "channel_ids": [...]} 
+          | {"type": "workspace", "workspace_id": "..."},
+    ...
+)
+```
+
+Поведение для `workspace`:
+- На момент tick'а шедулера digest резолвит текущий состав workspace
+- Если канал добавлен/удалён из workspace — следующий digest учитывает это
+- При delete_workspace подписки на этот workspace автодеактивируются с явным notification
+
+Аналогично для `subscribe_watchlist`.
+
+### Use case
+
+«Каждое утро присылай мне дайджест Эндокринологии». Если завтра добавлю второй эндокринологический канал в workspace — он автоматически попадёт в дайджест.
+
+### Affected files
+
+- `tg_parser/services/digest_service.py`
+- `tg_parser/services/watchlist_service.py`
+- `tg_parser/mcp/tools.py`
+- Возможна миграция: новое поле в таблице subscriptions для target_type
+
+### Связано
+
+- ENH-1 (MCP `trigger_topicization`) — паттерн «отдельная команда работает с workspace»
+- ISSUE-10 (subscribe не идемпотентны) — стоит фиксить вместе
+
+---
+
+## ENH-10 (Low): Cross-workspace keyword exclusion
+
+### Контекст
+
+В keyword overlaps много шумовых слов: `анализ`, `активность`, `безопасность`, `аспекты`, `влияние`. Они встречаются в 4-7 каналах, но содержательной ценности не несут.
+
+### Предложение
+
+Глобальный или per-workspace stop-list:
+```yaml
+keyword_exclusion:
+  global:
+    - анализ
+    - активность
+    - безопасность
+    - влияние
+    - влияния
+    - аспекты
+  workspaces:
+    лабораторная_диагностика:
+      - акции  # маркетинговый шум в kdl_ru
+      - офис
+```
+
+Применяется при keyword extraction или при overlap calculation.
+
+### Альтернатива
+
+TF-IDF фильтрация: слова с высокой document frequency автоматически отсеиваются.
+
+---
+
+## ENH-11 (Low): Topic merge/split для дедупликации
+
+### Контекст
+
+После добавления `profendocrinologist` в системе появилось несколько кластеров топиков на одну тему (микробиота: в `profendocrinologist`, `kdl_ru`, `LongevityClub`, `mind_rise`, `Lab4health` — 5 разных топиков). Это часть by design (per-channel topic-cards), но для аналитики иногда хочется иметь единый «meta-topic».
+
+### Предложение
+
+CLI или MCP:
+```
+tg-parser topic merge <topic_id_1> <topic_id_2> ...
+tg-parser topic split <topic_id> --by-keyword <kw1,kw2>
+```
+
+Создаёт meta-topic поверх существующих или разбивает большой topic-bundle на части.
+
+### Сложность
+
+L (Large) — требует структурных изменений в storage.
+
+---
+
+## ENH-12 (Medium): Initial backfill scan для новых watchlists
+
+### Контекст — обнаружено при создании watchlist
+
+После создания watchlist `get_watchlist_matches` возвращает `count: 0`. Из документации к инструменту: «After every incremental pipeline tick, new ProcessedDocuments are scored». Это означает **только forward-looking логика** — исторические документы никогда не оцениваются.
+
+Для системы с 11 220 уже накопленными документами это:
+- ❌ Все исторические темы не попадут в watchlist'ы пока не появятся новые посты на те же темы
+- ❌ Невозможно «подгрузить» интересные старые посты по теме
+- ❌ Невозможно валидировать watchlist (хорошо ли подобраны keywords/description) до того, как пойдут новые посты
+
+### Предложение
+
+Опциональный параметр при создании:
+```python
+subscribe_watchlist(
+    ...,
+    backfill: bool = False  # default False — текущее поведение
+)
+```
+
+Если `backfill=True`:
+1. Сразу после создания запускается one-time scan существующих `processed_documents` из указанных каналов
+2. Все docs >= threshold добавляются в `watch_matches` с пометкой `is_backfill: true`
+3. Пуши не отправляются (или только одно агрегированное «found N historical matches»)
+4. Возвращается count найденных matches
+
+### Параллельная альтернатива
+
+Отдельная команда `tg-parser watchlist backfill <interest_id> [--since-iso ...]` — explicit operation, не часть subscribe.
+
+### Стоимость
+
+Расход — только embedding similarity по уже существующим embeddings. **LLM не используется**, операция дешёвая.
+
+### Use case
+
+Создал watchlist «семаглутид» → сразу получаю список из ~15 исторических постов в `profendocrinologist`, `LongevityClub`, `AgeManagment`, релевантных теме. Можно сразу оценить качество подбора и подкрутить threshold/keywords.
+
+### Affected files
+
+- `tg_parser/services/watchlist_service.py`
+- `tg_parser/processing/watchlist_matcher.py`
+
+---
+
+## ENH-13 (Medium): Watchlist preview / dry-run
+
+### Контекст
+
+Связано с ENH-12, но **до создания** подписки. Хочется проверить «как сработала бы эта watchlist», не создавая её.
+
+### Предложение
+
+MCP tool:
+```python
+preview_watchlist(
+    channel_ids: array[str],
+    keywords: array[str] = None,
+    description: str = None,
+    threshold: float = 0.6,
+    sample_size: int = 20
+) -> {
+    "estimated_matches_total": int,
+    "sample_matches": [
+        {"doc_id": ..., "channel_id": ..., "score": 0.74, "snippet": "..."},
+        ...
+    ],
+    "score_distribution": {"0.6-0.7": 12, "0.7-0.8": 5, "0.8+": 2}
+}
+```
+
+Никакого изменения состояния, чистый readonly запрос. Embedding similarity по уже существующим документам, без LLM.
+
+### Use case
+
+Перед `subscribe_watchlist`:
+1. `preview_watchlist(keywords=["мicrобиоta", "пробиотики"], ...)` 
+2. Видишь: estimated 47 matches, top scores 0.81/0.79/0.76
+3. Подкручиваешь threshold/keywords пока не достигнешь нужного баланса
+4. Только после этого делаешь `subscribe_watchlist`
+
+### Стоимость
+
+$0. Использует уже посчитанные embeddings.
+
+---
+
+## Architectural observations (не предложения, а наблюдения)
+
+### O-1: MCP-API асимметрично
+
+Через MCP есть **много инструментов чтения** (`list_*`, `get_*`, `search_*`) и **мало инструментов записи** (`add_channel`, `subscribe_*`, `create_workspace`, `trigger_pipeline`). При этом:
+- Топикизация → только CLI
+- Link-topics → только CLI
+- Force topicization re-run → только CLI
+
+Это создаёт ситуацию когда «обычная работа» возможна через MCP, но «администрирование» требует SSH. Стоит сознательно решить — это by design (safety) или legacy (надо закрыть гэп).
+
+### O-2: Pipeline-этапы атомарны на уровне канала
+
+Каждый этап (ingest/process/topicize) — отдельный, прерываемый, перезапускаемый. Это хорошо. Но между этапами нет ясного контракта: `processed_documents` лежат в БД и могут быть топикизированы когда угодно, дотопикизированы, переэкспортированы. Это значит **расход API tokens идемпотентен** на уровне этапа: один раз процесстили → одни тратили на process, отдельно тратим на topicize.
+
+### O-3: Items_count = 102-103 у большинства тем
+
+В выводе `list_topics` многие топики имеют `items_count: 102` или `103`. Это похоже на технический потолок на размер topic_bundle. Стоит проверить — это by design (управление контекстом промпта) или артефакт.
+
+Источник наблюдения: kdl_ru (46 топиков, большинство с 102-103) и profendocrinologist (92 топика, тот же паттерн).
+
+### O-4: Watchlist'ы не переоценивают исторические документы
+
+Обнаружено при создании 4 watchlist'ов в сессии. После `subscribe_watchlist` `get_watchlist_matches` возвращает `count: 0`, даже если в системе уже есть 11 220 документов и многие соответствуют теме. Логика watchlist строго forward-looking: только новые `processed_documents` с момента создания подписки.
+
+**Следствие:**
+- Невозможна валидация watchlist на исторических данных
+- Невозможно «найти всё прошлое по теме X» через watchlist (нужно `search_knowledge_base` или `ask_question`)
+- Качество подбора keywords/description проявится только когда пойдут новые посты
+
+Закрывается через ENH-12 (backfill) или ENH-13 (preview).
+
+### O-5: Подписочные API принимают `channel_ids`, не `workspace_id`
+
+Подтверждено реальным вызовом MCP:
+- `subscribe_digest(channel_ids: array, ...)`
+- `subscribe_watchlist(channel_ids: array, ...)`
+
+Workspace-context в подписках отсутствует. Если состав workspace меняется — подписки на «дайджест workspace» (которые на самом деле дайджест-канала-Х) не обновляются. Закрывается через ENH-9.
+
+### O-6: Параметр `description` критичен для качества watchlist
+
+По документации `subscribe_watchlist`: «If description omitted, the embedding falls back to title + keywords». То есть **description формирует embedding** для семантической части матчинга. Короткое title + bag-of-keywords создаёт плохой embedding; развёрнутый description — гораздо лучше.
+
+**Практический вывод:** при создании watchlist всегда писать осмысленный description в 1-3 предложения. Это улучшает recall на семантически похожих, но текстуально различающихся постах.
+
+В сессии все 4 watchlist'а созданы с description'ами именно по этой причине.
+
+### O-7: Подписки не идемпотентны, в отличие от workspace-операций
+
+В системе **смешанные паттерны идемпотентности**:
+- ✅ `add_workspace_source` — корректно возвращает `changed: false` при дубликате
+- ❌ `subscribe_watchlist` — создаёт новую запись с новым UUID при тех же параметрах
+- ❌ `subscribe_digest` — то же поведение
+
+Это inconsistent API behavior. См. ISSUE-10 для подробностей и предложения по фиксу.
+
+### O-8: Auto-adjusted rate limits (наблюдение, не баг)
+
+При каждом incremental-вызове в логах появляются строки:
+```
+rate_limit_rpm_adjusted: 50 → 4000
+rate_limit_itpm_adjusted: 30000 → 2000000
+rate_limit_otpm_adjusted: 8000 → 400000
+```
+
+**Что происходит:** rate limiter стартует с очень консервативными default-значениями (50 rpm), затем, проверяя реальные limits аккаунта через ответы API, **автоматически поднимает их в 60-80 раз** до фактических значений (4000 rpm, 2M input tokens/min, 400K output tokens/min).
+
+**Это хорошо:**
+- Адаптивное поведение, не нужно вручную конфигурировать
+- Защита от первоначального burst при низком стартовом tier
+
+**Это потенциальный риск:**
+- **Стоимость становится непредсказуемой**. После adjustment один operator может за минуту потратить в 80 раз больше токенов чем ожидал — особенно при high-cost запросах вроде Opus или длинных контекстов
+- Adjustment происходит молча, без warning'а пользователю
+- Нет cost-cap mechanism (см. ENH-5)
+
+**Рекомендация:**
+- Логировать adjustment на уровне WARNING, не INFO
+- Добавить env-var `RATE_LIMIT_MAX_RPM` как hard ceiling
+- В CLI выводить «Rate limit raised to X — your bursty cost ceiling is now ~$Y/min»
+
+### O-9: Phase 3 в incremental-топикизации создаёт cross-channel links автоматически
+
+Раньше предполагалось, что `link-topics` — единственный способ создания связей. Реально каждый incremental-прогон в **Phase 3** уже создаёт connections для **новых** топиков канала:
+
+| Канал (incremental) | Phase 3 cross_links | Touched topics |
+|---|---:|---:|
+| profendocrinologist | 128 | 96 |
+| foodf4thought | 31 | 20 |
+| AgeManagment | 99 | 60 |
+| labdiagnostica_logical | 124 | 36 |
+| Lab4health | 105 | 41 |
+| mind_rise | 68 | 27 |
+| LongevityClub | 26 | 11 |
+| genotek | 26 | 25 |
+
+**Архитектурное следствие:**
+- `link-topics` нужен только когда **существующие** темы в системе должны быть пересмотрены под новый порядок (пересчёт всех пар)
+- При обычном workflow «добавил канал → incremental → ...» **link-topics не обязателен** — Phase 3 сделает links для новых тем
+- Но `link-topics` всё ещё ценен после **массовых добавлений** или при изменении threshold
+
+### O-10: `link-topics` — truncate-and-rebuild, не merge
+
+Из логов второго запуска link-topics: `Cleared 746 old topic links / Created 746 topic links from 173510 pairs`. Cleared = Created — это **намеренный полный пересчёт**, а не инкрементальное добавление. Раньше первый запуск показывал `Cleared 175 / Created 708`, что подтверждает: `Cleared` = всё что было в БД (включая то, что создавалось Phase 3 incremental'ов).
+
+**Архитектурное следствие:**
+- Любые ручные правки topic_links (если они когда-нибудь будут возможны через future feature) **будут потеряны** при следующем link-topics
+- Гарантирует консистентность графа со spec'ом (threshold, embedding model, и т.д.)
+- При смене threshold нужно перезапускать link-topics
+
+**Замечание для документации проекта:** стоит явно прописать в `--help` для link-topics: «*This command rebuilds the entire topic link graph from scratch. Any out-of-band edits to topic_links will be lost.*»
+
+### O-11: Singletons как индикатор зрелости топикизации канала
+
+Изначально у `profendocrinologist` было `singleton_count: 0` после full-режима — мы записали это как аномалию A1. После incremental с cross-channel context singletons появились (0 → 7). То же для других каналов после incremental.
+
+**Закономерность:** full-режим (без cross-channel) **не создаёт singletons**, все темы кластерные. Incremental с cross-channel — создаёт singletons естественным образом.
+
+Объяснение: в full LLM группирует «всё со всем» при отсутствии context, поэтому минимальная тема — это всегда минимум 2 документа. В incremental LLM знает темы других каналов и может пометить отдельный документ как singleton-тему, если он уникален.
+
+**Singleton/cluster ratio — индикатор зрелости топикизации канала:**
+- 0% singletons → канал был топикизирован только в full-режиме, никогда incremental
+- 5-15% singletons → один incremental после full (типичный case)
+- 20-50% singletons → канал прошёл много incremental проходов с разнообразным контентом
+- 78% (Lab4health) → исключение: возможно, специфика канала или legacy state до cross-channel features
+
+Это **полезная метрика для health-check** системы топикизации.
+
+### O-12: `foodf4thought` keyword extraction улучшился после incremental
+
+До incremental top keywords канала: `благополучие, вебинары, влияние, восприятие, врачей, гормональное, городской, для, доказательная` — почти всё общая лексика.
+
+После incremental: `mind-body, wellness-туризм, активация, активный, благополучие, вебинары, велнеса, вкус, влияние, влияния` — появились **предметные термины** (`mind-body`, `wellness-туризм`, `велнеса`).
+
+**Почему так:** новые темы, созданные incremental'ом для канала, дополнили keyword storage канала с предметными словами из их title/content. Это значит **keyword extraction зависит от существующих topic-cards**, не только от raw documents. То есть итеративная топикизация сама улучшает keyword quality. Это полезное emergent behavior.

--- a/docs/notes/mcp_testing/2026-05-15_claude_session/03-investigation-log.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/03-investigation-log.md
@@ -1,0 +1,330 @@
+# tg-parser — Investigation Log
+
+**Session date:** 2026-05-14
+**Investigator:** alexanderefimov + Claude (read-only mode)
+**Original trigger:** добавлен канал `@profendocrinologist`, не появился в обработке через 5 минут
+
+---
+
+## Цель документа
+
+Зафиксировать методику и хронологию расследования. Этот документ — methodological reference: какие шаги в каком порядке привели к каким выводам, какие гипотезы оказались верными/неверными. Полезен:
+- Для будущих похожих расследований
+- Для обучения других участников проекта
+- Как пример того, как **легко неправильно диагностировать** silent failure
+
+---
+
+## Хронология (UTC)
+
+### Phase 1: Initial state setup (05:30 – 05:43)
+
+| Время | Действие | Результат |
+|---|---|---|
+| 05:40:50 | `create_workspace "Лабораторная диагностика"` | id `a1a7584c-...` |
+| 05:40:54 | `create_workspace "Longevity"` | id `fb59c536-...` |
+| 05:40:55 – 05:41:00 | 8× `add_workspace_source` | 4 канала → Лабдиагностика, 4 → Longevity |
+| 05:43:47 | `create_workspace "Эндокринология"` | id `00ccbfb0-...` |
+| 05:44:xx | `add_channel "profendocrinologist"` | success, status=active |
+| 05:44:xx | `add_workspace_source` для profendocrinologist | added to Эндокринология |
+| 05:44:xx | `trigger_pipeline(profendocrinologist)` | `{triggered: true}` |
+| 05:50:xx | `get_pipeline_status` через 5 минут | `last_attempt_at: null` ⚠️ |
+
+### Phase 2: First wrong hypothesis (06:00 – 06:30)
+
+**Гипотеза:** silent failure в MCP `trigger_pipeline`. Сразу предложен bug report.
+
+**Тест 1:** Дёрнули `trigger_pipeline` ещё раз → тот же результат.
+
+**Анализ через MCP:**
+- `scheduler_enabled: true`, `default_interval_seconds: 3600`
+- Решено подождать естественный тик scheduler
+
+**SSH-исследование:**
+```
+docker compose ps
+→ tg_parser (api), tg_bot, tg_parser_mcp, postgres, grafana, prometheus
+```
+
+Обратили внимание: **MCP в отдельном контейнере**.
+
+```
+docker compose logs tg_parser | grep scheduler
+```
+
+Найдены APScheduler джобы:
+- `health_check` (5m) — тикает
+- `cleanup_expired_records`
+- `incremental_pipeline` (1h)
+- `incremental_embedding` (1h)
+
+В 20:28 UTC (через час после старта 19:28) `incremental_pipeline` сработал. Следующий — 05:28 UTC. Затем 06:28 UTC.
+
+**Вывод фазы 2:** Шедулер работает корректно. Мы попали в межтиковое окно. **Первоначальное наблюдение «канал не обработался» было false alarm.**
+
+### Phase 3: Discovery of real silent failure (06:30 UTC tick)
+
+После тика в 06:28 UTC:
+```
+list_channels(profendocrinologist) → raw_messages: 3443 ✅
+get_pipeline_status → last_success_at: 06:30:47
+```
+
+**Канал обработан шедулером в штатном режиме.** Но при этом:
+
+В логах **нет ни одной строки** про `trigger_pipeline` вызовы в 05:44 и 06:00. То есть MCP → tg_parser **реально не передало запрос**. Это и есть настоящий **ISSUE-1: silent no-op в MCP**.
+
+Архитектурный root cause: MCP в отдельном контейнере, без канала связи к шедулеру в tg_parser. `asyncio.create_task` локально в MCP-процессе либо умирает после возврата ответа, либо клиента Telethon в mcp-контейнере просто нет.
+
+### Phase 4: Second wrong hypothesis — `--skip-topicize` (06:30 – 07:30)
+
+**Наблюдение:** `processed_documents=0` после ingest для `profendocrinologist`. Топиков нет.
+
+**В логах видно:** `[3/4] Topicization skipped (--skip-topicize)` для **каждого канала** в каждом тике.
+
+**Гипотеза:** флаг `--skip-topicize` был включён как mitigation на время билинг-инцидента (вспомнили RCA по genotek) и забыли снять.
+
+**Юзер пополнил баланс → ждём следующего тика.**
+
+В тике 06:28 UTC обработка идёт **с tokens=4929, tokens=11112, tokens=1841** — то есть processing-этап теперь использует Anthropic API. Билинг-инцидент решён. Но `[3/4] Topicization skipped` — всё ещё везде.
+
+**Поиск флага в коде:**
+```
+grep -rn "skip-topicize\|skip_topicize" --include="*.py" ~/TG_parser/
+```
+
+Найдено:
+```
+tg_parser/services/scheduler_service.py:112: skip_topicize=True,
+```
+
+**Это хардкод, а не env-var. Не mitigation, а архитектурное решение.** Топикизация дорогая, шедулер тикает раз в час — by design она вне scheduled job, делается через manual `tg-parser topicize`.
+
+**Вывод фазы 4:** Гипотеза неверна. Лог `[3/4] Topicization skipped (--skip-topicize)` вводит в заблуждение — звучит как «передан флаг», на самом деле это «шедулер не делает топикизацию by design». Это ISSUE-3'.
+
+### Phase 5: Manual topicization (07:30 – 09:00)
+
+**Решение:** запускать топикизацию вручную через CLI.
+
+**Первая попытка (07:33 UTC) — kdl_ru:**
+```
+docker compose exec tg_parser tg-parser topicize --channel kdl_ru
+```
+
+Все 17 батчей упали одновременно с `Your credit balance is too low`. **Баланс снова закончился.**
+
+При этом CLI вывел:
+```
+✅ Topicization завершён:
+   • Создано тем: 0
+⚠️ Темы не созданы (возможно, недостаточно данных)
+```
+
+**Это ISSUE-7** — misleading success при тотальном fail.
+
+Деньги не потрачены: `total_tokens: 0` — API отбил pre-flight.
+
+**Второе пополнение баланса. Вторая попытка — kdl_ru:**
+
+Успех:
+- 46 топиков
+- coverage 90.49%
+- input_tokens: 306,754 + output_tokens: 50,172 = $1.67
+
+**Калибровка стоимости.** Линейный прогноз для profendocrinologist (3440 docs): ~$6.84.
+
+**Третья попытка — profendocrinologist:**
+
+Успех:
+- 92 топика
+- coverage 75.60%
+- Очень содержательные темы по эндокринологии
+
+### Phase 6: Cross-channel analysis (09:00 – конец фазы)
+
+**`link-topics`:**
+- 708 links создано из 140,485 пар
+- threshold 0.3, avg similarity 0.3345
+- Бесплатно (Jaccard + cosine на готовых данных)
+- 40 секунд работы
+
+**Тестирование `get_related_topics`** на эндокринологической теме «Микробиота»:
+- 5 связей с 4 каналами
+- Топовая связь (0.41) — keyword-overlap пустой, чистая embedding-similarity
+
+**`get_cross_channel_stats`:**
+- 718 keyword overlaps
+- Идентичная картина до и после link-topics → **endpoint не использует topic_links** (ISSUE-8)
+- Дублирующиеся keywords в overlap из-за отсутствия лемматизации (ISSUE-9)
+
+### Phase 7: Subscription setup (после возобновления работы)
+
+Настройка watchlist и digest. Получили `chat_id = 5445781511` через `@userinfobot`.
+
+**Обнаружения по архитектуре подписок:**
+
+1. **`subscribe_*` принимают только `channel_ids`, не `workspace_id`.** То есть «дайджест workspace» в чистом виде невозможен, нужно явное перечисление каналов. Подтверждение ENH-9 (теперь High priority).
+
+2. **`subscribe_*` не идемпотентны.** Повторный вызов с теми же параметрами создаёт новую подписку. В отличие от `add_workspace_source` (корректный idempotent). Новый ISSUE-10.
+
+3. **Watchlist forward-only.** После создания `get_watchlist_matches` возвращает 0 — даже хотя в системе 11,220 готовых документов. Логика инкрементальная, исторический backfill не делается. O-4, ENH-12.
+
+4. **Description критичен для embedding.** Если не задан — embedding строится из title+keywords. Все 4 watchlist'а в сессии получили развёрнутый description. O-6.
+
+**Созданы:**
+- 4 watchlist (GLP-1, Микробиота, Биомаркеры, mTOR) — детали в data-quality-report.md
+- 1 digest для Эндокринологии (ежедневно 9:00 Europe/Nicosia)
+
+Watchlist'ы заработают со следующего scheduler tick.
+
+### Phase 8: Massive incremental topicization + финальный link-topics
+
+После закрытия первой версии документов решили пройти дотопикизацию всех каналов в incremental режиме, чтобы устранить аномалии (A1, A3) и повысить coverage.
+
+**Порядок (от меньшего к большему):**
+
+1. **`profendocrinologist` (incremental)** — 840 uncovered → Phase 1: 647 assigned (77% hit rate), Phase 2: 80 assigned + 19 new topics, 51 unassignable. Phase 3: 128 cross_links. Coverage 75.6% → **98.7%**. Появились первые 7 singletons (разрешение аномалии A1).
+
+2. **`foodf4thought` (incremental)** — 142 uncovered → Phase 1: 6 (4% hit rate), Phase 2: 37 + 11 new, 65 unassignable. Phase 3: 31 cross_links. Coverage 53.9% → **80.5%**. **Подтверждение** что keyword extraction для канала работает плохо: только 4% hit rate в Phase 1 vs 77% у profendocrinologist.
+
+3. **`AgeManagment` (incremental)** — 278 uncovered → Phase 1: 39 (14% hit rate), Phase 2: 122 + 14 new, 64 unassignable. Phase 3: 99 cross_links. Coverage 74.7% → **94.6%**.
+
+   **Здесь впервые наблюдалось** «Topic failed quality criteria, skipping» — 6 раз за прогон. Quality filter отбрасывал некоторые предлагаемые темы, **без указания причины** (новый ISSUE-11).
+
+4. **`labdiagnostica_logical` (incremental)** — 257 uncovered → Phase 1: 121 (47%), Phase 2: 50 + 5 new. Phase 3: 124 cross_links. Coverage 77.6% → **94.2%**.
+
+5. **`Lab4health` (incremental)** — 127 uncovered → Phase 1: 70, Phase 2: 41 + 5 new. Phase 3: 105 cross_links. Coverage 93.0% → **99.8%** (рекорд системы).
+
+6. **`mind_rise` (incremental)** — 146 → Coverage 86.9% → **98.5%**.
+
+7. **`LongevityClub` (incremental)** — 36 → Coverage 89.4% → **99.1%**.
+
+8. **`genotek` (incremental)** — 175 → Coverage 84.1% → **99.0%**.
+
+**Финальный `link-topics`:**
+- Pairs evaluated: 173 510 (было 140 485 — +23.5%)
+- Cleared 746 / Created 746 — подтверждение что link-topics это **truncate-and-rebuild** (новый O-10)
+- Avg similarity 0.3352 (стабильно)
+
+**Архитектурные открытия фазы 8:**
+- O-8: rate limiter auto-adjusts от 50 → 4000 rpm
+- O-9: Phase 3 incremental уже создаёт cross-links — link-topics не обязателен после incremental
+- O-10: link-topics семантически truncate-and-rebuild
+- O-11: singletons как индикатор зрелости топикизации
+- O-12: foodf4thought keywords улучшились после incremental
+- ISSUE-11: «Topic failed quality criteria, skipping» — без указания причины
+
+**Phase 1 hit rate как индикатор качества keyword extraction канала:**
+
+| Канал | hit rate | Природа |
+|---|---:|---|
+| profendocrinologist | 77% | Сильная предметная лексика |
+| labdiagnostica_logical | 47% | Хорошая лабораторная терминология |
+| genotek | 69% | Сильные генетические термины |
+| Lab4health | 55% | Хороший mix |
+| mind_rise | 67% | Стабильная wellness-лексика |
+| AgeManagment | 14% | Слишком специфические редкие keywords |
+| LongevityClub | 11% | Слишком специфические редкие keywords |
+| foodf4thought | 4% | Общая лексика, не предметная |
+
+**Итог сессии:**
+- 441 (до сессии) → 641 topics (+200 за всю сессию)
+  - +46 от full kdl_ru (новый channel)
+  - +92 от full profendocrinologist (новый channel)
+  - +62 от Phase 8 incrementals по всем 9 каналам
+- 175 → 746 cross-channel links (+571)
+- 718 → 795 keyword overlaps (+77)
+- Все каналы > 80% coverage, большинство > 94%
+- Стоимость всех incremental + final: ~$4-5
+
+---
+
+## Lessons Learned
+
+### L1: «Никаких следов» — это симптом, а не отсутствие проблемы
+
+`last_attempt_at = null` и пустые логи — **аномалия**, не «всё в порядке». Когда что-то должно было произойти и не произошло — это всегда баг.
+
+### L2: Сходство симптомов != причинно-следственная связь
+
+Изначальный симптом «канал не обрабатывается» был **совпадением двух разных явлений**:
+- ISSUE-1 (silent MCP failure) — реальный баг
+- Межтиковое окно scheduler — норма
+
+Час потрачен на гипотезы вокруг scheduler. Только разбор логов показал, что scheduler норм, а MCP молча проглатывает запросы.
+
+### L3: Misleading messages дорого стоят
+
+Сообщение `[3/4] Topicization skipped (--skip-topicize)` стоило **~2 часа времени** на проверку гипотезы про забытый mitigation. Будь сообщение `(scheduler does not auto-topicize by design)` — диагностика была бы за 30 секунд.
+
+Аналогично: `✅ Topicization завершён` при 0 топиков создало момент когда мы могли подумать «темы не создались по data reason».
+
+### L4: Read-only investigation работает
+
+Весь debug сделан без единого изменения на сервере (до фазы топикизации, когда уже понимали, что делаем). Команды `docker compose logs`, `grep`, `docker compose exec ... --help` дали полную картину. **Стоимость расследования: 0.** Это сильная стратегия для production-сервисов.
+
+### L5: Калибровка > прогноз
+
+Прогноз стоимости топикизации `profendocrinologist` сначала был «$15-30», после калибровки на kdl_ru — точно $6.84 (реальный результат пока неизвестен, но порядок верный). **Один малый канал → точная экстраполяция на большой.**
+
+### L6: Сетевая изоляция — баг и фича одновременно
+
+Контейнер MCP отделён от tg_parser сетью внутри docker-compose. Это:
+- ✅ безопасно (MCP не имеет доступа к Telethon session)
+- ❌ создаёт architectural gap (MCP не может триггерить ingest)
+
+Решение должно быть осознанным: либо MCP вызывает HTTP API tg_parser (новый interface), либо MCP получает доступ к shared queue / event bus.
+
+### L7: by-design vs not-yet-implemented
+
+Несколько раз думали «это баг», на деле — by design:
+- `--skip-topicize` хардкод в шедулере → by design (cost control)
+- `get_cross_channel_stats` без topic_links → likely just not-yet-implemented (it should know about them after link-topics)
+
+Граница между «фича не сделана» и «фича не нужна по дизайну» неявная. **Любой API должен явно документировать своё поведение.**
+
+### L8: Гипотезы про данные надо проверять, а не доказывать
+
+В Data Quality Report A1 была сформулирована как «у profendocrinologist 0 singletons, возможная причина — full без cross-channel». В Phase 8 эта гипотеза **была явно проверена** — один прогон incremental с cross-channel, singletons появились (0 → 7). Аномалия разрешена.
+
+Это пример хорошего цикла: документ → гипотеза → эксперимент → ответ → обновление документа. Не все аномалии нужно немедленно объяснять — иногда правильно записать «возможная причина» и проверить позже.
+
+### L9: Инкрементальный режим — основная стратегия maintenance
+
+До Phase 8 не было ясно, насколько часто и в каких сценариях запускать incremental. Сейчас понятно:
+- Phase 1 hit rate показывает, насколько канал «созревший» в keyword extraction
+- Каждый incremental прогон стоит **~$0.0030/uncovered doc**, что в 5-7× дешевле full
+- Phase 3 incremental уже делает cross-channel links — link-topics нужен реже, чем казалось
+- Quality filter работает молчаливо (ISSUE-11)
+
+**Главный рабочий паттерн:** weekly incremental по всем каналам. Полная сеть из 9 каналов держится за ~$4-5/неделя.
+
+### L10: Многослойные «потолки» в production-системе
+
+В Phase 8 наблюдали несколько технических потолков, которые проявились естественно:
+- `items_count` ≈ 100-103 у большинства тем (potential bundle ceiling, O-3)
+- foodf4thought ≈ 80% coverage (keyword extraction ceiling, A3)
+- rate_limit_rpm = 4000 (после auto-adjust, O-8)
+- Phase 1 hit rate от 4% до 77% (предметность лексики канала)
+
+Эти потолки **не баги**, а свойства системы. Полезно их фиксировать в Data Quality Report как baseline — чтобы при следующем замере можно было сразу понять, изменилось ли что-то.
+
+---
+
+## Time accounting
+
+| Фаза | Длительность | Ценность |
+|---|---|---|
+| Phase 1 (setup) | ~15 мин | High — workspaces созданы |
+| Phase 2 (wrong hypothesis scheduler) | ~30 мин | Low — гипотеза не подтвердилась |
+| Phase 3 (real bug found) | ~5 мин | High — ISSUE-1 идентифицирован |
+| Phase 4 (wrong hypothesis flag) | ~60 мин | Medium — нашли ISSUE-3', но долго |
+| Phase 5 (topicization) | ~90 мин | High — оба канала обработаны |
+| Phase 6 (cross-channel) | ~30 мин | High — данные ценные |
+| Phase 7 (subscriptions) | ~15 мин | High — 4 watchlist + 1 digest активны |
+| Phase 8 (massive incremental + final link-topics) | ~25 мин | High — coverage 80-100% везде, +62 topics (incremental), +571 links |
+| **Total** | **~4 часа 10 мин** | |
+
+**Производительность recovery:** если бы log message `[3/4] Topicization skipped` был ясным, фаза 4 сократилась бы до 5 минут (= экономия ~50 минут). Это reinforces ROI фикса ISSUE-3'.
+
+**ROI вывод по Phase 8:** массовая incremental-фаза заняла ~25 минут и дала очень большой прирост качества системы (coverage везде > 80%, новый граф 746 cross-channel links). Стоимость — ~$4-5. **Этот workflow можно автоматизировать** через ENH-1 (MCP `trigger_topicization`) + cron — раз в неделю incremental для всех каналов, что поддержит систему в актуальном состоянии.

--- a/docs/notes/mcp_testing/2026-05-15_claude_session/04-operational-runbook.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/04-operational-runbook.md
@@ -1,0 +1,521 @@
+# tg-parser — Operational Runbook
+
+Типовые операции с системой tg-parser, основанные на сессии 2026-05-14.
+
+---
+
+## Index
+
+1. [Добавление нового канала](#1-добавление-нового-канала)
+2. [Топикизация нового канала](#2-топикизация-нового-канала)
+3. [Дотопикизация после добавления](#3-дотопикизация-всех-каналов-после-добавления)
+4. [Cross-channel linking](#4-cross-channel-linking)
+5. [Диагностика «канал не обрабатывается»](#5-диагностика-канал-не-обрабатывается)
+6. [Восстановление после billing-инцидента](#6-восстановление-после-billing-инцидента)
+7. [Оценка стоимости перед топикизацией](#7-оценка-стоимости-перед-топикизацией)
+8. [Настройка watchlist и digest](#8-настройка-watchlist-и-digest)
+
+---
+
+## 1. Добавление нового канала
+
+### MCP-команды
+
+```python
+# 1. Создать channel-source
+add_channel(channel_id="newchannel")
+
+# 2. (Опционально) Добавить в workspace
+add_workspace_source(
+    workspace_id="<workspace-uuid>",
+    channel_id="newchannel"
+)
+```
+
+### Что произойдёт автоматически
+
+Шедулер `incremental_pipeline` подхватит канал на **следующем тике** (раз в час). Выполнит:
+1. `[1/4] Ingest` — выкачает посты из Telegram
+2. `[2/4] Process` — обработает каждый документ через Anthropic API (тратит токены!)
+3. `[3/4] Topicize` — **пропускается by design** (`--skip-topicize` хардкод в шедулере, см. ISSUE-3')
+4. `[4/4] Export` — экспортирует в `./output`
+
+### Что НЕ произойдёт автоматически
+
+- **Топикизация** — нужно запустить вручную, см. раздел 2 (для одного канала) или раздел 3 (для всех)
+- **Link-topics** — обычно не нужен после нового топикизации (см. O-9), но при необходимости см. раздел 4
+- **Уведомления о новых темах** — нужно настроить watchlist/digest, см. раздел 8
+
+### ⚠️ MCP `trigger_pipeline` не работает
+
+Согласно ISSUE-1, `trigger_pipeline` через MCP — silent no-op. **Если нужно запустить сразу, не дожидаясь часа:**
+
+```bash
+# Через SSH на VPS:
+# (До фикса ISSUE-1)
+docker compose exec tg_parser tg-parser ingest --source newchannel
+```
+
+Альтернативно — просто дождаться следующего тика (≤ 1 час).
+
+---
+
+## 2. Топикизация нового канала
+
+### Когда
+
+После того как канал прошёл ingest+process (т.е. `processed_documents` в `list_channels` стал ненулевым).
+
+### Команда
+
+```bash
+docker compose exec tg_parser tg-parser topicize --channel <channel_id>
+```
+
+### Что произойдёт
+
+- Для нового канала (0 тем) → `--mode auto` → `full`
+- Для канала с существующими темами → `--mode auto` → `incremental` (+ cross-channel context)
+- `--cross-channel` по умолчанию `True` (но в `full`-режиме не используется)
+
+### Расход
+
+Калибровка от 2026-05-14: ~$0.0020 за документ (Sonnet 4 с тарифами $3/$15 за 1M токенов).
+
+| Размер канала | Прогноз cost |
+|---|---:|
+| 300 docs | ~$0.60 |
+| 800 docs | ~$1.60 |
+| 1500 docs | ~$3.00 |
+| 3500 docs | ~$7.00 |
+
+### ⚠️ Проверки перед запуском
+
+1. Баланс Anthropic API > прогнозируемой стоимости × 2 (запас)
+2. Канал прошёл process: `list_channels` показывает `processed_documents > 0`
+3. Если важна cross-channel связность с другими каналами — после топикизации запустить `link-topics`
+
+### ⚠️ Verify success
+
+CLI **может ложно рапортовать `✅ Topicization завершён`** при тотальном fail (ISSUE-7). Всегда проверяй:
+
+```python
+# После завершения CLI:
+list_topics(channel_id="<channel>", limit=3)
+# Должно вернуть total > 0
+```
+
+Если total = 0 и в логах CLI видны `Batch X/Y failed: ...` — это **реальный fail**, не data issue.
+
+---
+
+## 3. Дотопикизация всех каналов после добавления
+
+### Контекст
+
+Когда добавлен новый канал и/или хочется поднять coverage существующих каналов, стоит запустить incremental по всем. Это **бесплатно по сравнению с full** и **очень эффективно**.
+
+### Команда (batch для всех каналов)
+
+```bash
+for channel in Lab4health labdiagnostica_logical genotek AgeManagment kdl_ru \
+               LongevityClub foodf4thought mind_rise profendocrinologist; do
+    echo "=== Топикизация $channel ==="
+    docker compose exec tg_parser tg-parser topicize --channel "$channel" --mode incremental
+done
+```
+
+### Что произойдёт
+
+В режиме `incremental` для каждого канала:
+1. **Phase 1 (keyword assign):** uncovered docs привязываются к существующим темам по keywords (бесплатно)
+2. **Phase 2 (LLM discover):** оставшиеся docs группируются в новые темы через LLM с cross-channel context
+3. **Phase 3 (cross-channel TopicLinks):** automatically создаются links между новыми темами и темами других каналов (бесплатно)
+
+### Эффективность по типам каналов
+
+Из сессии 2026-05-14, **Phase 1 hit rate** показывает «созревание» канала:
+
+| Канал | hit rate | Природа |
+|---|---:|---|
+| profendocrinologist | 77% | Сильная предметная лексика — Phase 1 работает отлично |
+| labdiagnostica_logical | 47% | Хорошая лабораторная терминология |
+| AgeManagment | 14% | Специфические редкие keywords |
+| foodf4thought | 4% | Общая лексика — Phase 1 почти не работает |
+
+**Если hit rate < 20%** — это сигнал что канал слабо предметный или keyword extraction нужно улучшить.
+
+### Стоимость batch для всей системы
+
+Из сессии 2026-05-14 (8 каналов, 1670 uncovered docs total) → **~$4-5** на весь batch. Время **~5 минут** при rate_limit auto-adjusted (см. O-8).
+
+### Effect на coverage
+
+Реальные результаты сессии (incremental в обратном порядке размера):
+
+| Канал | Coverage до | Coverage после |
+|---|---:|---:|
+| Lab4health | 93.0% | **99.8%** |
+| LongevityClub | 89.4% | 99.1% |
+| genotek | 84.1% | 99.0% |
+| profendocrinologist | 75.6% | 98.7% |
+| mind_rise | 86.9% | 98.5% |
+| AgeManagment | 74.7% | 94.6% |
+| labdiagnostica_logical | 77.6% | 94.2% |
+| foodf4thought | 53.9% | 80.5% |
+
+Каналы с предметной лексикой выходят на 94-100%. `foodf4thought` упирается в потолок ~80% из-за специфики keyword extraction.
+
+### После batch — нужен ли link-topics?
+
+**Обычно — нет.** Phase 3 каждого incremental уже создаёт cross-channel links для новых тем. `link-topics` нужен только в одном из случаев:
+- Изменился threshold (default 0.3)
+- Хочется полный пересчёт связей **между всеми** темами, не только с новыми
+- После массовых изменений (новые каналы + редкие incremental'ы)
+
+В обычном workflow добавления одного канала — Phase 3 достаточно.
+
+---
+
+## 4. Cross-channel linking
+
+### Когда нужно
+
+В **большинстве случаев — НЕ нужно**. Phase 3 каждого incremental-прогона уже создаёт cross-channel links для новых тем (см. O-9). `link-topics` нужен только когда:
+
+1. **Изменился threshold** или другая настройка similarity → нужен полный пересчёт
+2. **Массовые добавления каналов** + хочется убедиться что всё связано правильно
+3. **Периодический re-build** (раз в месяц) для актуализации графа
+
+### ⚠️ Truncate-and-rebuild semantics
+
+`link-topics` **полностью удаляет** все существующие links и создаёт заново (см. O-10). В логах это видно как:
+```
+Cleared 746 old topic links
+Created 746 topic links from 173510 pairs (threshold=0.30)
+```
+
+`Cleared = Created` — нормально, означает полный пересчёт.
+
+**Любые ручные правки (если когда-нибудь будут возможны) будут потеряны.**
+
+### Команда
+
+```bash
+docker compose exec tg_parser tg-parser link-topics
+# или с custom threshold:
+docker compose exec tg_parser tg-parser link-topics --threshold 0.35
+```
+
+### Что произойдёт
+
+1. Старые links удаляются полностью
+2. Все пары топиков из разных каналов оцениваются: Jaccard (keywords) + cosine (embeddings)
+3. Пары с score >= threshold → создаются как `topic_link` записи
+
+### Расход
+
+**$0** — работает на готовых данных в БД, LLM не вызывается.
+
+### Время
+
+~40-46 секунд для 641 топика (173K пар).
+
+### Threshold guide
+
+| Threshold | Поведение |
+|---|---|
+| 0.20 | Много связей, включая шумовые |
+| 0.30 (default) | Сбалансированно |
+| 0.40 | Только сильные связи |
+| 0.50+ | Только очень сильные совпадения |
+
+При размере системы 641 топик и threshold 0.3 получили 746 links (ratio ~0.43% от всех пар).
+
+### Verify
+
+```python
+# Через MCP после link-topics:
+get_related_topics(topic_id="<какой-то существующий topic_id>")
+# Должно вернуть список связей с similarity_score
+```
+
+---
+
+## 5. Диагностика «канал не обрабатывается»
+
+### Симптом
+
+Канал добавлен через `add_channel`, прошло время, `list_channels` показывает `raw_messages: 0`.
+
+### Decision tree
+
+**Шаг 1.** Сколько прошло с момента `add_channel`?
+
+```python
+# Через MCP:
+get_pipeline_status(channel_id="<channel>")
+```
+
+- **< 1 час и `last_attempt_at: null`** — нормально. Шедулер тикает раз в час. Жди.
+- **> 1 час и `last_attempt_at: null`** — аномалия. См. шаг 2.
+- **`last_attempt_at` есть, `raw_messages: 0`** — Telegram-проблема. Канал может быть приватный, неправильное имя, и т.д. См. шаг 3.
+
+**Шаг 2.** Проверка scheduler:
+
+```bash
+# На VPS:
+docker compose logs tg_parser --since 1h | grep -i "scheduler\|incremental_pipeline"
+```
+
+Должны быть строки `Running job "incremental_pipeline"`. Если нет — шедулер мёртв. Перезапустить контейнер:
+
+```bash
+docker compose restart tg_parser
+```
+
+**Шаг 3.** Проверка Telethon:
+
+```bash
+docker compose logs tg_parser --since 1h | grep -i "<channel_id>\|telethon\|telegram"
+```
+
+Ищи: `ChannelPrivateError`, `UsernameNotOccupiedError`, `FloodWaitError`, или session-related ошибки.
+
+### ⚠️ MCP `trigger_pipeline` не помогает
+
+См. ISSUE-1: `triggered: true`, но реально ничего не делает. До фикса использовать SSH-команды.
+
+---
+
+## 6. Восстановление после billing-инцидента
+
+### Симптом
+
+В логах массово:
+```
+{"error": "Your credit balance is too low to access the Anthropic API..."}
+```
+
+### Шаги
+
+**1. Пополнить баланс.** Console: https://console.anthropic.com
+
+**2. Дождаться следующего scheduler tick (≤ 1 час).** Шедулер сам подхватит обработку.
+
+**3. Проверить что обработка идёт:**
+
+```bash
+docker compose logs tg_parser --since 5m | grep "tokens="
+# Должны быть строки вида:
+# "[2/4] Processing completed in N s: processed=N, failed=N, tokens=N"
+# где tokens > 0
+```
+
+Если `tokens=0` — billing ещё не разблокирован.
+
+**4. Дотопикизировать каналы, у которых упала топикизация:**
+
+```bash
+# Проверить какие каналы потеряли темы:
+# Через MCP: list_channels — смотри coverage_percent
+
+# Если у канала coverage < ожидаемого:
+docker compose exec tg_parser tg-parser topicize --channel <channel> --mode incremental
+```
+
+**5. После всех топикизаций — link-topics только если нужна полная пересборка графа:**
+
+В обычном workflow Phase 3 каждого incremental уже создаёт cross-links для новых тем (см. O-9). Запускайте link-topics только если:
+- Затронуто много каналов сразу (> 50% системы)
+- Хочется быть уверенным, что граф пересчитан с учётом всех изменений
+
+```bash
+docker compose exec tg_parser tg-parser link-topics
+```
+
+**⚠️ Помните:** link-topics — это truncate-and-rebuild (см. O-10), а не merge. Все существующие links будут пересозданы.
+
+### Profilactic
+
+Поставить alert на низкий баланс Anthropic (через их Console, есть billing alerts). Целевой минимум: 2× стоимость одного полного pipeline-цикла для всех каналов.
+
+---
+
+## 7. Оценка стоимости перед топикизацией
+
+До implementaion ENH-6 (pre-flight estimate) — оценивать вручную.
+
+### Формула
+
+```
+estimated_input_tokens  ≈ documents_count × 365   (калибровка от kdl_ru)
+estimated_output_tokens ≈ documents_count × 60
+estimated_cost_usd = (input/1M)*$3 + (output/1M)*$15
+```
+
+### Калькулятор
+
+```python
+def estimate_topicization_cost(docs_count: int) -> dict:
+    in_tokens  = docs_count * 365
+    out_tokens = docs_count * 60
+    in_cost  = in_tokens  * 3.0  / 1_000_000
+    out_cost = out_tokens * 15.0 / 1_000_000
+    return {
+        "input_tokens": in_tokens,
+        "output_tokens": out_tokens,
+        "input_cost_usd": round(in_cost, 2),
+        "output_cost_usd": round(out_cost, 2),
+        "total_cost_usd": round(in_cost + out_cost, 2),
+        "estimated_minutes": (docs_count / 50 / 5) * 0.2  # 50/batch, 5 concurrency, ~12s/batch
+    }
+```
+
+### Контрольная точка
+
+Калибровка от 2026-05-14:
+- kdl_ru: 841 docs → 306,754 in + 50,172 out → $1.67 (факт)
+- Формула выше дала бы: 307,000 in + 50,500 out → $1.68 ✅
+
+Расхождение менее 1%.
+
+### Прогноз для всех текущих каналов
+
+| Канал | docs | full topicize | incremental (приблизит.) |
+|---|---:|---:|---:|
+| profendocrinologist | 3 442 | ~$7 | ~$1.7 (840 uncovered → 0) |
+| Lab4health | 1 827 | ~$3.6 | ~$0.25 (127 uncovered → 4) |
+| labdiagnostica_logical | 1 148 | ~$2.3 | ~$0.50 (257 uncovered → 69) |
+| AgeManagment | 1 100 | ~$2.2 | ~$0.55 (278 uncovered → 64) |
+| mind_rise | 1 111 | ~$2.2 | ~$0.30 (146 uncovered → 8) |
+| genotek | 1 104 | ~$2.2 | ~$0.35 (175 uncovered → 11) |
+| kdl_ru | 841 | $1.67 (факт) | — |
+| LongevityClub | 339 | ~$0.7 | ~$0.10 (36 uncovered → 3) |
+| foodf4thought | 308 | ~$0.6 | ~$0.30 (142 uncovered → 65 unassignable) |
+| **Полная re-topicization всей системы** | **11 220** | **~$23** | **~$4-5** |
+
+**Из реального опыта сессии 2026-05-14:** полный massive incremental по всем 9 каналам обошёлся примерно в **$4-5**, занял **~25 минут**, дал прирост **+62 темы (incremental-only)** и **+571 cross-channel link**.
+
+**Стратегический вывод:** incremental в **5-7× дешевле** full при сопоставимом качестве. Рекомендованный workflow:
+- Full только при первом добавлении канала
+- Incremental раз в неделю-месяц по всей системе
+- link-topics только при изменении threshold или массовых правках
+
+---
+
+## 8. Настройка watchlist и digest
+
+### Prerequisites
+
+**1. Узнать Telegram chat_id**
+
+Через бот `@userinfobot`: `/start` → возвращает `Id: <число>`. Это `chat_id` для личных пушей.
+
+**2. Инициализировать диалог с ботом проекта**
+
+Telegram запрещает ботам писать первым. До настройки подписок один раз отправить боту `/start`. Иначе подписки создадутся, но пуши не доставятся (ошибка `Forbidden: bot can't initiate conversation`).
+
+### 8.1 Создать watchlist (моментальные пуши при match)
+
+```python
+# MCP:
+subscribe_watchlist(
+    title="Семаглутид и GLP-1",
+    description="GLP-1 рецептор-агонисты, семаглутид, тирзепатид. Клинические исследования.",
+    channel_ids=["profendocrinologist", "LongevityClub", "AgeManagment"],
+    chat_id=5445781511,
+    keywords=["семаглутид", "GLP-1", "оземпик", "тирзепатид"],
+    threshold=0.6
+)
+```
+
+**Принципы:**
+- **Один watchlist на тему**, не валить всё в один
+- **Description обязателен** — формирует embedding (без него только title+keywords, recall хуже). См. O-6 в enhancements.md
+- **Channel_ids подбираются по релевантности темы**, не «все каналы». Шум — главный враг watchlist
+- **Threshold 0.6 default**, повышай если много false positives, снижай если recall плохой
+
+### 8.2 Создать digest (расписанный дайджест)
+
+```python
+subscribe_digest(
+    name="Эндокринология — ежедневный дайджест",
+    channel_ids=["profendocrinologist"],
+    chat_id=5445781511,
+    cron_expression="0 9 * * *",       # 9:00
+    timezone="Europe/Nicosia",          # локальная зона
+    format="summary",                   # summary | bullets | detailed
+    language="ru"
+)
+```
+
+**Cron-примеры:**
+- `0 9 * * *` — каждый день в 9:00
+- `0 9 * * 1` — каждый понедельник в 9:00
+- `0 9 1 * *` — первое число каждого месяца в 9:00
+- `0 9 * * 1,4` — понедельник и четверг 9:00
+
+### 8.3 Проверить созданные подписки
+
+```python
+list_watchlists()  # все мои интересы
+list_digests()     # все мои digest-подписки
+```
+
+### 8.4 Найти match'и watchlist (после следующего scheduler tick)
+
+```python
+get_watchlist_matches(interest_id="<id>", since_iso="2026-05-14T00:00:00")
+```
+
+⚠️ **Watchlist оценивает только новые документы**, появившиеся после создания подписки (см. O-4 в enhancements.md). Для поиска по историческим данным используй `search_knowledge_base` или `ask_question`.
+
+### 8.5 Удалить подписку
+
+```python
+unsubscribe_watchlist(interest_id="<id>")
+unsubscribe_digest(subscription_id="<id>")
+```
+
+### ⚠️ Подписки НЕ идемпотентны
+
+Повторный `subscribe_*` с теми же параметрами создаст **новую** подписку с новым UUID. Если перезапускаешь скрипт настройки — сначала почисть существующие, либо проверь `list_*` перед `subscribe_*`. См. ISSUE-10 в bug-report.md.
+
+### Best practices
+
+1. **Validate keywords/description вручную** на этапе planning — сейчас нет preview-инструмента (см. ENH-13). Можно использовать `search_knowledge_base` с теми же keywords и оценить релевантность top results.
+2. **Не более 5-7 watchlist одновременно** — иначе сложно различать пуши и легко проспать главное.
+3. **Threshold tuning итеративно:** start с 0.6, через неделю смотри matches, корректируй.
+4. **Periodic review:** раз в месяц `list_watchlists` → удалять устаревшие.
+
+---
+
+## Quick reference card
+
+```
+CHECK STATUS:           list_channels(workspace_id=...)
+CHECK ONE CHANNEL:      get_pipeline_status(channel_id=...)
+ADD CHANNEL:            add_channel(channel_id="...") + add_workspace_source(...)
+TOPICIZE NEW:           docker compose exec tg_parser tg-parser topicize --channel X
+LINK TOPICS:            docker compose exec tg_parser tg-parser link-topics
+SEE RELATED:            get_related_topics(topic_id="...")
+CROSS-CHANNEL STATS:    get_cross_channel_stats() or with workspace_id=...
+SEARCH:                 search_knowledge_base(query="...")
+ASK Q:                  ask_question(question="...")
+SUBSCRIBE WATCHLIST:    subscribe_watchlist(title, channel_ids, chat_id, keywords, description)
+SUBSCRIBE DIGEST:       subscribe_digest(name, channel_ids, chat_id, cron, timezone)
+LIST SUBSCRIPTIONS:     list_watchlists() / list_digests()
+UNSUBSCRIBE:            unsubscribe_watchlist(id) / unsubscribe_digest(id)
+```
+
+## SSH-base operations (до фикса MCP gaps)
+
+```
+SSH:                    ssh -p 2296 user@212.72.189.15
+LOGS:                   docker compose logs --since 30m tg_parser
+TOPICIZE:               docker compose exec tg_parser tg-parser topicize --channel X
+LINK:                   docker compose exec tg_parser tg-parser link-topics
+INSPECT JOBS:           docker compose logs tg_parser | grep apscheduler
+RESTART:                docker compose restart tg_parser
+```

--- a/docs/notes/mcp_testing/2026-05-15_claude_session/05-data-quality-report.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/05-data-quality-report.md
@@ -1,0 +1,334 @@
+# tg-parser — Data Quality Report
+
+**Snapshot date:** 2026-05-14 (после Phase 8 — финальное состояние сессии)
+**Total:** 9 каналов, 3 workspaces, 11,220 documents, **641 topics**, **746 topic links**, **795 keyword overlaps**, 4 watchlists, 1 digest
+
+---
+
+## 1. Состояние каналов
+
+| Канал | Workspace | Raw | Processed | Topics | Coverage | Singletons | Clusters |
+|---|---|---:|---:|---:|---:|---:|---:|
+| Lab4health | Лабдиагностика | 1 845 | 1 827 | **171** | **99.78%** | 131 | 40 |
+| **profendocrinologist** | Эндокринология | 3 443 | 3 442 | 111 | 98.66% | **7** ✨ | 104 |
+| AgeManagment | Longevity | 1 105 | 1 100 | 89 | 94.64% | 27 | 62 |
+| labdiagnostica_logical | Лабдиагностика | 1 164 | 1 148 | 84 | 94.16% | 13 | 71 |
+| **kdl_ru** | Лабдиагностика | 842 | 841 | 46 | 90.49% | 12 | 34 |
+| mind_rise | Longevity | 1 111 | 1 111 | 45 | 98.47% | 8 | 37 |
+| LongevityClub | Longevity | 339 | 339 | 38 | 99.12% | 21 | 17 |
+| genotek | Лабдиагностика | 1 109 | 1 104 | 36 | 99.00% | 6 | 30 |
+| foodf4thought | Longevity | 310 | 308 | 21 | **80.52%** | 3 | 18 |
+| **ИТОГО** | | **11 268** | **11 220** | **641** | **средн. ~95%** | **228** | **413** |
+
+✨ — у profendocrinologist singletons появились после Phase 8 incremental (раньше было 0). Аномалия A1 разрешена.
+
+### Эволюция за сессию
+
+| Канал | Topics до → после | Coverage до → после |
+|---|---|---|
+| Lab4health | 166 → **171** | 93.05% → **99.78%** |
+| profendocrinologist | 0 (new) → **111** | 0% → 98.66% |
+| AgeManagment | 75 → **89** | 74.73% → **94.64%** |
+| labdiagnostica_logical | 79 → **84** | 77.61% → **94.16%** |
+| kdl_ru | 0 (new) → **46** | 0% → 90.49% |
+| mind_rise | 43 → **45** | 86.86% → 98.47% |
+| LongevityClub | 36 → **38** | 89.38% → 99.12% |
+| genotek | 32 → **36** | 84.15% → **99.00%** |
+| foodf4thought | 10 → **21** | 53.90% → **80.52%** |
+| **Всего** | **до сессии: 441 → финал: 641 (+200)** | **средн. ~95%** |
+
+### Аномалии — состояние
+
+#### A1 (РАЗРЕШЕНА): profendocrinologist singletons
+
+Раньше: `singleton_count: 0`. Сейчас: **7 singletons**. Гипотеза подтвердилась: full без cross-channel даёт 0 singletons, incremental с cross-channel context — создаёт singletons естественно. См. O-11 в enhancements.md.
+
+#### A2 (РАЗРЕШЕНА): profendocrinologist coverage
+
+Раньше: 75.60% при 92 темах. Сейчас: **98.66%** при 111 темах. Incremental + cross-channel дотянул coverage почти до потолка системы. Оставшиеся 1.34% — это нормальный «хвост» (короткие посты, объявления).
+
+#### A3 (ЧАСТИЧНО РАЗРЕШЕНА): foodf4thought slabое звено
+
+Coverage поднялся с 53.9% до **80.5%**, top keywords улучшились: появились **предметные термины** `mind-body`, `wellness-туризм`, `велнеса` (см. O-12 в enhancements.md). Но **65 docs остаются unassignable** — это реальный потолок для канала. Возможно, контент слишком короткий и общий. Дальнейшие улучшения возможны через full `--force` или принять как baseline.
+
+#### A4 (НОВАЯ, ОТКРЫТА): «Topic failed quality criteria, skipping» — silent reject
+
+В incremental режиме на AgeManagment, labdiagnostica_logical и genotek наблюдалось отбрасывание предлагаемых тем без указания причины. Может скрывать полезных кандидатов. См. ISSUE-11 в bug-report.md.
+
+---
+
+## 2. Состояние workspaces
+
+### Лабораторная диагностика (4 канала)
+
+| Метрика | Значение |
+|---|---:|
+| Каналов | 4 |
+| Documents | 4 920 |
+| Topics | **337** (было 323) |
+| Avg coverage | **95.86%** (было 86.43%) |
+
+Каналы: Lab4health, labdiagnostica_logical, kdl_ru, genotek.
+
+Сильный workspace. Тематика сфокусирована: лабораторные методы, диагностика, маркеры. Все каналы > 90% coverage. Кросс-связи внутри workspace очень содержательные (helicobacter+pylori, anti+aller, B12, etc.).
+
+### Longevity (4 канала)
+
+| Метрика | Значение |
+|---|---:|
+| Каналов | 4 |
+| Documents | 2 858 |
+| Topics | **193** (было 164) |
+| Avg coverage | **93.19%** (было 76.22%) |
+
+Каналы: AgeManagment, mind_rise, LongevityClub, foodf4thought.
+
+После Phase 8 workspace выровнялся. foodf4thought всё ещё отстаёт (80.5%), но остальные > 94%. Самый концентрированный канал — LongevityClub (38 топиков на 339 docs, 99.1% coverage).
+
+### Эндокринология (1 канал)
+
+| Метрика | Значение |
+|---|---:|
+| Каналов | 1 |
+| Documents | 3 442 |
+| Topics | **111** (было 92) |
+| Avg coverage | **98.66%** (было 75.60%) |
+
+Один канал, но самый большой. После incremental прошёл с 75.6% до 98.66% coverage, появились 7 singleton-тем. Высокоспециализированный профессиональный канал, теперь полностью топикизирован.
+
+---
+
+## 3. Cross-channel связность
+
+### По keywords (через `get_cross_channel_stats`)
+
+- **Total overlaps:** **795** (было 718, +77)
+- Большинство — между парами/тройками каналов
+- Сквозные (5-7 каналов): `анализ`, `активность`, `безопасность`, `covid-19`
+
+### По topic_links (через `link-topics`)
+
+- **Total links:** **746** (было 708, +38)
+- **Threshold:** 0.3
+- **Avg similarity:** 0.3352 (было 0.3345)
+- **Pairs evaluated:** **173 510** (было 140 485)
+- **Семантика:** truncate-and-rebuild (Cleared 746 = Created 746 — см. O-10)
+
+Сильные пары (по наблюдению, без полного перебора):
+- profendocrinologist ↔ kdl_ru (микробиота, B12)
+- profendocrinologist ↔ LongevityClub (GLP-1, метаболизм)
+- kdl_ru ↔ labdiagnostica_logical (методы, маркеры)
+
+### ⚠️ Note: Phase 3 incremental тоже создаёт links
+
+Из сессии 2026-05-14: каждый incremental-прогон создаёт cross-channel links для новых тем (см. O-9). За Phase 8 было создано:
+- profendocrinologist: 128 links
+- labdiagnostica_logical: 124
+- Lab4health: 105
+- AgeManagment: 99
+- mind_rise: 68
+- foodf4thought: 31
+- LongevityClub: 26
+- genotek: 26
+- **Итого Phase 3 (incremental): 607 links** перед финальным link-topics
+
+После финального truncate-and-rebuild `link-topics` все эти links были пересозданы вместе с links для существующих тем. Финал: 746 links.
+
+### ⚠️ Limitation
+
+`get_cross_channel_stats` сейчас не использует `topic_links` (см. ISSUE-8). Реальная семантическая связность недооценена в текущем endpoint'е.
+
+---
+
+## 4. Top keywords by channel — экспертная оценка
+
+### Высоко содержательные (профессиональная лексика)
+
+**profendocrinologist:**
+`17-гсдг-3, 46,xy, bimagrumab, 25(oh)d, bethesda, BRAF`
+→ узкоспециальные эндокринологические термины.
+
+**labdiagnostica_logical:**
+`b12, clia, helicobacter, igg, mar-тест, mchc, pandas, prisca, pylori, авидность`
+→ лабораторные методы и маркеры.
+
+**genotek:**
+`car-t, crispr, herc2, oca2, polg-мутации, t-лимфоцитов, y-хромосома`
+→ генетика, иммунология.
+
+### Средне содержательные
+
+**Lab4health, kdl_ru, mind_rise, AgeManagment, LongevityClub** — смесь предметной лексики и общих слов.
+
+### Низко содержательные (но улучшаются итеративно)
+
+**foodf4thought:**
+
+До Phase 8 incremental: `благополучие, вебинары, влияние, восприятие, врачей, гормональное, городской, для, доказательная` → почти все — общая лексика.
+
+После Phase 8 incremental: `mind-body, wellness-туризм, активация, активный, благополучие, вебинары, велнеса, вкус, влияние, влияния` → появились предметные термины `mind-body`, `wellness-туризм`, `велнеса`.
+
+**Подтверждено:** keyword extraction зависит от существующих topic-cards канала, и itерacция incremental → новые темы → keywords из их title постепенно улучшает quality. См. O-12 в enhancements.md.
+
+---
+
+## 5. Keyword overlap noise
+
+В выдаче `get_cross_channel_stats` много шумовых overlap-записей:
+
+### Стоп-слова (нужна фильтрация):
+- `анализ` (7 каналов)
+- `активность` (6)
+- `безопасность` (6)
+- `аспекты` (4)
+- `влияние`, `влияния`, `восприятие` (foodf4thought-driven)
+
+### Грамматические дубли (нужна лемматизация, см. ISSUE-9):
+- `аллергия` / `аллергии` / `аллергические`
+- `анализ` / `анализа` / `анализам` / `анализов` / `анализы`
+- `адаптация` / `адаптации`
+- `бад` / `бады`
+- `бактерии` / `бактериальные`
+- `белки` / `белков`
+
+После лемматизации `overlap_count` снизится с 795 до ~550-600 при сохранении информативности.
+
+---
+
+## 6. Готовность системы
+
+### ✅ Готово
+- Все 9 каналов прошли ingest + process + topicize
+- Все 3 workspaces полностью затопикизированы
+- Topic links построены (746)
+- Coverage везде > 80%, у 7 из 9 каналов > 94%
+- Cross-channel analytics работает (с оговорками)
+- 4 watchlist + 1 digest активны
+
+### ⚠️ Требует внимания
+- ISSUE-3': `--skip-topicize` в шедулере → новые посты не топикизируются автоматически (by design, но мешает)
+- ISSUE-8: `get_cross_channel_stats` не отражает реальной связности (не использует topic_links)
+- ISSUE-11: «Topic failed quality criteria, skipping» — отбрасывание без causa
+- foodf4thought упирается в 80% coverage (см. A3)
+
+### ❌ Известные проблемы
+- ISSUE-1: MCP `trigger_pipeline` silent no-op
+- ISSUE-7: CLI `topicize` рапортует success при fail
+- ISSUE-9: keywords не лемматизированы
+- ISSUE-10: subscribe_* не идемпотентны
+
+---
+
+## 7. Активные подписки
+
+### Watchlists (4 шт.)
+
+| Title | Каналов | Threshold | UUID |
+|---|---:|---:|---|
+| GLP-1 агонисты и семаглутид | 3 | 0.6 | `9f23fd49-8794-427d-a5c0-235a24e175cb` |
+| Микробиота и кишечный микробиом | 6 | 0.6 | `62a994b2-e166-491c-8e2e-065c7bf5be78` |
+| Биомаркеры старения | 5 | 0.6 | `ab6ab349-89a5-453e-864d-f6396d63630c` |
+| mTOR и геропротекторы | 3 | 0.6 | `42df2709-0055-4398-b866-67ee4ad05f6f` |
+
+**chat_id:** 5445781511 (личный диалог owner с ботом)
+
+**Параметры:**
+- Все active, threshold 0.6, notify_mode `instant`
+- Description прописан везде (улучшает embedding-based recall)
+- Channel selection делается тематически, не «все 9»
+
+### Digest (1 шт.)
+
+| Name | Каналы | Schedule | Timezone | Format |
+|---|---|---|---|---|
+| Эндокринология — ежедневный дайджест | profendocrinologist | `0 9 * * *` | Europe/Nicosia | summary |
+
+UUID: `94483db9-9351-4f99-9aec-46949d9ddd09`
+
+### Покрытие каналов подписками
+
+| Канал | В скольких watchlist'ах | Digest |
+|---|---:|---|
+| profendocrinologist | 2 (GLP-1, Микробиота) | ✅ |
+| LongevityClub | 4 (все) | — |
+| AgeManagment | 3 (GLP-1, Биомаркеры, mTOR) | — |
+| mind_rise | 3 (Микробиота, Биомаркеры, mTOR) | — |
+| Lab4health | 2 (Микробиота, Биомаркеры) | — |
+| kdl_ru | 1 (Микробиота) | — |
+| foodf4thought | 1 (Микробиота) | — |
+| genotek | 1 (Биомаркеры) | — |
+| labdiagnostica_logical | 0 | — |
+
+**Наблюдение:** `labdiagnostica_logical` не покрыт ни одним watchlist. Это сознательно: канал про методы лабдиагностики (масс-спектрометрия, ИФА), темы из watchlist'ов туда плохо ложатся. Если в будущем добавятся темы вроде «лабораторная диагностика гормональных нарушений» — стоит включить.
+
+### ⚠️ Известные ограничения
+
+1. **Forward-only:** watchlist'ы не сканируют исторические 11,220 документов (O-4). Match'и появятся со следующего scheduler tick (~через час) и только для новых постов.
+2. **Не идемпотентны** (ISSUE-10): повторный subscribe создаст дубль.
+3. **Не workspace-bound** (O-5, ENH-9): подписки на каналы, а не workspaces.
+
+---
+
+## 8. Метрики, которые стоит регулярно отслеживать
+
+### Дневные
+- Сумма raw_messages во всех каналах (прирост в день)
+- Сумма tokens spent на Anthropic API (через processing-этап pipeline_service логи)
+- fail_count по каналам
+
+### Недельные
+- coverage_percent по каналам (должен расти или быть стабильным)
+- topics_count по каналам (должен расти при добавлении новых постов)
+- total_links после link-topics (растёт с topics, но нелинейно — pairs масштабируются квадратично, ratio ~0.4-0.5% от всех пар при threshold 0.3)
+- avg_similarity links (стабилен ~0.33, дрейф вверх/вниз — сигнал изменения характера системы)
+
+### При необходимости
+- average items_count per topic (если стабильно 102-103 — проверить, не упирается ли в технический потолок)
+- ratio singletons/clusters (по каналам — драматическое изменение сигналит о смене характера канала)
+- **Phase 1 hit rate при incremental** (низкие значения < 20% — сигнал слабого keyword extraction для канала)
+- **Quality filter rejected count** при incremental (если ISSUE-11 будет исправлен)
+
+---
+
+## 9. Capacity & Cost forecasting
+
+### Current state cost (итог сессии 2026-05-14)
+
+Полная стоимость, инвестированная в данные:
+- Processing (один scheduler tick всех каналов): ~$2
+- kdl_ru full topicize: **$1.67** (факт)
+- profendocrinologist full topicize: **~$7** (приблиз.)
+- Phase 8: 8 incremental по всем каналам (кроме profendocrinologist первого прогона): **~$4-5**
+- link-topics × 2: **$0**
+- Watchlist + digest setup: **$0**
+- **Total: ~$15** за всю сессию
+
+### Калибровка
+
+После сессии 2026-05-14 есть надёжные точки калибровки:
+- **Full topicize:** ~$0.0020 за document
+- **Incremental topicize:** **~$0.003 за uncovered document** (Phase 2 LLM cost; Phase 1 + Phase 3 бесплатны)
+- **Pre-flight estimate:** см. раздел 7 в operational-runbook.md
+
+### Forecast при росте
+
+| Сценарий | Triggered cost |
+|---|---|
+| +1 small channel (300 docs) | $0.60 full topicize + $0.10 process per cycle |
+| +1 medium channel (1500 docs) | $3.00 full topicize + $0.50 process per cycle |
+| Full re-topicization всей системы (11 220 docs) | ~$23 |
+| **Maintenance — incremental по всем 9 каналам раз в неделю** | **~$4-5/неделя** |
+| Daily processing (incremental, scheduler) | <$1/day |
+
+### Стратегические выводы по стоимости
+
+1. **Full только при первом добавлении канала** — больше никогда (если не нужен полный re-topicize)
+2. **Maintenance via incremental — основной паттерн** для актуализации
+3. **link-topics — бесплатный** инструмент, не сдерживайтесь от частого использования при изменениях
+4. **При мониторинге Anthropic balance** держите минимум $30 запас (3× недельный maintenance + queue для emergencies)
+
+### Recommendations
+
+1. **Поставить billing alert** в Anthropic Console на $10 минимум, $50 рекомендуемо
+2. **Не запускать `--force` re-topicize** без оценки
+3. **Отслеживать `tokens=` в логах процессинга** — резкий рост значит больше новых постов (нормально) или дрейф в длину постов (внимание)

--- a/docs/notes/mcp_testing/2026-05-15_claude_session/README.md
+++ b/docs/notes/mcp_testing/2026-05-15_claude_session/README.md
@@ -1,0 +1,163 @@
+# tg-parser — Session 2026-05-14: Documents Index
+
+Полный набор документов, созданных по итогам сессии расследования и работы с tg-parser 2026-05-14.
+
+## Документы в этой папке
+
+| # | Файл | Назначение |
+|---|---|---|
+| 01 | `01-bug-report.md` | 11 issue (1 retracted, 10 активных) для bug tracker |
+| 02 | `02-enhancements.md` | 13 предложений по улучшениям + 12 архитектурных наблюдений |
+| 03 | `03-investigation-log.md` | Хронология расследования (8 фаз) + lessons learned |
+| 04 | `04-operational-runbook.md` | 8 типовых операций с системой |
+| 05 | `05-data-quality-report.md` | Финальный снапшот данных, метрик и активных подписок |
+
+---
+
+## Финальная статистика системы (2026-05-14, конец сессии)
+
+| Метрика | Значение |
+|---|---:|
+| Каналов | 9 |
+| Workspaces | 3 |
+| Total documents | 11 220 |
+| Total topics | **641** |
+| Cross-channel topic links | **746** |
+| Keyword overlaps | **795** |
+| Watchlists | 4 |
+| Digests | 1 |
+| **Coverage** | **средн. ~95%** (от 80.5% до 99.8%) |
+| Затраты на сессию | ~$15 |
+
+---
+
+## Priority items для следующей итерации
+
+### Critical (нужно решить до production scale)
+
+1. **ISSUE-1** — MCP `trigger_pipeline` silent no-op
+   Главный архитектурный баг. Без фикса MCP-интеграция неполноценна.
+
+2. **ISSUE-7** — CLI `topicize` рапортует ✅ при тотальном fail
+   Опасно для автоматизации.
+
+3. **ISSUE-10** — `subscribe_*` не идемпотентны
+   Опасно для automation. Повторный запуск скрипта создаёт дубли подписок → двойные пуши.
+
+### High (UX и safety)
+
+4. **ISSUE-3'** — misleading log `[3/4] Topicization skipped (--skip-topicize)`
+   Один из главных «time-sink» багов сессии. Простой фикс.
+
+5. **ENH-5** — Cost-control flag (`--max-cost-usd`) для топикизации
+   Защита от непреднамеренных расходов. Особенно важно учитывая auto-adjusted rate limit (O-8).
+
+6. **ENH-1** — MCP `trigger_topicization`
+   Закрывает architectural gap, позволит автоматизировать weekly maintenance.
+
+7. **ENH-9** — Workspace-bound subscriptions (digest + watchlist)
+   Сейчас подписки только на channel_ids; добавление каналов в workspace не отражается.
+
+### Medium
+
+8. **ISSUE-4** — `last_attempt_at` не обновляется
+9. **ISSUE-8** — `get_cross_channel_stats` игнорирует `topic_links`
+10. **ISSUE-11** — «Topic failed quality criteria, skipping» без указания причины
+11. **ENH-12** — Backfill scan для watchlists на исторические данные
+12. **ENH-13** — Preview / dry-run для watchlist перед созданием
+13. **ENH-3** — Health-check для stuck active sources
+14. **ENH-6** — Pre-flight cost estimate
+
+### Low
+
+15. Остальные ISSUE и ENH — по мере возможности
+
+---
+
+## Quick-win plan
+
+Самое полезное за минимум усилий:
+
+1. ✅ **Поправить misleading log** (ISSUE-3') — 5 минут, экономит часы будущих debug-сессий
+2. ✅ **Поправить CLI exit code при failed batches** (ISSUE-7) — 30 минут, защищает от silent failure в автоматизации
+3. ✅ **Добавить idempotency на subscribe_*** (ISSUE-10) — 1 час, защищает от дублей в автоматизации
+4. ✅ **Логировать reason для "Topic failed quality criteria"** (ISSUE-11) — 30 минут
+5. ✅ **Логировать rate_limit adjustment как WARN, не INFO** (часть O-8) — 5 минут
+6. ✅ **Добавить billing alert в Anthropic Console** — 2 минуты (не часть кода)
+
+После этого — браться за ISSUE-1 (это уже архитектурное изменение, требует продумывания) и ENH-1.
+
+---
+
+## Operational status — что сделано в сессии
+
+| Действие | Результат |
+|---|---|
+| Создан workspace «Лабораторная диагностика» | ✅ 4 канала |
+| Создан workspace «Longevity» | ✅ 4 канала |
+| Создан workspace «Эндокринология» | ✅ 1 канал |
+| Добавлен канал `@profendocrinologist` | ✅ ingest + process |
+| Топикизирован `kdl_ru` (full) | ✅ 46 тем, $1.67 |
+| Топикизирован `profendocrinologist` (full) | ✅ 92 тем, ~$7 |
+| Топикизированы все 9 каналов (Phase 8 incremental) | ✅ +62 новых тем, ~$5 |
+| Запущен `link-topics` × 2 | ✅ 708 → **746 связей** |
+| Создан watchlist «GLP-1 и семаглутид» | ✅ 3 канала |
+| Создан watchlist «Микробиота» | ✅ 6 каналов |
+| Создан watchlist «Биомаркеры старения» | ✅ 5 каналов |
+| Создан watchlist «mTOR и геропротекторы» | ✅ 3 канала |
+| Создан digest «Эндокринология» | ✅ 9:00 ежедневно Europe/Nicosia |
+| Зафиксированы 10 активных issue + 13 enhancement + 12 observations | ✅ Эти документы |
+
+**Total cost:** ~$15 за всю сессию.
+
+---
+
+## Контекст для будущих сессий
+
+### Что знать про систему
+
+- **Шедулер** (APScheduler в `tg_parser` container) тикает `incremental_pipeline` раз в час
+- **Топикизация автоматически НЕ делается** — by design (`--skip-topicize` хардкод в scheduler_service.py:112), нужно вручную через CLI
+- **Cross-channel linking** запускается отдельно через `link-topics`, бесплатно, быстро (~46 сек)
+- **Phase 3 incremental** уже создаёт cross-links для новых тем (см. O-9) — link-topics не нужен после обычного incremental
+- **link-topics — truncate-and-rebuild** (см. O-10) — Cleared = Created, любые edits будут утеряны
+- **Rate limit auto-adjusts** от 50 → 4000 rpm (см. O-8) — может скрытно поднять burst cost
+- **MCP — отдельный контейнер**, имеет архитектурную асимметрию (см. ISSUE-1)
+- **Subscriptions forward-only**, не сканируют исторические данные (см. O-4, ENH-12)
+
+### Что знать про данные
+
+- **641 топиков, 11 220 документов, 746 cross-channel links** на 2026-05-14 (финал сессии)
+- **9 каналов** в 3 workspaces, все coverage > 80%
+- **profendocrinologist** — крупнейший канал (3442 docs, 111 топиков, coverage 98.7%)
+- **foodf4thought** — упирается в 80% coverage из-за слабого keyword extraction (A3)
+- **Phase 1 hit rate** — индикатор предметности keywords (77% у profendocrinologist vs 4% у foodf4thought)
+- **Singletons** — индикатор зрелости топикизации (full → 0, incremental → 5-15%)
+
+### Что знать про стоимость
+
+- **~$0.0020 за document** на full topicize (Sonnet 4)
+- **~$0.003 за uncovered document** на incremental topicize (только Phase 2)
+- **~$4-5/неделя** на maintenance via incremental по всем каналам
+- **~$23** на полную re-topicization всей системы
+- **<$1/день** на incremental updates при текущем темпе
+- **Watchlist / digest / link-topics / Phase 3 incremental — $0** (используют готовые данные, без LLM)
+
+---
+
+## Передача в Cursor
+
+Все эти документы предназначены для копирования в проект (например `docs/sessions/2026-05-14/`) или в систему задач:
+
+```bash
+# Скопировать в проект:
+cp /path/to/these/docs ~/TG_parser/docs/sessions/2026-05-14/
+
+# Или открыть в Cursor для интеграции с issue tracker
+```
+
+Для bug tracker особенно полезен файл `01-bug-report.md` — каждый ISSUE отформатирован под перенос в отдельный тикет.
+
+Документ `04-operational-runbook.md` — рабочая инструкция для maintenance: добавление каналов, инкрементальные апдейты, восстановление после инцидентов.
+
+Документы `02-enhancements.md` и `05-data-quality-report.md` — материал для planning следующих итераций разработки и улучшения качества данных.

--- a/docs/notes/mcp_testing/README.md
+++ b/docs/notes/mcp_testing/README.md
@@ -1,0 +1,25 @@
+# MCP Testing Sessions
+
+External testing sessions of the TG_parser MCP surface — bug reports, enhancement proposals, operational findings, and data quality assessments produced by AI agents or human operators exercising the deployed MCP tools end-to-end.
+
+## Purpose
+
+Each session lives in a dedicated subdirectory and is a **read-only snapshot** of the testing agent's output. Derived actions (bug filings, parity tracker updates, ADR drafts, planning artifacts) are landed via separate PRs that reference the snapshot, preserving the raw artifact's integrity for audit / regression / methodology lessons.
+
+## Sessions
+
+| Date | Tester | Files | Key findings | Derived-action PR |
+|---|---|---|---|---|
+| [2026-05-15](2026-05-15_claude_session/) | Claude (Anthropic) | 6 documents (~129 KB) | 11 issues + 13 enhancements + 12 observations + 4 data anomalies + 8 runbook procedures | _(filled when PR B lands)_ |
+
+## Conventions
+
+- Subdirectory: `YYYY-MM-DD_<tester>_session/` (sortable, identifies tester)
+- Entry point: `README.md` inside each session subdirectory
+- Numbered files: `01-bug-report.md`, `02-enhancements.md`, etc. (consistent within each session, varies across sessions as the testing scope dictates)
+- **Read-only**: snapshot files are not edited after intake. Refinements happen in derived-action PRs.
+
+## Related
+
+- [BUG_LOG.md](../BUG_LOG.md) — current Active / Resolved bug tracker; references session findings via BUG-XXX IDs
+- [PARITY_DECISION_TRACKING.md](../PARITY_DECISION_TRACKING.md) — parity gap tracker; session-discovered gaps land as O-N observations


### PR DESCRIPTION
## Summary

- Lands `docs/notes/mcp_testing/2026-05-15_claude_session/` as a read-only
  external-testing-session snapshot (6 files, ~129 KB).
- Establishes the `docs/notes/mcp_testing/` folder convention for future
  testing sessions (Claude, Gemini, manual user, ...) with a folder-level
  README index and per-session README landing pages.
- Mirror of PR #70 / PR #73 planning-artifact-snapshot pattern — separates
  raw artifact intake from derived-action distillation.

## Why a separate PR (intake)?

Keeps derived-action PR B (BUG-015..024 filing + parity O-3 + BUG-009
cleanup) focused on distillation. Reviewer of B sees concrete cross-refs
to landed paths in main rather than working-copy.

## Cross-links

- Derived-action PR (B) follows this PR — files BUG-015..024 referencing
  these snapshot sections.
- `docs/notes/HANDOFF_POST_WAVE1_STEP2_2026-05-15.md` — context for why
  this intake happens now (clean observability baseline objective).

## Test plan

None — read-only docs artifact.

Made with [Cursor](https://cursor.com)