### PR TITLE
feat(parity): Wave 1 step 3 — Surface Parity MVP (P-1 + P-2 + ENH-9 + BUG-022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Wave 1 step 3 — Surface Parity (Watchlist + Digest HTTP API + Idempotency) (2026-05-22)
+
+**Контекст.** Wave 1 step 3 «Surface Parity MVP» landed as a single PR with 4 atomic commits. Closes BUG-022 (subscribe-tool idempotency, all four surfaces) + ENH-9 (`workspace_id` параметр на subscribe-tools); adds P-1 (Watchlist HTTP API, 5 endpoints) + P-2 (Digest HTTP API, 4 endpoints) + Stripe-style `Idempotency-Key` HTTP middleware. Source of truth: [`docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`](docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md); DONE marker stub [`docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md`](docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md).
+
+#### Added
+
+- **HTTP API for watchlist (P-1)** — `POST/GET/DELETE /api/v1/watchlists` + `GET /api/v1/watchlists/{id}/matches`. Five endpoints under `/api/v1/watchlists`; auth via existing `X-API-Key`; `workspace_id` optional FK; response shape `{watchlist_id, created, changed_fields}` per Q-OPEN-1; soft-delete with idempotent 204+204; matches history with `?since=ISO8601` + offset/limit pagination.
+- **HTTP API for digest (P-2)** — `POST/GET/DELETE /api/v1/digests`. Four endpoints; response shape `{digest_id, created, changed_fields}`; cron/timezone pre-validation at router (parity with MCP path); **HARD delete** (asymmetric vs watchlist soft-delete — sprint Q-OPEN-8 lock).
+- **ENH-9** — `workspace_id` parameter on `subscribe_watchlist` / `subscribe_digest` across MCP / Bot / CLI / HTTP surfaces (FK to `workspaces`, `ON DELETE SET NULL`). Unknown / foreign workspaces collapse to a 404-like `WorkspaceNotFound` to avoid leaking existence.
+- **Idempotency-Key HTTP middleware (commit 4/4)** — Stripe-style FastAPI dependency `idempotency_key_check` wired on POST `/api/v1/watchlists` + POST `/api/v1/digests` (opt-in per endpoint, Q-OPEN-7). Same key + same body → cached 2xx replay; same key + different body → `422 IdempotencyKeyMismatch` (Q-OPEN-1 lean per ADR 0009); 24h TTL; only 2xx outcomes cached (R-2 mitigation); canonical JSON body hashing for client-side serialization-order independence (R-4 mitigation).
+- **Hourly cleanup tick** — `cleanup_stale_idempotency_keys` runs every top-of-hour (cron `0 * * * *`) deleting rows with `created_at < now() - 24h` and refreshing the `tg_idempotency_keys_table_size` gauge.
+- **Prometheus metrics** — `tg_idempotency_keys_hit_total{result=hit|miss|mismatch}` counter + `tg_idempotency_keys_table_size` gauge (Karpathy principle 6).
+
+#### Fixed
+
+- **BUG-022** — `subscribe_watchlist` / `subscribe_digest` are now idempotent on their natural keys (`(user_id, title)` for watchlist; `(owner_id, name)` for digest). Previously a retry with identical args inserted a duplicate row with a new UUID; now the service-layer pre-flight lookup updates mutable fields and returns the existing UUID with `created=false` + `changed_fields=[...]`.
+
+#### Internal
+
+- **Alembic migration** `f1a2b3c4d5e6` (Wave 1 step 3 foundation, commit 1/4): creates `idempotency_keys` table (PK `key`, FK `user_id` → `users.id`, JSONB `response_body`, indexed `created_at`); adds `UNIQUE (user_id, title)` on `watch_interests`; adds `UNIQUE (owner_id, name)` on `digest_subscriptions`; adds `workspace_id` FK column on both tables (`ON DELETE SET NULL`). Self-defensive `RuntimeError` in `upgrade()` blocks duplicate rows pre-migration (Q-OPEN-4 from ADR 0009).
+- **Domain model** — `IdempotencyKey` (Pydantic) for the new HTTP cache row shape.
+- **Storage port** — `IdempotencyKeyRepo` ABC with SQLAlchemy implementation `SAIdempotencyKeyRepo` (uses `ON CONFLICT (key) DO NOTHING` so race-condition double-inserts collapse gracefully).
+- **DB context** — `idempotency_key_repo()` async context manager in `tg_parser/services/db_context.py`.
+- **API exception handler** — `IdempotencyKeyMismatchError` → 422 Q7-envelope handler registered globally in `tg_parser/api/main.py`.
+- **ADR 0009** promoted `Draft` → `Accepted (2026-05-22)`. Option C hybrid implemented as planned.
+- **ADR 0008** remains `Draft` — `chat_id`-only target locked for this sprint; polymorphic webhook / channel target deferred to Wave 1 step 4 + Wave 2A per sprint prompt anti-scope.
+
+#### Tests
+
+- `tests/test_idempotency_key_middleware.py` — **12 scenarios** (4 pure helper + 8 PG-gated functional): canonical-JSON ordering / whitespace / empty / non-JSON pass-through (R-4), no-header passthrough, cache hit, body-hash mismatch 422 (R-4 + Q-OPEN-1), R-2 4xx-not-cached, canonical body hash stability end-to-end across key reorder, per-user scope (cross-user same-key collisions degrade safely with the locked `UNIQUE(key)` PK; security invariant «no cache leakage» holds), propagation to digest endpoint, GET endpoint unaffected (Q-OPEN-7).
+- `tests/test_idempotency_cleanup_job.py` — **3 scenarios** for the hourly tick (deletes >24h rows, emits `tg_idempotency_keys_table_size` gauge, no-op on empty table).
+- All P-1 / P-2 service + HTTP tests added by commits 1/4–3/4 remain green (84 specific regression tests verified).
+- Full suite: default mode **2175 passed / 311 skipped / 0 failed** (was 2171/300/0); `TEST_POSTGRES=1` **2477 passed / 9 skipped / 0 failed** (was 2462/9/0). ∆ = +15 tests across 2 new files; **0 regressions**.
+- Lint: `ruff format` + `ruff check` clean on all touched files.
+
+#### Refs
+
+- Sprint prompt: [`docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`](docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md).
+- ADRs: [`docs/adr/0009-idempotency.md`](docs/adr/0009-idempotency.md) (Accepted), [`docs/adr/0008-subscription-target-model.md`](docs/adr/0008-subscription-target-model.md) (Draft — chat_id-only locked for this sprint).
+- DONE marker stub: [`docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md`](docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md) (post-24h-watch sections marked TBD).
+
 ### S2 quick-wins — BUG-018 / BUG-017 / BUG-023 (2026-05-21)
 
 **Контекст.** Wave 1 step 3 sequencing S2 slot per [`START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`](docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md). Three independent low/medium-effort observability + automation-safety bugs filed against the 2026-05-15 Claude MCP testing session bundled into one PR with atomic commits. Source of truth: per-bug records in [`docs/notes/BUG_LOG.md`](docs/notes/BUG_LOG.md) (closure rows under «Update 2026-05-21»).

--- a/docs/MCP_AGENT_GUIDE.md
+++ b/docs/MCP_AGENT_GUIDE.md
@@ -1005,6 +1005,17 @@ Channel-scoped tools enforce ownership: non-admin users can only access channels
 | `POST` | `/api/v1/users` | admin | Create user |
 | `PATCH` | `/api/v1/users/{user_id}` | admin | Update user |
 | `DELETE` | `/api/v1/users/{user_id}` | admin | Delete user + auth mappings |
+| `POST` | `/api/v1/watchlists` | api_key | Subscribe to a watchlist (idempotent upsert; `Idempotency-Key` header supported) |
+| `GET` | `/api/v1/watchlists` | api_key | List caller's watchlists (offset/limit) |
+| `GET` | `/api/v1/watchlists/{watchlist_id}` | api_key | Watchlist details (with `workspace_name` JOIN) |
+| `DELETE` | `/api/v1/watchlists/{watchlist_id}` | api_key | Soft-delete watchlist (idempotent 204+204) |
+| `GET` | `/api/v1/watchlists/{watchlist_id}/matches` | api_key | Match history (`?since=`, offset/limit) |
+| `POST` | `/api/v1/digests` | api_key | Subscribe to a scheduled digest (idempotent upsert; `Idempotency-Key` supported) |
+| `GET` | `/api/v1/digests` | api_key | List caller's digest subscriptions |
+| `GET` | `/api/v1/digests/{digest_id}` | api_key | Digest subscription details |
+| `DELETE` | `/api/v1/digests/{digest_id}` | api_key | HARD delete (second DELETE → 404; ASYMMETRIC vs watchlist) |
+
+> **HTTP API ↔ MCP parity (Wave 1 step 3):** the 9 watchlist/digest HTTP endpoints above are a direct alternative to MCP `subscribe_watchlist` / `list_watchlists` / `unsubscribe_watchlist` / `get_watchlist_matches` / `subscribe_digest` / `list_digests` / `unsubscribe_digest`. Backend semantics are identical (service-layer natural-key upsert closes BUG-022 cross-surface); the HTTP surface additionally offers an optional Stripe-style `Idempotency-Key` header (24h TTL) for transient-retry safety. The `Idempotency-Key` mechanism is **HTTP-only** — MCP / Bot / CLI clients rely solely on the service-layer natural-key idempotency. `workspace_id` (ENH-9) is available on both surfaces.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1626,6 +1626,108 @@ DEFAULT_MAX_CHANNELS=20
 
 ---
 
+## HTTP API — Watchlist + Digest (Wave 1 step 3, Surface Parity)
+
+`POST/GET/DELETE /api/v1/watchlists` + `POST/GET/DELETE /api/v1/digests` — 9 endpoints, идентичная семантика MCP-инструментам `subscribe_watchlist` / `subscribe_digest` (см. [MCP_AGENT_GUIDE.md](MCP_AGENT_GUIDE.md)), но через стандартный REST. Подходит для интеграций без MCP-runtime (web-приложения, backend-сервисы, CI пайплайны).
+
+### Базовый URL и аутентификация
+
+- **Base URL:** `https://your-host/api/v1`
+- **Auth:** обязательный заголовок `X-API-Key: <ваш ключ>` (тот же ключ, что используется на остальных API-эндпоинтах — см. [Конфигурация → API_KEY_REQUIRED](#конфигурация)).
+- **Workspace scoping:** опциональное поле `workspace_id` в теле POST (ENH-9) — привязывает подписку к workspace; пустое = без workspace, как раньше.
+
+### Endpoints
+
+#### Watchlist (P-1) — 5 эндпоинтов
+
+| Метод | Путь | Описание |
+|-------|------|----------|
+| `POST`   | `/api/v1/watchlists` | Создать / идемпотентно обновить интерес (по натуральному ключу `(user_id, title)`). Возвращает `{watchlist_id, created, changed_fields}`. |
+| `GET`    | `/api/v1/watchlists?offset=&limit=` | Список интересов пользователя (offset/limit пагинация, default `limit=50`, max 200). |
+| `GET`    | `/api/v1/watchlists/{watchlist_id}` | Детали одного интереса (включая `workspace_name` через JOIN). |
+| `DELETE` | `/api/v1/watchlists/{watchlist_id}` | Soft-delete (`is_active=false`); матчи в `watch_matches` сохраняются для истории. Идемпотентно — повторный DELETE на уже-неактивной строке тоже даёт 204. |
+| `GET`    | `/api/v1/watchlists/{watchlist_id}/matches?since=&offset=&limit=` | История матчей (даже после soft-delete интереса). |
+
+#### Digest (P-2) — 4 эндпоинта
+
+| Метод | Путь | Описание |
+|-------|------|----------|
+| `POST`   | `/api/v1/digests` | Создать / идемпотентно обновить подписку (по натуральному ключу `(owner_id, name)`). Возвращает `{digest_id, created, changed_fields}`. |
+| `GET`    | `/api/v1/digests?offset=&limit=` | Список подписок пользователя. |
+| `GET`    | `/api/v1/digests/{digest_id}` | Детали подписки. |
+| `DELETE` | `/api/v1/digests/{digest_id}` | **HARD delete** (асимметрия с watchlist: повторный DELETE даёт 404). |
+
+### Idempotency-Key (Stripe-style, опционально)
+
+Любой POST на `/api/v1/watchlists` или `/api/v1/digests` поддерживает заголовок `Idempotency-Key: <UUID или произвольная строка>`:
+
+- **Тот же ключ + то же тело** → закэшированный 2xx-ответ воспроизводится дословно, второй INSERT не выполняется.
+- **Тот же ключ + другое тело** → `422 {"detail": "...", "error_class": "IdempotencyKeyMismatch"}` — сгенерируйте новый ключ или повторите оригинальное тело.
+- **TTL:** 24 часа; устаревшие записи чистятся ежечасным cron-таском (`0 * * * *`).
+- **Scope:** per-user (ключи разных пользователей не пересекаются по семантике; конкретный механизм — глобальный `UNIQUE(key)` плюс фильтр `user_id` на чтении).
+
+Сервис-уровневая идемпотентность по натуральному ключу действует **всегда** (включая запросы без `Idempotency-Key`), так что повторный POST с одинаковыми `title`/`name` всегда вернёт ту же запись — `Idempotency-Key` нужен только для защиты от транзитных сетевых ретраев (см. ADR 0009).
+
+### Формат ошибок
+
+Все ошибки на этой поверхности возвращаются в Q7-shaped envelope:
+
+```json
+{
+  "detail": "Workspace '...' not found",
+  "error_class": "WorkspaceNotFound"
+}
+```
+
+Значения `error_class`: `NotFound`, `WorkspaceNotFound`, `InvalidCron`, `IdempotencyKeyMismatch`.
+
+### Примеры curl
+
+```bash
+# 1. Создать watchlist
+curl -X POST https://your-host/api/v1/watchlists \
+  -H "X-API-Key: $TG_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{
+    "title": "MiCA / EU crypto regulation",
+    "channel_ids": ["@crypto_news", "@eu_policy"],
+    "chat_id": 12345,
+    "keywords": ["MiCA", "regulation"],
+    "threshold": 0.6
+  }'
+# → 201 {"watchlist_id": "...", "created": true, "changed_fields": []}
+
+# 2. Создать digest подписку с workspace_id
+curl -X POST https://your-host/api/v1/digests \
+  -H "X-API-Key: $TG_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "morning-eu-crypto",
+    "channel_ids": ["@crypto_news"],
+    "chat_id": 12345,
+    "cron_expression": "0 9 * * *",
+    "timezone": "Europe/Berlin",
+    "format": "summary",
+    "language": "ru",
+    "workspace_id": "00000000-0000-0000-0000-000000000010"
+  }'
+# → 201 {"digest_id": "...", "created": true, "changed_fields": []}
+
+# 3. История матчей за последние сутки
+curl "https://your-host/api/v1/watchlists/$WID/matches?since=2026-05-20T00:00:00Z&limit=100" \
+  -H "X-API-Key: $TG_API_KEY"
+```
+
+### Deferred / not yet available
+
+- **Webhook target** (доставка в URL вместо `chat_id`) — запланировано в Wave 2A; сейчас только `chat_id`.
+- **Channel publish target** (доставка в Telegram-канал, не в личный чат) — Wave 1 step 4 (Shareable Digest).
+- **`Idempotency-Key` на других POST** (`/api/v1/process`, `/api/v1/export`, …) — broadening отложен на future PR (Q-OPEN-7 lock).
+- **MCP / Bot / CLI surfaces** не понимают HTTP-заголовки в принципе; для них достаточно сервис-уровневой натуральной идемпотентности.
+
+---
+
 ## Logging (v3.1)
 
 ### Форматы логов

--- a/docs/adr/0009-idempotency.md
+++ b/docs/adr/0009-idempotency.md
@@ -2,12 +2,15 @@
 
 ## Статус
 
-**Draft** (2026-05-21). Decision scope-bound to Wave 1 step 3 sprint
-(BUG-022 closure + P-1 / P-2 HTTP API design). This ADR defines the
-**idempotency contract** for write tools across all four surfaces, with
-particular focus on `subscribe_watchlist` / `subscribe_digest` (where
-BUG-022 manifests) and the new HTTP API endpoints (where the contract
-becomes public).
+**Accepted (2026-05-22).** Promoted from Draft after Wave 1 step 3
+sprint execution sub-session landed all four planned commits (1/4–4/4).
+Option C hybrid (natural-key upsert + HTTP `Idempotency-Key` middleware)
+implemented as described in the [Recommendation](#recommendation-preliminary-non-binding)
+section; open questions Q1–Q4 + Q7 resolved as documented in the
+[history](#история). This ADR defines the **idempotency contract** for
+write tools across all four surfaces, with particular focus on
+`subscribe_watchlist` / `subscribe_digest` (where BUG-022 manifests)
+and the new HTTP API endpoints (where the contract becomes public).
 
 ## Контекст
 
@@ -309,3 +312,4 @@ execution sub-session.
 | Дата | Изменение |
 |------|-----------|
 | 2026-05-21 | Draft created in S1 planning sub-session. Captures problem statement (BUG-022 + HTTP API contract design) + 3-option matrix + preliminary Option C (hybrid) recommendation. Final shape locked in step 3 execution sub-session. |
+| 2026-05-22 | Promoted **Draft → Accepted**. Wave 1 step 3 sprint landed Option C hybrid as planned across 4 atomic commits. Service-layer natural-key upsert (commits 1/4–3/4) closes BUG-022 on all four surfaces; HTTP `Idempotency-Key` middleware (commit 4/4) provides transient-retry safety on POST `/api/v1/watchlists` + POST `/api/v1/digests` (opt-in per Q-OPEN-7; broadening deferred). Open Q1 (body-hash mismatch) resolved as **422 `IdempotencyKeyMismatch`** (lean). Open Q2 (TTL) locked at **24h** (KISS, not env-configurable); cleanup tick lands as a top-of-hour cron `0 * * * *` (Q3). Q4 (pre-migration cleanup ordering) handled via self-defensive `RuntimeError` in `upgrade()` of migration `f1a2b3c4d5e6`. Schema note: `idempotency_keys` PK is `(key)` alone, not `(key, user_id)` composite — cross-user same-key collisions degrade gracefully (no cache leakage, second user just loses retry-cache benefit). Karpathy principle 6 metrics shipped: `tg_idempotency_keys_hit_total{result=hit\|miss\|mismatch}` + `tg_idempotency_keys_table_size` gauge. See [`docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md`](../notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md) for the sprint DONE marker. |

--- a/docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md
+++ b/docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md
@@ -1,0 +1,118 @@
+# Wave 1 Step 3 — DONE marker (STUB, pre-24h-watch)
+
+**Дата создания:** 2026-05-22 (immediately after commit 4/4 lands; TBD-fields will be filled after the 24h post-deploy watch window closes).
+**Закрывает:** Wave 1 step 3 «Surface Parity MVP» per [`PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md` § 5.1](PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md).
+**Packaging:** single PR + 4 atomic commits (mirror Wave 1 step 1 / step 2 hybrid pattern) per sprint prompt § 8.
+
+> **STATUS NOTE.** This marker is a **stub**. Sections marked **TBD** will be filled after the 24h watch window closes GREEN per sprint prompt § 6. Authoring procedure mirrors `REVIEW_2026-05-14_WAVE1_STEP2_DONE.md` (Wave 1 step 2 precedent).
+
+---
+
+## 1. Что закрыто
+
+| Sprint slot | Commit (4/4) | Squash SHA | Deployed | 24h watch verdict |
+|---|---|---|---|---|
+| ENH-9 + BUG-022 service-layer foundation | 1/4 | `56e65e2` | _TBD_ | _TBD_ |
+| P-1 Watchlist HTTP API (5 endpoints) | 2/4 | `6efb20b` | _TBD_ | _TBD_ |
+| P-2 Digest HTTP API (4 endpoints) | 3/4 | `0e450eb` | _TBD_ | _TBD_ |
+| Idempotency-Key HTTP middleware + cleanup + docs | 4/4 | _TBD (this commit)_ | _TBD_ | _TBD_ |
+
+**Закрытые bug / feature IDs:**
+
+* **BUG-022** — `subscribe_watchlist` / `subscribe_digest` now idempotent on natural keys (`(user_id, title)` / `(owner_id, name)`). Service-layer pre-flight lookup updates mutable fields and returns existing UUID with `created=false`. Cross-surface fix (MCP / Bot / CLI / HTTP).
+* **ENH-9** — `workspace_id` параметр на subscribe-tools на всех четырёх поверхностях; FK to `workspaces` с `ON DELETE SET NULL`.
+* **P-1** — Watchlist HTTP API landed.
+* **P-2** — Digest HTTP API landed.
+
+## 2. Acceptance signals table (per sprint prompt § 6)
+
+| # | Criterion | Source of truth | Status (pre-watch) | Watch verdict |
+|---|---|---|---|---|
+| 1 | `2175+ / 300+ / 0` default-mode pytest | `pytest -q --tb=line` | ✅ **2175 / 311 / 0** (verified pre-merge) | n/a |
+| 2 | `2475+ / 9 / 0` `TEST_POSTGRES=1` pytest | `TEST_POSTGRES=1 pytest -q --tb=line` | ✅ **2477 / 9 / 0** (verified pre-merge) | n/a |
+| 3 | `ruff format` + `ruff check` clean | repo-wide | ✅ verified pre-merge | n/a |
+| 4 | 0 regressions on `test_api_watchlists`, `test_api_digests`, `test_subscribe_idempotency`, `test_watchlist_workspace_id`, `test_f4*`, `test_f6*`, `test_f11*` | targeted pytest | ✅ verified pre-merge (84 regression tests) | n/a |
+| 5 | `tg_idempotency_keys_hit_total{result=hit\|miss\|mismatch}` time-series visible in Prometheus 24h post-deploy | `query?query=tg_idempotency_keys_hit_total` | _pending 24h watch_ | _TBD_ |
+| 6 | `tg_idempotency_keys_table_size` gauge updates after first hourly cleanup tick (T+1h post-deploy) | `query?query=tg_idempotency_keys_table_size` | _pending 24h watch_ | _TBD_ |
+
+## 3. Post-watch state
+
+_TBD after 24h watch closes._ Will include:
+
+* Prometheus query_range snapshots over the watch window (`up{service=api|bot|mcp}` gauges, scheduler tick counter, new metrics from commit 4/4).
+* Container health snapshot (`docker ps` table).
+* Bot / API / MCP error-log scan over the watch window (`docker logs --since/--until`).
+* Workspace + watchlist + digest surface zero-error proof.
+* New-vs-regression bug class adjudication (mirror Wave 1 step 2 precedent — `git diff <merge_sha>^ <merge_sha>` as the discriminator).
+
+## 4. Known partials / monitoring-only
+
+| Item | Reason | Re-evaluate trigger |
+|---|---|---|
+| **ADR 0008** chat_id-only target (locked for this sprint) | Polymorphic webhook / channel target consciously deferred per sprint prompt anti-scope. Wave 1 step 4 (Shareable Digest) + Wave 2A (webhook surface) carry the follow-up. | Wave 1 step 4 planning sub-session re-reads ADR 0008 § Options + this marker. |
+| **Idempotency-Key middleware opt-in per endpoint (Q-OPEN-7)** | Wired only on POST `/api/v1/watchlists` + POST `/api/v1/digests`. Broadening to other POST endpoints (`/api/v1/process`, `/api/v1/export`, …) is intentionally deferred. | Future PR if production usage shows broader transient-retry pain. ADR 0009 already prescribes the pattern. |
+| **idempotency_keys schema `UNIQUE(key)` (not composite)** | PK is `key` alone (migration `f1a2b3c4d5e6`, commit 1/4 — locked, not amend-able per AGENTS.md § Hard rules). Cross-user same-key collisions degrade gracefully (security invariant «no cross-user cache leakage» holds; only second user loses retry-cache benefit). | If production tracking shows non-trivial cross-user `Idempotency-Key` collisions (low expected rate — clients typically use UUIDv4), file as a follow-up to migrate to composite PK in a future schema sprint. |
+| **MCP / Bot / CLI surfaces** | No HTTP header equivalent of `Idempotency-Key`. Service-layer natural-key upsert (Option A from ADR 0009) is the sole protection. Adequate for these surfaces (no transient-retry concern equivalent to HTTP timeout). | n/a (architecturally complete). |
+
+## 5. Cross-references
+
+| Document | Зачем |
+|---|---|
+| Sprint prompt | [`docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`](START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md) — locked decisions Q1–Q9 + acceptance criteria. |
+| ADR 0009 (Accepted) | [`docs/adr/0009-idempotency.md`](../adr/0009-idempotency.md) — Option C hybrid (service-layer + HTTP header). |
+| ADR 0008 (Draft) | [`docs/adr/0008-subscription-target-model.md`](../adr/0008-subscription-target-model.md) — target model; chat_id-only for this sprint, polymorphic deferred. |
+| CHANGELOG | [`CHANGELOG.md`](../../CHANGELOG.md) — `[Unreleased]` § «Wave 1 step 3 — Surface Parity» consolidates all 4 commits. |
+| USER_GUIDE | [`docs/USER_GUIDE.md`](../USER_GUIDE.md) — new «HTTP API — Watchlist + Digest» section. |
+| MCP_AGENT_GUIDE | [`docs/MCP_AGENT_GUIDE.md`](../MCP_AGENT_GUIDE.md) — REST table + parity note. |
+| Wave 1 step 2 DONE marker (template) | [`REVIEW_2026-05-14_WAVE1_STEP2_DONE.md`](REVIEW_2026-05-14_WAVE1_STEP2_DONE.md) — structural mirror for the post-watch update. |
+| Wave 1 step 1 DONE marker | [`REVIEW_2026-05-08_WAVE1_STEP1_DONE.md`](REVIEW_2026-05-08_WAVE1_STEP1_DONE.md) — earliest precedent. |
+
+## 6. Lessons learned
+
+_TBD after 24h watch._ Mirror Wave 1 step 2's pattern: 3-5 short bullet-points distinguishing «new bug surfaced by watch» vs «regression introduced by sprint» via `git diff` adjudication, plus any unanticipated operational gaps (e.g., env drift, fresh-log-buffer revelations).
+
+## 7. Pre-next-step
+
+**Wave 1 step 4 — Shareable Digest (per [`PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md` § 5.1](PRODUCT_STRATEGY_AUDIENCE_DRIVEN_2026-05-02.md)).**
+
+Recommended sequence post-merge:
+
+```
+[этот PR mergeт]
+  ↓
+Deploy → 24h watch window opens
+  ↓ (24h GREEN)
+Update this DONE marker (fill § 2 watch verdicts, § 3 post-watch state, § 6 lessons)
+  ↓
+Wave 1 step 4 planning sub-session (~0.3 session) —
+  read PARITY_DECISION_TRACKING.md § 3 (shareable digest signals + O-1/O-2),
+  ADR 0008 § Options (polymorphic target promotion?),
+  Wave 1 step 4 scope refinement
+  ↓
+Wave 1 step 4 sprint (Shareable Digest — channel-publish target,
+  shareable links, audience activation A2 «Curator»)
+```
+
+Wave 1 step 3 sets up the prerequisites for shareable digests by establishing:
+
+* HTTP API surface that downstream sharing tooling can consume.
+* `workspace_id` scoping across both subscribe-tools.
+* `Idempotency-Key` middleware reusable for any future POST that involves shareable-link generation (per ADR 0009 generalisation note).
+* Natural-key idempotency contract on `digest_subscriptions` — guarantees that batched share invitations (potential Wave 1 step 4 surface) don't duplicate rows.
+
+---
+
+## Appendix — Sprint metrics (provisional, pre-watch)
+
+| Metric | Value |
+|---|---|
+| Commits | 4 (atomic) |
+| Files touched (cumulative) | _TBD (final diff aggregate)_ |
+| LOC delta (cumulative) | _TBD (target was 1000–1400; final TBD after diff)_ |
+| New tests | ~50+ across watchlist HTTP, digest HTTP, service-layer idempotency, middleware, cleanup (final count TBD after diff) |
+| New Prometheus metrics | 2 (`tg_idempotency_keys_hit_total{result}`, `tg_idempotency_keys_table_size`) |
+| New scheduler task | 1 (`idempotency_keys_cleanup`, cron `0 * * * *`) |
+| New ADR transitions | 1 (ADR 0009 Draft → Accepted) |
+| Migrations | 1 (`f1a2b3c4d5e6`, commit 1/4) |
+
+_Final aggregates filled in the post-watch update._

--- a/docs/runbooks/wave1_step3_idempotency_dedupe.md
+++ b/docs/runbooks/wave1_step3_idempotency_dedupe.md
@@ -1,0 +1,124 @@
+# Runbook — Wave 1 step 3 pre-migration dedupe (BUG-022)
+
+**Trigger:** Alembic migration `f1a2b3c4d5e6` (`20260521_wave1_step3_foundation`)
+raises `RuntimeError` with a message like:
+
+```
+Migration aborted: <N> duplicate (user_id, title) group(s) found in
+watch_interests. ... Dedupe by hand per
+docs/runbooks/wave1_step3_idempotency_dedupe.md before re-running
+`alembic upgrade head`.
+```
+
+**Why:** the migration introduces two natural-key UNIQUE constraints
+(`uq_watch_interests_user_title`, `uq_digest_subscriptions_owner_name`)
+to close BUG-022 (`subscribe_*` was not idempotent — repeated calls
+created duplicate rows). The constraint applies to ALL rows (active
+or soft-deleted) so the service-layer upsert can resurrect
+soft-deleted interests when the user re-subscribes with the same
+label. Pre-existing duplicates would block the constraint
+installation; the migration's self-defensive pre-flight catches that
+and aborts cleanly instead of mid-table partial state.
+
+## 1. Inspect
+
+Run both inspection queries against the ingestion DB
+(`tg_parser` in production; `tg_parser_test` locally):
+
+```sql
+SELECT user_id, title, COUNT(*) AS n
+FROM watch_interests
+GROUP BY user_id, title
+HAVING COUNT(*) > 1
+ORDER BY n DESC, user_id;
+
+SELECT owner_id, name, COUNT(*) AS n
+FROM digest_subscriptions
+GROUP BY owner_id, name
+HAVING COUNT(*) > 1
+ORDER BY n DESC, owner_id;
+```
+
+Note each `(user_id, title)` / `(owner_id, name)` pair plus the
+duplicate count.
+
+## 2. Resolve
+
+For each duplicate group keep exactly one row (preferably the most
+recently touched — highest `updated_at`) and delete the rest. Example
+SQL pattern for watchlist (adapt to digest by swapping table /
+columns):
+
+```sql
+-- Inspect candidates per group:
+SELECT id, user_id, title, is_active, updated_at, created_at
+FROM watch_interests
+WHERE (user_id, title) IN (
+    SELECT user_id, title FROM watch_interests
+    GROUP BY user_id, title HAVING COUNT(*) > 1
+)
+ORDER BY user_id, title, updated_at DESC;
+
+-- Delete all but the latest per group (preserve provenance — the
+-- caller can also merge keywords / channel_ids manually before
+-- DELETE if the rows are semantically distinct):
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY user_id, title
+                              ORDER BY updated_at DESC, created_at DESC) AS rn
+    FROM watch_interests
+)
+DELETE FROM watch_interests
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+```
+
+> ⚠️ Hard DELETE drops match history (`watch_matches` rows CASCADE on
+> `interest_id`). If preserving match log of the older row matters,
+> instead UPDATE the older row's `title` to a suffixed variant
+> (e.g. `<title> (archived 2026-05-21)`) before re-running the
+> migration; that defuses the UNIQUE collision while keeping all
+> rows.
+
+For digest the audit blast radius is smaller (no `watch_matches`
+analogue — digest sends are observability-only metrics) so the
+DELETE path is usually safe.
+
+## 3. Verify
+
+Re-run both inspection queries from § 1 — expect 0 rows.
+
+```sql
+SELECT COUNT(*) FROM (
+    SELECT 1 FROM watch_interests
+    GROUP BY user_id, title HAVING COUNT(*) > 1
+) AS d;
+-- Expected: 0
+
+SELECT COUNT(*) FROM (
+    SELECT 1 FROM digest_subscriptions
+    GROUP BY owner_id, name HAVING COUNT(*) > 1
+) AS d;
+-- Expected: 0
+```
+
+## 4. Restart migration
+
+```bash
+.venv/bin/alembic -c migrations/alembic_ingestion.ini upgrade head
+# or, via the project CLI wrapper if it exposes `db check`:
+# .venv/bin/tg-parser db upgrade --branch ingestion
+```
+
+Expected output: clean `Running upgrade e9f0a1b2c3d5 -> f1a2b3c4d5e6,
+Wave 1 step 3 — Surface Parity foundation (ENH-9 + BUG-022)`.
+
+## 5. Cross-references
+
+- BUG_LOG.md § BUG-022 (issue) — service-layer upsert closes the
+  bug; this runbook covers the one-off pre-existing-row cleanup
+  needed before the constraint can be installed.
+- ADR 0009 (idempotency) — Option C hybrid; service-layer half is
+  the natural-key UNIQUE this runbook protects.
+- Sprint prompt
+  `docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md` § 3 Q2
+  + § 8 R-3 (risk register).

--- a/migrations/versions/ingestion/20260521_wave1_step3_foundation.py
+++ b/migrations/versions/ingestion/20260521_wave1_step3_foundation.py
@@ -1,0 +1,201 @@
+"""Wave 1 step 3 — Surface Parity foundation (ENH-9 + BUG-022)
+
+Revision ID: f1a2b3c4d5e6
+Revises: e9f0a1b2c3d5
+Create Date: 2026-05-21
+
+Wave 1 step 3 / commit 1/4 — service-layer foundation for the
+Surface Parity sprint. Three additive changes against the ingestion
+domain — no read-path regression:
+
+1. ``watch_interests.workspace_id UUID NULL`` FK → ``workspaces.id``
+   ``ON DELETE SET NULL`` (ENH-9: optional workspace association;
+   interest survives workspace deletion per ADR 0008 Q3-A).
+2. ``digest_subscriptions.workspace_id UUID NULL`` FK → ``workspaces.id``
+   ``ON DELETE SET NULL`` (ENH-9, same semantics).
+3. ``UNIQUE (user_id, title)`` on ``watch_interests`` +
+   ``UNIQUE (owner_id, name)`` on ``digest_subscriptions`` —
+   natural-key idempotency boundary that closes BUG-022 at the DB
+   layer. Service-layer upsert (commit 1/4 ``WatchlistService.subscribe``
+   / ``DigestService.subscribe``) catches the ``IntegrityError`` and
+   retries as UPDATE so race-condition concurrent inserts collapse
+   into a single row.
+4. ``idempotency_keys`` table (skeleton — used by HTTP middleware in
+   commit 4/4). PK on ``key TEXT``, FK on ``user_id``, ``request_hash``
+   + ``response_body JSONB`` for safe replay, 24h TTL via cleanup job
+   (commit 4/4). Indexes on ``created_at`` (cleanup sweep) and
+   ``user_id`` (per-tenant scoping).
+
+Self-defensive pre-flight (Option A from sprint prompt §3 Q-OPEN-5):
+before ADD CONSTRAINT UNIQUE on both tables, ``upgrade()`` runs SELECT
+queries to detect ``(user_id, title)`` and ``(owner_id, name)``
+duplicate groups. If any are found, ``upgrade()`` raises
+``RuntimeError`` with a pointer to
+``docs/runbooks/wave1_step3_idempotency_dedupe.md`` so the operator
+deduplicates by hand before re-running. R-3 from sprint risk register
+downgraded High → Low by this guard.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: str | None = "e9f0a1b2c3d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_RUNBOOK_REF = "docs/runbooks/wave1_step3_idempotency_dedupe.md"
+
+
+def _assert_no_duplicates(conn: sa.engine.Connection) -> None:
+    """Self-defensive pre-flight before ADD CONSTRAINT UNIQUE.
+
+    The new UNIQUE constraints apply to ALL rows (active or
+    soft-deleted) because re-subscribing with the same label should
+    resurrect the existing row at the service layer — we cannot allow
+    two physical rows even if one is ``is_active = FALSE``. The check
+    therefore runs without an ``is_active`` filter.
+    """
+    wi_dups = conn.execute(
+        sa.text(
+            "SELECT user_id, title, COUNT(*) AS n "
+            "FROM watch_interests "
+            "GROUP BY user_id, title "
+            "HAVING COUNT(*) > 1"
+        )
+    ).fetchall()
+    if wi_dups:
+        raise RuntimeError(
+            f"Migration aborted: {len(wi_dups)} duplicate (user_id, title) "
+            f"group(s) found in watch_interests. Pre-existing duplicates "
+            f"would violate the new UNIQUE constraint introduced by this "
+            f"migration (BUG-022 natural-key idempotency). Dedupe by hand "
+            f"per {_RUNBOOK_REF} before re-running `alembic upgrade head`."
+        )
+
+    ds_dups = conn.execute(
+        sa.text(
+            "SELECT owner_id, name, COUNT(*) AS n "
+            "FROM digest_subscriptions "
+            "GROUP BY owner_id, name "
+            "HAVING COUNT(*) > 1"
+        )
+    ).fetchall()
+    if ds_dups:
+        raise RuntimeError(
+            f"Migration aborted: {len(ds_dups)} duplicate (owner_id, name) "
+            f"group(s) found in digest_subscriptions. Pre-existing duplicates "
+            f"would violate the new UNIQUE constraint introduced by this "
+            f"migration (BUG-022 natural-key idempotency). Dedupe by hand "
+            f"per {_RUNBOOK_REF} before re-running `alembic upgrade head`."
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Self-defensive dedupe pre-flight (R-3 downgrade High → Low).
+    _assert_no_duplicates(conn)
+
+    # 2. ENH-9: workspace_id FK on both subscription tables.
+    conn.execute(
+        sa.text(
+            "ALTER TABLE watch_interests "
+            "ADD COLUMN IF NOT EXISTS workspace_id UUID NULL "
+            "REFERENCES workspaces(id) ON DELETE SET NULL"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_watch_interests_workspace_id "
+            "ON watch_interests(workspace_id) WHERE workspace_id IS NOT NULL"
+        )
+    )
+
+    conn.execute(
+        sa.text(
+            "ALTER TABLE digest_subscriptions "
+            "ADD COLUMN IF NOT EXISTS workspace_id UUID NULL "
+            "REFERENCES workspaces(id) ON DELETE SET NULL"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_digest_subscriptions_workspace_id "
+            "ON digest_subscriptions(workspace_id) WHERE workspace_id IS NOT NULL"
+        )
+    )
+
+    # 3. BUG-022: natural-key UNIQUE constraints. Raw SQL (mirrors the
+    # codebase convention from 20260513_add_workspaces.py — keep
+    # constraint creation outside the alembic op.* surface so the
+    # static-analysis guardrail in tests/test_migrations_self_contained.py
+    # treats the constraint name correctly rather than mis-classifying
+    # it as an ALTER target).
+    conn.execute(
+        sa.text(
+            "ALTER TABLE watch_interests "
+            "ADD CONSTRAINT uq_watch_interests_user_title UNIQUE (user_id, title)"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "ALTER TABLE digest_subscriptions "
+            "ADD CONSTRAINT uq_digest_subscriptions_owner_name UNIQUE (owner_id, name)"
+        )
+    )
+
+    # 4. idempotency_keys skeleton (commit 4/4 wires HTTP middleware).
+    conn.execute(
+        sa.text(
+            """
+            CREATE TABLE IF NOT EXISTS idempotency_keys (
+                key TEXT PRIMARY KEY,
+                user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                request_hash TEXT NOT NULL,
+                response_body JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+    )
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_idempotency_keys_created_at "
+            "ON idempotency_keys(created_at)"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS idx_idempotency_keys_user_id ON idempotency_keys(user_id)"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_idempotency_keys_user_id"))
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_idempotency_keys_created_at"))
+    conn.execute(sa.text("DROP TABLE IF EXISTS idempotency_keys"))
+
+    conn.execute(
+        sa.text(
+            "ALTER TABLE digest_subscriptions "
+            "DROP CONSTRAINT IF EXISTS uq_digest_subscriptions_owner_name"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "ALTER TABLE watch_interests DROP CONSTRAINT IF EXISTS uq_watch_interests_user_title"
+        )
+    )
+
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_digest_subscriptions_workspace_id"))
+    conn.execute(sa.text("ALTER TABLE digest_subscriptions DROP COLUMN IF EXISTS workspace_id"))
+
+    conn.execute(sa.text("DROP INDEX IF EXISTS idx_watch_interests_workspace_id"))
+    conn.execute(sa.text("ALTER TABLE watch_interests DROP COLUMN IF EXISTS workspace_id"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ _ALEMBIC_BRANCHES = ("ingestion", "raw", "processing")
 # next access, defeating the cache.
 _TRUNCATE_TABLES_BY_BRANCH: dict[str, tuple[str, ...]] = {
     "ingestion": (
+        "idempotency_keys",
         "watch_matches",
         "watch_interests",
         "workspace_sources",

--- a/tests/test_api_digests.py
+++ b/tests/test_api_digests.py
@@ -1,0 +1,817 @@
+"""
+HTTP API tests for the digest surface (Wave 1 step 3 commit 3/4 / P-2).
+
+Covers the four endpoints under ``/api/v1/digests`` introduced in this
+commit:
+
+* ``POST   /api/v1/digests``               — subscribe.
+* ``GET    /api/v1/digests``               — list.
+* ``GET    /api/v1/digests/{id}``          — get single.
+* ``DELETE /api/v1/digests/{id}``          — HARD delete.
+
+Test split mirrors ``tests/test_api_watchlists.py``:
+
+* Auth gate tests (no DB) — verify 401 / 403 via the same
+  ``X-API-Key`` machinery used elsewhere on the API.
+* Functional tests (PG-gated) — exercise the full request/response
+  contract end-to-end against the real ingestion DB. They mirror the
+  scenarios listed in the sprint prompt §5 test plan.
+
+Key asymmetries vs ``test_api_watchlists.py``:
+
+* The label field is ``name`` (not ``title``) per Q6.
+* The response shape uses ``digest_id`` (not ``watchlist_id``) per Q7.
+* **DELETE is HARD**: the second DELETE on the same id returns 404,
+  not 204 (Q8 digest variant + parent Q-OPEN-8 REST-strict lock).
+* No ``/matches`` sub-resource (digest "matches" are scheduled sends).
+
+The PG-backed tests piggyback on ``test_db`` from ``tests/conftest.py``
+and the ``TEST_POSTGRES`` env gate (same shape as ``test_f6_*`` and
+``test_api_watchlists``). Auth dependency is overridden via
+``app.dependency_overrides[resolve_current_user]`` so each test can
+inject the exact ``CurrentUser`` it needs without standing up the
+``X-API-Key`` → user-resolver chain.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.main import create_app
+from tg_parser.auth.models import CurrentUser
+from tg_parser.domain.models import DigestFormat, DigestSubscription
+from tg_parser.storage.sqlalchemy.digest_subscription_repo import SADigestSubscriptionRepo
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _user(user_id: str, *, name: str = "alice", role: str = "user") -> CurrentUser:
+    """Build a :class:`CurrentUser` mirroring the watchlist test helper.
+
+    Non-admin roles get an empty ``allowed_channel_ids`` so the
+    F4-A channel-scope guard does not interfere — the digest HTTP
+    surface (like the watchlist one) does not run
+    ``assert_channel_access`` itself; channel ownership is enforced
+    at the MCP / Bot surfaces, the HTTP layer is intentionally a
+    thinner wrapper so the same idempotent upsert is reachable from
+    any client.
+    """
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else [],
+        max_channels=100,
+    )
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app():
+    """Fresh FastAPI app per test (mirrors ``test_api_watchlists.py``)."""
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+async def _digest_db(test_db):
+    """Truncate F4 + F6 + users tables for a clean per-test slate."""
+    session = test_db.ingestion_state_session()
+    try:
+        await session.execute(text("DELETE FROM digest_subscriptions"))
+        await session.execute(text("DELETE FROM workspace_sources"))
+        await session.execute(text("DELETE FROM workspaces"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db
+
+
+@pytest.fixture
+async def user_repo(_digest_db):
+    session = _digest_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def workspace_repo(_digest_db):
+    session = _digest_db.ingestion_state_session()
+    try:
+        yield SAWorkspaceRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def subscription_repo(_digest_db):
+    session = _digest_db.ingestion_state_session()
+    try:
+        yield SADigestSubscriptionRepo(session)
+    finally:
+        await session.close()
+
+
+def _override_user(app, user: CurrentUser) -> None:
+    """Install / replace the auth dependency override for the current test."""
+
+    async def _resolver() -> CurrentUser:
+        return user
+
+    app.dependency_overrides[resolve_current_user] = _resolver
+
+
+# ============================================================================
+# Auth gate tests — no DB, just verify the X-API-Key contract is reachable.
+# ============================================================================
+
+
+class TestAuthGates:
+    """Auth contract tests for POST /api/v1/digests (Q1).
+
+    These are the only digest tests that do NOT use the dependency
+    override — we deliberately let the real ``resolve_current_user``
+    run so the X-API-Key dependency chain is exercised end-to-end.
+    """
+
+    async def test_create_digest_missing_api_key_returns_401(self, app):
+        """No X-API-Key header + api_key_required=True → 401 from the resolver."""
+        transport = ASGITransport(app=app)
+        with patch("tg_parser.api.auth.settings") as mock:
+            mock.api_key_required = True
+            mock.api_keys = {"valid-key": "tester"}
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/api/v1/digests",
+                    json={
+                        "name": "Morning brief",
+                        "channel_ids": ["durov"],
+                        "chat_id": 42,
+                    },
+                )
+        assert response.status_code == 401, response.text
+
+    async def test_create_digest_invalid_api_key_returns_403(self, app):
+        """Wrong X-API-Key value + api_key_required=True → 403."""
+        transport = ASGITransport(app=app)
+        with patch("tg_parser.api.auth.settings") as mock:
+            mock.api_key_required = True
+            mock.api_keys = {"valid-key": "tester"}
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/api/v1/digests",
+                    headers={"X-API-Key": "totally-wrong-key"},
+                    json={
+                        "name": "Morning brief",
+                        "channel_ids": ["durov"],
+                        "chat_id": 42,
+                    },
+                )
+        assert response.status_code == 403, response.text
+
+
+# ============================================================================
+# Functional tests (PG-gated).
+# ============================================================================
+
+
+@pg_only
+class TestCreateDigest:
+    async def test_happy_path(self, app, client, user_repo):
+        owner = await user_repo.create_user("alice_create")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "cron_expression": "0 9 * * *",
+                "timezone": "UTC",
+                "format": "summary",
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        # Q-OPEN-1 shape: {digest_id, created, changed_fields}.
+        assert set(body.keys()) == {"digest_id", "created", "changed_fields"}
+        assert isinstance(body["digest_id"], str) and body["digest_id"]
+        assert body["created"] is True
+        assert body["changed_fields"] == []
+
+    async def test_idempotent_same_args_returns_existing_id(self, app, client, user_repo):
+        owner = await user_repo.create_user("alice_idem_same")
+        _override_user(app, _user(owner.id))
+
+        payload = {
+            "name": "Daily brief",
+            "channel_ids": ["durov"],
+            "chat_id": 12345,
+            "cron_expression": "0 9 * * *",
+            "timezone": "UTC",
+            "format": "summary",
+        }
+        first = await client.post("/api/v1/digests", json=payload)
+        second = await client.post("/api/v1/digests", json=payload)
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["digest_id"] == second.json()["digest_id"]
+        assert second.json()["created"] is False
+        assert second.json()["changed_fields"] == []
+
+    async def test_upsert_different_cron_lists_changed_fields(self, app, client, user_repo):
+        """Same name + different cron → ``changed_fields=["cron_expression"]``."""
+        owner = await user_repo.create_user("alice_idem_diff")
+        _override_user(app, _user(owner.id))
+
+        first = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "cron_expression": "0 9 * * *",
+                "timezone": "UTC",
+                "format": "summary",
+            },
+        )
+        assert first.status_code == 201
+        second = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "cron_expression": "30 8 * * *",  # changed
+                "timezone": "UTC",
+                "format": "summary",
+            },
+        )
+
+        assert second.status_code == 201
+        assert second.json()["digest_id"] == first.json()["digest_id"]
+        assert second.json()["created"] is False
+        assert "cron_expression" in second.json()["changed_fields"]
+
+    async def test_workspace_id_valid_attaches_fk_and_returns_workspace_name(
+        self, app, client, user_repo, workspace_repo
+    ):
+        """ENH-9 + Q-OPEN-3 in one test: valid ``workspace_id`` is stored
+        on POST and the follow-up GET single emits both ``workspace_id``
+        and the JOIN-resolved ``workspace_name``.
+        """
+        owner = await user_repo.create_user("alice_ws_ok")
+        ws = await workspace_repo.create(owner_id=owner.id, name="EU reg")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "EU brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "workspace_id": ws.id,
+            },
+        )
+        assert response.status_code == 201, response.text
+
+        get_response = await client.get(f"/api/v1/digests/{response.json()['digest_id']}")
+        assert get_response.status_code == 200, get_response.text
+        body = get_response.json()
+        assert body["workspace_id"] == ws.id
+        assert body["workspace_name"] == "EU reg"
+
+    async def test_workspace_id_foreign_returns_404_workspace_not_found(
+        self, app, client, user_repo, workspace_repo
+    ):
+        alice = await user_repo.create_user("alice_ws_foreign")
+        bob = await user_repo.create_user("bob_ws_owner")
+        foreign_ws = await workspace_repo.create(owner_id=bob.id, name="other")
+        _override_user(app, _user(alice.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "workspace_id": foreign_ws.id,
+            },
+        )
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "WorkspaceNotFound"
+        assert "not found" in body["detail"].lower()
+
+    async def test_workspace_id_unknown_uuid_returns_404_workspace_not_found(
+        self, app, client, user_repo
+    ):
+        """Unknown (well-formed but non-existent) workspace_id → same 404 / error_class.
+
+        Parity with the P-1 watchlist surface: unknown and foreign
+        collapse to the same ``WorkspaceNotFound`` so existence of a
+        foreign workspace cannot be inferred from a distinguishable
+        error code (F4-B EC2).
+        """
+        owner = await user_repo.create_user("alice_ws_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "workspace_id": "00000000-0000-0000-0000-000000000999",
+            },
+        )
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "WorkspaceNotFound"
+        assert "not found" in body["detail"].lower()
+
+    async def test_validation_empty_name_returns_422(self, app, client, user_repo):
+        """``name`` violates ``min_length=1`` → Pydantic 422 before the service runs.
+
+        Guards against future schema regression where the
+        ``DigestCreateRequest.name`` constraint gets relaxed and an
+        empty name leaks all the way to the service-layer
+        ``DigestSubscription`` validator (which would surface as 500
+        instead of the locked 422 contract).
+        """
+        owner = await user_repo.create_user("alice_validation_name")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+            },
+        )
+        assert response.status_code == 422, response.text
+
+    async def test_invalid_cron_returns_422_invalid_cron(self, app, client, user_repo):
+        """Malformed cron → 422 with ``error_class="InvalidCron"`` AND no row written.
+
+        The router pre-validates ``cron_expression`` + ``timezone``
+        (mirror of the MCP path) so an invalid spec is rejected
+        *before* the upsert runs and never leaves a half-written row.
+        The follow-up GET list assertion is the §3 H.2 guard: it
+        proves the pre-validation aborted before any INSERT, not just
+        that the 422 was emitted with a stale row left behind.
+        """
+        owner = await user_repo.create_user("alice_cron_bad")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "cron_expression": "not a valid cron",
+                "timezone": "UTC",
+            },
+        )
+        assert response.status_code == 422, response.text
+        body = response.json()
+        assert body["error_class"] == "InvalidCron"
+
+        # No row was written — the pre-validation aborted before the upsert.
+        list_resp = await client.get("/api/v1/digests")
+        assert list_resp.status_code == 200, list_resp.text
+        assert list_resp.json() == {"items": [], "total": 0}
+
+    async def test_invalid_timezone_returns_422_invalid_cron(self, app, client, user_repo):
+        """Unknown IANA timezone → 422 with ``error_class="InvalidCron"``.
+
+        The cron / timezone pre-validation pair lives in the same
+        helper, so an unknown ``ZoneInfo`` name surfaces under the
+        same ``error_class`` as a malformed cron. Mirrors the
+        :func:`mcp_server.subscribe_digest` rejection shape so HTTP
+        and MCP clients see parity. The unrelated cron field is
+        deliberately valid here to isolate the timezone failure path.
+        """
+        owner = await user_repo.create_user("alice_tz_bad")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "cron_expression": "0 9 * * *",
+                "timezone": "Mars/Olympus",
+            },
+        )
+        assert response.status_code == 422, response.text
+        assert response.json()["error_class"] == "InvalidCron"
+
+    async def test_invalid_format_returns_422(self, app, client, user_repo):
+        """``format`` outside the Pydantic ``Literal`` → 422 before the service runs.
+
+        Guards :class:`DigestCreateRequest.format` against silent
+        widening (Literal-Enum drift): an unknown value must surface
+        as a Pydantic validation error, not reach
+        ``DigestFormat(...)`` which would raise ``ValueError`` and
+        bubble to a 500 via the global exception handler.
+        """
+        owner = await user_repo.create_user("alice_format_bad")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "format": "novella",  # not in Literal[summary, bullets, detailed]
+            },
+        )
+        assert response.status_code == 422, response.text
+
+    async def test_upsert_different_format_language_lists_changed_fields(
+        self, app, client, user_repo
+    ):
+        """Same name + different format AND language → both fields surface
+        on ``changed_fields`` and the row keeps the same id.
+
+        Pairs with :meth:`test_upsert_different_cron_lists_changed_fields`
+        to cover the non-cron mutable columns flagged by
+        :meth:`DigestService._apply_digest_upsert`. Using a *set*
+        comparison so future re-ordering inside the service does not
+        flip this test (the contract is "exact set of fields", not
+        "exact list order").
+        """
+        owner = await user_repo.create_user("alice_idem_fmt_lang")
+        _override_user(app, _user(owner.id))
+
+        first = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "format": "summary",
+                "language": "ru",
+            },
+        )
+        assert first.status_code == 201
+        second = await client.post(
+            "/api/v1/digests",
+            json={
+                "name": "Daily brief",
+                "channel_ids": ["durov"],
+                "chat_id": 12345,
+                "format": "bullets",
+                "language": "en",
+            },
+        )
+
+        assert second.status_code == 201
+        assert second.json()["digest_id"] == first.json()["digest_id"]
+        assert second.json()["created"] is False
+        assert set(second.json()["changed_fields"]) == {"format", "language"}
+
+
+@pg_only
+class TestListDigests:
+    async def test_scoped_to_user(self, app, client, user_repo, subscription_repo):
+        """List endpoint only returns rows owned by ``user.id`` (non-admin)."""
+        alice = await user_repo.create_user("alice_list_scope")
+        bob = await user_repo.create_user("bob_list_scope")
+
+        # Seed one subscription per user via the repo (bypass the HTTP layer).
+        for owner_id, name in ((alice.id, "alice-brief"), (bob.id, "bob-brief")):
+            await subscription_repo.create(
+                DigestSubscription(
+                    id="",
+                    owner_id=owner_id,
+                    chat_id=42,
+                    name=name,
+                    channel_ids=["durov"],
+                    cron_expression="0 9 * * *",
+                    timezone="UTC",
+                    format=DigestFormat.SUMMARY,
+                    language="ru",
+                    is_active=True,
+                )
+            )
+
+        _override_user(app, _user(alice.id))
+        response = await client.get("/api/v1/digests")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 1
+        assert [i["name"] for i in body["items"]] == ["alice-brief"]
+        assert body["items"][0]["owner_id"] == alice.id
+
+    async def test_pagination_offset_limit(self, app, client, user_repo, subscription_repo):
+        owner = await user_repo.create_user("alice_list_pagi")
+
+        for n in range(5):
+            await subscription_repo.create(
+                DigestSubscription(
+                    id="",
+                    owner_id=owner.id,
+                    chat_id=100 + n,
+                    name=f"brief-{n}",
+                    channel_ids=["durov"],
+                    cron_expression="0 9 * * *",
+                    timezone="UTC",
+                    format=DigestFormat.SUMMARY,
+                    language="ru",
+                    is_active=True,
+                )
+            )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get("/api/v1/digests", params={"offset": 1, "limit": 2})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+
+    async def test_empty_list_returns_zero_total(self, app, client, user_repo):
+        """Caller with zero subscriptions → ``{items: [], total: 0}``.
+
+        Sanity check for the Q7 envelope shape under the empty-row
+        case — guards against accidental "return None / 204" drift.
+        """
+        owner = await user_repo.create_user("alice_list_empty")
+        _override_user(app, _user(owner.id))
+
+        response = await client.get("/api/v1/digests")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body == {"items": [], "total": 0}
+
+    async def test_workspace_name_resolved_in_list(
+        self, app, client, user_repo, subscription_repo, workspace_repo
+    ):
+        """List endpoint joins ``workspaces.name`` for items with ``workspace_id``.
+
+        Verifies the Q-OPEN-3 single-JOIN contract on the *list*
+        path (the single-GET path is covered by
+        :meth:`TestCreateDigest.test_workspace_id_valid_attaches_fk_and_returns_workspace_name`).
+        Items without ``workspace_id`` carry ``workspace_name=None``
+        on the same response so the field is always present.
+        """
+        owner = await user_repo.create_user("alice_list_wsname")
+        ws = await workspace_repo.create(owner_id=owner.id, name="EU reg")
+
+        await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=owner.id,
+                chat_id=42,
+                name="with-ws",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.SUMMARY,
+                language="ru",
+                is_active=True,
+                workspace_id=ws.id,
+            )
+        )
+        await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=owner.id,
+                chat_id=43,
+                name="no-ws",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.SUMMARY,
+                language="ru",
+                is_active=True,
+            )
+        )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get("/api/v1/digests")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 2
+        by_name = {item["name"]: item for item in body["items"]}
+        assert by_name["with-ws"]["workspace_id"] == ws.id
+        assert by_name["with-ws"]["workspace_name"] == "EU reg"
+        assert by_name["no-ws"]["workspace_id"] is None
+        assert by_name["no-ws"]["workspace_name"] is None
+
+
+@pg_only
+class TestGetDigest:
+    async def test_owner_gets_full_payload_without_workspace(
+        self, app, client, user_repo, subscription_repo
+    ):
+        """Single GET for a row WITHOUT ``workspace_id`` returns a full
+        :class:`DigestResponse` body with ``workspace_id=None`` and
+        ``workspace_name=None``.
+
+        Pairs with
+        :meth:`TestCreateDigest.test_workspace_id_valid_attaches_fk_and_returns_workspace_name`
+        which exercises the *with-workspace* branch; together they
+        prove that ``_resolve_workspace_names`` returns the correct
+        empty / populated dict and the renderer always emits the
+        ``workspace_name`` field (Q-OPEN-3: never an absent key).
+        Also covers the §A.GET happy-path slot — the workspace test
+        bundles two contracts in one assertion, so this is the
+        dedicated single-GET sanity check.
+        """
+        owner = await user_repo.create_user("alice_get_happy")
+        stored = await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=owner.id,
+                chat_id=12345,
+                name="Daily brief",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.BULLETS,
+                language="en",
+                is_active=True,
+            )
+        )
+        _override_user(app, _user(owner.id))
+
+        response = await client.get(f"/api/v1/digests/{stored.id}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["id"] == stored.id
+        assert body["owner_id"] == owner.id
+        assert body["name"] == "Daily brief"
+        assert body["channel_ids"] == ["durov"]
+        assert body["cron_expression"] == "0 9 * * *"
+        assert body["timezone"] == "UTC"
+        assert body["format"] == "bullets"
+        assert body["language"] == "en"
+        assert body["is_active"] is True
+        assert body["workspace_id"] is None
+        assert body["workspace_name"] is None
+
+    async def test_foreign_subscription_returns_404_not_403(
+        self, app, client, user_repo, subscription_repo
+    ):
+        alice = await user_repo.create_user("alice_get_foreign")
+        bob = await user_repo.create_user("bob_get_foreign")
+
+        bob_sub = await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=bob.id,
+                chat_id=42,
+                name="bob-only",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.SUMMARY,
+                language="ru",
+                is_active=True,
+            )
+        )
+
+        _override_user(app, _user(alice.id))
+        response = await client.get(f"/api/v1/digests/{bob_sub.id}")
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "NotFound"
+
+    async def test_unknown_uuid_returns_404(self, app, client, user_repo):
+        """Well-formed but non-existent digest UUID → 404 ``NotFound``.
+
+        Distinct from the foreign-ownership case (a row exists but
+        belongs to someone else): here no row exists at all. Both
+        collapse to ``error_class=NotFound`` so a caller cannot infer
+        whether a UUID is "free" or "taken by another tenant".
+        """
+        owner = await user_repo.create_user("alice_get_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.get("/api/v1/digests/00000000-0000-0000-0000-000000000999")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"
+
+
+@pg_only
+class TestDeleteDigest:
+    async def test_hard_delete_first_call_204_then_404(
+        self, app, client, user_repo, subscription_repo
+    ):
+        """First DELETE on own row → 204; row hard-deleted (verify via
+        follow-up GET → 404); second DELETE on the same id → **404**
+        (REST-strict per parent Q-OPEN-8 lock; ASYMMETRIC vs the
+        watchlist soft-delete 204+204 pattern).
+        """
+        owner = await user_repo.create_user("alice_delete_hard")
+        stored = await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=owner.id,
+                chat_id=42,
+                name="Daily brief",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.SUMMARY,
+                language="ru",
+                is_active=True,
+            )
+        )
+
+        _override_user(app, _user(owner.id))
+        first = await client.delete(f"/api/v1/digests/{stored.id}")
+        assert first.status_code == 204, first.text
+        assert first.content == b""  # 204 must be body-less.
+
+        # Hard-delete: follow-up GET on the same id returns 404.
+        get_resp = await client.get(f"/api/v1/digests/{stored.id}")
+        assert get_resp.status_code == 404, get_resp.text
+        assert get_resp.json()["error_class"] == "NotFound"
+
+        # Second DELETE on the same id → 404 (HARD DELETE asymmetry).
+        second = await client.delete(f"/api/v1/digests/{stored.id}")
+        assert second.status_code == 404, second.text
+        assert second.json()["error_class"] == "NotFound"
+
+    async def test_foreign_subscription_returns_404(
+        self, app, client, user_repo, subscription_repo
+    ):
+        alice = await user_repo.create_user("alice_delete_foreign")
+        bob = await user_repo.create_user("bob_delete_foreign")
+
+        bob_sub = await subscription_repo.create(
+            DigestSubscription(
+                id="",
+                owner_id=bob.id,
+                chat_id=42,
+                name="bob-only",
+                channel_ids=["durov"],
+                cron_expression="0 9 * * *",
+                timezone="UTC",
+                format=DigestFormat.SUMMARY,
+                language="ru",
+                is_active=True,
+            )
+        )
+        _override_user(app, _user(alice.id))
+        response = await client.delete(f"/api/v1/digests/{bob_sub.id}")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"
+
+    async def test_unknown_uuid_returns_404(self, app, client, user_repo):
+        """DELETE on a never-existed UUID → 404 ``NotFound``.
+
+        Distinct from :meth:`test_hard_delete_first_call_204_then_404`
+        (which deletes an existing row and then re-DELETEs the now-gone
+        id) and from :meth:`test_foreign_subscription_returns_404`
+        (which targets a row owned by someone else). Here we send
+        DELETE for a UUID that has never been written: the response
+        must still be a 404 ``NotFound`` so a caller cannot tell
+        "free UUID" apart from "another tenant's UUID".
+        """
+        owner = await user_repo.create_user("alice_delete_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.delete("/api/v1/digests/00000000-0000-0000-0000-000000000999")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"

--- a/tests/test_api_watchlists.py
+++ b/tests/test_api_watchlists.py
@@ -1,0 +1,865 @@
+"""
+HTTP API tests for the watchlist surface (Wave 1 step 3 commit 2/4 / P-1).
+
+Covers the five endpoints under ``/api/v1/watchlists`` introduced in
+this commit:
+
+* ``POST   /api/v1/watchlists``                       — subscribe.
+* ``GET    /api/v1/watchlists``                       — list.
+* ``GET    /api/v1/watchlists/{id}``                  — get single.
+* ``DELETE /api/v1/watchlists/{id}``                  — soft-delete.
+* ``GET    /api/v1/watchlists/{id}/matches``          — match history.
+
+Test split:
+
+* Auth gate tests (no DB) — verify 401 / 403 via the same
+  ``X-API-Key`` machinery used elsewhere on the API.
+* Functional tests (PG-gated) — exercise the full request/response
+  contract end-to-end against the real ingestion DB. They mirror the
+  scenarios listed in the sprint prompt §5 test plan.
+
+The PG-backed tests piggyback on ``test_db`` from ``tests/conftest.py``
+and the ``TEST_POSTGRES`` env gate (same shape as ``test_f11_*`` and
+``test_f4b_*``). Auth dependency is overridden via
+``app.dependency_overrides[resolve_current_user]`` so each test can
+inject the exact ``CurrentUser`` it needs without standing up the
+``X-API-Key`` → user-resolver chain.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.main import create_app
+from tg_parser.auth.models import CurrentUser
+from tg_parser.domain.models import WatchMatch
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+from tg_parser.storage.sqlalchemy.watch_interest_repo import SAWatchInterestRepo
+from tg_parser.storage.sqlalchemy.watch_match_repo import SAWatchMatchRepo
+from tg_parser.storage.sqlalchemy.workspace_repo import SAWorkspaceRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _user(user_id: str, *, name: str = "alice", role: str = "user") -> CurrentUser:
+    """Build a :class:`CurrentUser` with admin-like field defaults.
+
+    Non-admin roles get an empty ``allowed_channel_ids`` so the
+    F4-A channel-scope guard does not interfere — the watchlist
+    surface does not run ``assert_channel_access`` itself (callers
+    are free to subscribe to channels they don't own at the HTTP
+    layer; the scheduler hook is the one that enforces visibility).
+    """
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else [],
+        max_channels=100,
+    )
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app():
+    """Fresh FastAPI app per test (mirrors ``test_api_security.py``)."""
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+async def _watchlist_db(test_db):
+    """Truncate F4 + F11 + workspace tables for a clean per-test slate."""
+    session = test_db.ingestion_state_session()
+    try:
+        await session.execute(text("DELETE FROM watch_matches"))
+        await session.execute(text("DELETE FROM watch_interests"))
+        await session.execute(text("DELETE FROM workspace_sources"))
+        await session.execute(text("DELETE FROM workspaces"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db
+
+
+@pytest.fixture
+async def user_repo(_watchlist_db):
+    session = _watchlist_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def workspace_repo(_watchlist_db):
+    session = _watchlist_db.ingestion_state_session()
+    try:
+        yield SAWorkspaceRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def interest_repo(_watchlist_db):
+    session = _watchlist_db.ingestion_state_session()
+    try:
+        yield SAWatchInterestRepo(session)
+    finally:
+        await session.close()
+
+
+@pytest.fixture
+async def match_repo(_watchlist_db):
+    session = _watchlist_db.ingestion_state_session()
+    try:
+        yield SAWatchMatchRepo(session)
+    finally:
+        await session.close()
+
+
+def _override_user(app, user: CurrentUser) -> None:
+    """Install / replace the auth dependency override for the current test."""
+
+    async def _resolver() -> CurrentUser:
+        return user
+
+    app.dependency_overrides[resolve_current_user] = _resolver
+
+
+# ============================================================================
+# Auth gate tests — no DB, just verify the X-API-Key contract is reachable.
+# ============================================================================
+
+
+class TestAuthGates:
+    """Auth contract tests for POST /api/v1/watchlists (Q1).
+
+    These are the only watchlist tests that do NOT use the dependency
+    override — we deliberately let the real ``resolve_current_user``
+    run so the X-API-Key dependency chain is exercised end-to-end.
+    """
+
+    async def test_create_watchlist_missing_api_key_returns_401(self, app):
+        """No X-API-Key header + api_key_required=True → 401 from the resolver."""
+        transport = ASGITransport(app=app)
+        with patch("tg_parser.api.auth.settings") as mock:
+            mock.api_key_required = True
+            mock.api_keys = {"valid-key": "tester"}
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/api/v1/watchlists",
+                    json={
+                        "title": "MiCA",
+                        "channel_ids": ["crypto_news"],
+                        "chat_id": 42,
+                    },
+                )
+        assert response.status_code == 401, response.text
+
+    async def test_create_watchlist_invalid_api_key_returns_403(self, app):
+        """Wrong X-API-Key value + api_key_required=True → 403."""
+        transport = ASGITransport(app=app)
+        with patch("tg_parser.api.auth.settings") as mock:
+            mock.api_key_required = True
+            mock.api_keys = {"valid-key": "tester"}
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/api/v1/watchlists",
+                    headers={"X-API-Key": "totally-wrong-key"},
+                    json={
+                        "title": "MiCA",
+                        "channel_ids": ["crypto_news"],
+                        "chat_id": 42,
+                    },
+                )
+        assert response.status_code == 403, response.text
+
+
+# ============================================================================
+# Functional tests (PG-gated).
+# ============================================================================
+
+
+@pg_only
+class TestCreateWatchlist:
+    async def test_happy_path(self, app, client, user_repo):
+        owner = await user_repo.create_user("alice_create")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "keywords": ["mica"],
+                "description": "EU crypto rules",
+                "threshold": 0.55,
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        # Q-OPEN-1 shape: {watchlist_id, created, changed_fields}.
+        assert set(body.keys()) == {"watchlist_id", "created", "changed_fields"}
+        assert isinstance(body["watchlist_id"], str) and body["watchlist_id"]
+        assert body["created"] is True
+        assert body["changed_fields"] == []
+
+    async def test_idempotent_same_args_returns_existing_id(self, app, client, user_repo):
+        owner = await user_repo.create_user("alice_idem_same")
+        _override_user(app, _user(owner.id))
+
+        payload = {
+            "title": "MiCA",
+            "channel_ids": ["crypto_news"],
+            "chat_id": 12345,
+            "keywords": ["mica"],
+            "threshold": 0.6,
+        }
+        first = await client.post("/api/v1/watchlists", json=payload)
+        second = await client.post("/api/v1/watchlists", json=payload)
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["watchlist_id"] == second.json()["watchlist_id"]
+        assert second.json()["created"] is False
+        assert second.json()["changed_fields"] == []
+
+    async def test_upsert_different_args_lists_changed_fields(self, app, client, user_repo):
+        owner = await user_repo.create_user("alice_idem_diff")
+        _override_user(app, _user(owner.id))
+
+        first = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "keywords": ["mica"],
+                "threshold": 0.6,
+            },
+        )
+        assert first.status_code == 201
+        second = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "keywords": ["mica", "psd3"],
+                "threshold": 0.6,
+            },
+        )
+
+        assert second.status_code == 201
+        assert second.json()["watchlist_id"] == first.json()["watchlist_id"]
+        assert second.json()["created"] is False
+        assert "keywords" in second.json()["changed_fields"]
+
+    async def test_workspace_id_valid_attaches_fk(self, app, client, user_repo, workspace_repo):
+        owner = await user_repo.create_user("alice_ws_ok")
+        ws = await workspace_repo.create(owner_id=owner.id, name="EU reg")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "workspace_id": ws.id,
+            },
+        )
+        assert response.status_code == 201, response.text
+
+        # Verify by reading back through the GET single endpoint so the
+        # ``workspace_name`` JOIN (Q-OPEN-3) is exercised in the same test.
+        get_response = await client.get(f"/api/v1/watchlists/{response.json()['watchlist_id']}")
+        assert get_response.status_code == 200, get_response.text
+        body = get_response.json()
+        assert body["workspace_id"] == ws.id
+        assert body["workspace_name"] == "EU reg"
+
+    async def test_workspace_id_foreign_returns_404_workspace_not_found(
+        self, app, client, user_repo, workspace_repo
+    ):
+        alice = await user_repo.create_user("alice_ws_foreign")
+        bob = await user_repo.create_user("bob_ws_owner")
+        foreign_ws = await workspace_repo.create(owner_id=bob.id, name="other")
+        _override_user(app, _user(alice.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "workspace_id": foreign_ws.id,
+            },
+        )
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "WorkspaceNotFound"
+        assert "not found" in body["detail"].lower()
+
+    async def test_workspace_id_unknown_uuid_returns_404_workspace_not_found(
+        self, app, client, user_repo
+    ):
+        """Unknown (well-formed but non-existent) workspace_id → same 404 / error_class.
+
+        Mirrors :meth:`test_workspace_id_foreign_returns_404_workspace_not_found`
+        but with a UUID that has *never* existed in the workspaces table.
+        Both unknown and foreign collapse to the same
+        ``WorkspaceNotFound`` per Q-OPEN-3 + the F4-B EC2 contract —
+        existence of a foreign workspace must not be leaked via a
+        distinguishable error code.
+        """
+        owner = await user_repo.create_user("alice_ws_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+                "workspace_id": "00000000-0000-0000-0000-000000000999",
+            },
+        )
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "WorkspaceNotFound"
+        assert "not found" in body["detail"].lower()
+
+    async def test_validation_empty_title_returns_422(self, app, client, user_repo):
+        """Title violates ``min_length=1`` → Pydantic 422 before the service runs.
+
+        Guards against future schema regression where the
+        ``WatchlistCreateRequest.title`` constraint gets relaxed and
+        an empty title leaks all the way to the service-layer
+        ``WatchInterest`` validator (which would surface as 500
+        instead of the locked 422 contract).
+        """
+        owner = await user_repo.create_user("alice_validation_title")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+            },
+        )
+        assert response.status_code == 422, response.text
+
+
+@pg_only
+class TestListWatchlists:
+    async def test_scoped_to_user(self, app, client, user_repo, interest_repo):
+        alice = await user_repo.create_user("alice_list_scope")
+        bob = await user_repo.create_user("bob_list_scope")
+
+        # Seed one interest per user via the repo (bypass the HTTP layer).
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        for owner_id, title in ((alice.id, "alice-MiCA"), (bob.id, "bob-MiCA")):
+            await interest_repo.create(
+                WatchInterest(
+                    id="",
+                    user_id=owner_id,
+                    chat_id=42,
+                    title=title,
+                    description=None,
+                    keywords=["mica"],
+                    exclude_keywords=[],
+                    channel_ids=["crypto_news"],
+                    threshold=0.6,
+                    notify_mode=NotifyMode.INSTANT,
+                    is_active=True,
+                    embedding=None,
+                )
+            )
+
+        _override_user(app, _user(alice.id))
+        response = await client.get("/api/v1/watchlists")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 1
+        assert [i["title"] for i in body["items"]] == ["alice-MiCA"]
+        assert body["items"][0]["user_id"] == alice.id
+
+    async def test_pagination_offset_limit(self, app, client, user_repo, interest_repo):
+        owner = await user_repo.create_user("alice_list_pagi")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        for n in range(5):
+            await interest_repo.create(
+                WatchInterest(
+                    id="",
+                    user_id=owner.id,
+                    chat_id=100 + n,
+                    title=f"watch-{n}",
+                    description=None,
+                    keywords=["x"],
+                    exclude_keywords=[],
+                    channel_ids=["chan"],
+                    threshold=0.6,
+                    notify_mode=NotifyMode.INSTANT,
+                    is_active=True,
+                    embedding=None,
+                )
+            )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get("/api/v1/watchlists", params={"offset": 1, "limit": 2})
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+
+    async def test_empty_list_returns_zero_total(self, app, client, user_repo):
+        """Caller with zero interests → ``{items: [], total: 0}``.
+
+        Sanity check for the Q7 envelope shape under the empty-row
+        case — guards against accidental "return None / 204" drift.
+        """
+        owner = await user_repo.create_user("alice_list_empty")
+        _override_user(app, _user(owner.id))
+
+        response = await client.get("/api/v1/watchlists")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body == {"items": [], "total": 0}
+
+    async def test_workspace_name_resolved_in_list(
+        self, app, client, user_repo, interest_repo, workspace_repo
+    ):
+        """List endpoint joins ``workspaces.name`` for items with ``workspace_id``.
+
+        Verifies the Q-OPEN-3 single-JOIN contract on the *list*
+        path (the single-GET path is covered by
+        :meth:`TestCreateWatchlist.test_workspace_id_valid_attaches_fk`).
+        Items without ``workspace_id`` carry ``workspace_name=None``
+        on the same response so the field is always present.
+        """
+        owner = await user_repo.create_user("alice_list_wsname")
+        ws = await workspace_repo.create(owner_id=owner.id, name="EU reg")
+
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=42,
+                title="with-ws",
+                description=None,
+                keywords=["x"],
+                exclude_keywords=[],
+                channel_ids=["chan"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+                workspace_id=ws.id,
+            )
+        )
+        await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=43,
+                title="no-ws",
+                description=None,
+                keywords=["x"],
+                exclude_keywords=[],
+                channel_ids=["chan"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get("/api/v1/watchlists")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 2
+        by_title = {item["title"]: item for item in body["items"]}
+        assert by_title["with-ws"]["workspace_id"] == ws.id
+        assert by_title["with-ws"]["workspace_name"] == "EU reg"
+        assert by_title["no-ws"]["workspace_id"] is None
+        assert by_title["no-ws"]["workspace_name"] is None
+
+
+@pg_only
+class TestGetWatchlist:
+    async def test_owner_gets_full_payload(
+        self, app, client, user_repo, interest_repo, workspace_repo
+    ):
+        owner = await user_repo.create_user("alice_get")
+        ws = await workspace_repo.create(owner_id=owner.id, name="EU reg")
+
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        stored = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=12345,
+                title="MiCA",
+                description="EU regulation",
+                keywords=["mica"],
+                exclude_keywords=[],
+                channel_ids=["crypto_news"],
+                threshold=0.65,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+                workspace_id=ws.id,
+            )
+        )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get(f"/api/v1/watchlists/{stored.id}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["id"] == stored.id
+        assert body["workspace_id"] == ws.id
+        assert body["workspace_name"] == "EU reg"
+        assert body["threshold"] == pytest.approx(0.65)
+        assert body["keywords"] == ["mica"]
+        assert "embedding" not in body  # explicitly elided per WatchlistResponse contract
+
+    async def test_foreign_interest_returns_404_not_403(
+        self, app, client, user_repo, interest_repo
+    ):
+        alice = await user_repo.create_user("alice_get_foreign")
+        bob = await user_repo.create_user("bob_get_foreign")
+
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        bob_interest = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=bob.id,
+                chat_id=42,
+                title="bob-only",
+                description=None,
+                keywords=["x"],
+                exclude_keywords=[],
+                channel_ids=["chan"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+
+        _override_user(app, _user(alice.id))
+        response = await client.get(f"/api/v1/watchlists/{bob_interest.id}")
+
+        assert response.status_code == 404, response.text
+        body = response.json()
+        assert body["error_class"] == "NotFound"
+
+    async def test_unknown_uuid_returns_404(self, app, client, user_repo):
+        """Well-formed but non-existent watchlist UUID → 404 ``NotFound``.
+
+        Distinct from the foreign-ownership case (a row exists but
+        belongs to someone else): here no row exists at all. Both
+        collapse to ``error_class=NotFound`` so a caller cannot infer
+        whether a UUID is "free" or "taken by another tenant".
+        """
+        owner = await user_repo.create_user("alice_get_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.get("/api/v1/watchlists/00000000-0000-0000-0000-000000000999")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"
+
+
+@pg_only
+class TestDeleteWatchlist:
+    async def test_soft_delete_preserves_matches(
+        self, app, client, user_repo, interest_repo, match_repo
+    ):
+        owner = await user_repo.create_user("alice_delete_soft")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        stored = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=42,
+                title="MiCA",
+                description=None,
+                keywords=["mica"],
+                exclude_keywords=[],
+                channel_ids=["crypto_news"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+        # Seed a match so we can verify history survives.
+        await match_repo.upsert_many(
+            [
+                WatchMatch(
+                    id=0,
+                    interest_id=stored.id,
+                    source_ref="tg:crypto_news:post:1",
+                    channel_id="crypto_news",
+                    keyword_score=0.7,
+                    semantic_score=0.0,
+                    combined_score=0.7,
+                    notified=False,
+                )
+            ]
+        )
+
+        _override_user(app, _user(owner.id))
+        response = await client.delete(f"/api/v1/watchlists/{stored.id}")
+        assert response.status_code == 204, response.text
+        assert response.content == b""  # 204 must be body-less
+
+        # Matches endpoint still serves history (Q8 watchlist variant).
+        matches_resp = await client.get(f"/api/v1/watchlists/{stored.id}/matches")
+        assert matches_resp.status_code == 200, matches_resp.text
+        body = matches_resp.json()
+        assert body["total"] == 1
+        assert body["items"][0]["source_ref"] == "tg:crypto_news:post:1"
+
+    async def test_idempotent_second_call_also_204(self, app, client, user_repo, interest_repo):
+        owner = await user_repo.create_user("alice_delete_idem")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        stored = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=42,
+                title="MiCA",
+                description=None,
+                keywords=["mica"],
+                exclude_keywords=[],
+                channel_ids=["crypto_news"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+
+        _override_user(app, _user(owner.id))
+        first = await client.delete(f"/api/v1/watchlists/{stored.id}")
+        second = await client.delete(f"/api/v1/watchlists/{stored.id}")
+
+        assert first.status_code == 204
+        assert second.status_code == 204  # REST-strict per parent Q-OPEN-8 lock.
+
+    async def test_foreign_interest_returns_404(self, app, client, user_repo, interest_repo):
+        alice = await user_repo.create_user("alice_delete_foreign")
+        bob = await user_repo.create_user("bob_delete_foreign")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        bob_interest = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=bob.id,
+                chat_id=42,
+                title="bob-only",
+                description=None,
+                keywords=["x"],
+                exclude_keywords=[],
+                channel_ids=["chan"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+        _override_user(app, _user(alice.id))
+        response = await client.delete(f"/api/v1/watchlists/{bob_interest.id}")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"
+
+    async def test_unknown_uuid_returns_404(self, app, client, user_repo):
+        """DELETE on a never-existed UUID → 404 ``NotFound`` (not 204).
+
+        REST-strict idempotency per Q-OPEN-8 collapses repeated
+        DELETEs on an existing row to 204 — but for an id that has
+        never been written we still want a 404 so clients can
+        distinguish "deleted-by-someone" from "your id never
+        existed". The ``NotFound`` error_class matches the GET single
+        contract.
+        """
+        owner = await user_repo.create_user("alice_delete_unknown")
+        _override_user(app, _user(owner.id))
+
+        response = await client.delete("/api/v1/watchlists/00000000-0000-0000-0000-000000000999")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"
+
+
+@pg_only
+class TestGetMatches:
+    async def test_filtered_by_since(self, app, client, user_repo, interest_repo, match_repo):
+        owner = await user_repo.create_user("alice_matches_since")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        stored = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=42,
+                title="MiCA",
+                description=None,
+                keywords=["mica"],
+                exclude_keywords=[],
+                channel_ids=["crypto_news"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+        await match_repo.upsert_many(
+            [
+                WatchMatch(
+                    id=0,
+                    interest_id=stored.id,
+                    source_ref=f"tg:crypto_news:post:{n}",
+                    channel_id="crypto_news",
+                    keyword_score=0.7,
+                    semantic_score=0.0,
+                    combined_score=0.7,
+                    notified=False,
+                )
+                for n in range(3)
+            ]
+        )
+
+        _override_user(app, _user(owner.id))
+        future = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+        response = await client.get(
+            f"/api/v1/watchlists/{stored.id}/matches",
+            params={"since": future},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 0  # strict-`>` filter drops every row with created_at <= since.
+        assert body["items"] == []
+
+    async def test_pagination_offset_limit(self, app, client, user_repo, interest_repo, match_repo):
+        owner = await user_repo.create_user("alice_matches_pagi")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        stored = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=owner.id,
+                chat_id=42,
+                title="MiCA",
+                description=None,
+                keywords=["mica"],
+                exclude_keywords=[],
+                channel_ids=["crypto_news"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+        await match_repo.upsert_many(
+            [
+                WatchMatch(
+                    id=0,
+                    interest_id=stored.id,
+                    source_ref=f"tg:crypto_news:post:{n}",
+                    channel_id="crypto_news",
+                    keyword_score=0.7,
+                    semantic_score=0.0,
+                    combined_score=0.7,
+                    notified=False,
+                )
+                for n in range(5)
+            ]
+        )
+
+        _override_user(app, _user(owner.id))
+        response = await client.get(
+            f"/api/v1/watchlists/{stored.id}/matches",
+            params={"offset": 2, "limit": 2},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["total"] == 5
+        assert len(body["items"]) == 2
+
+    async def test_foreign_interest_returns_404_not_403(
+        self, app, client, user_repo, interest_repo
+    ):
+        """Match-history visibility tracks owner-only just like GET single.
+
+        Bob owns the interest; alice asks for ``/{bob_id}/matches``.
+        Mirrors :meth:`TestGetWatchlist.test_foreign_interest_returns_404_not_403`
+        but on the sub-resource path — the cross-tenant guard must
+        apply to every endpoint that exposes interest data, not just
+        the top-level GET.
+        """
+        alice = await user_repo.create_user("alice_matches_foreign")
+        bob = await user_repo.create_user("bob_matches_foreign")
+        from tg_parser.domain.models import NotifyMode, WatchInterest
+
+        bob_interest = await interest_repo.create(
+            WatchInterest(
+                id="",
+                user_id=bob.id,
+                chat_id=42,
+                title="bob-only",
+                description=None,
+                keywords=["x"],
+                exclude_keywords=[],
+                channel_ids=["chan"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                is_active=True,
+                embedding=None,
+            )
+        )
+        _override_user(app, _user(alice.id))
+        response = await client.get(f"/api/v1/watchlists/{bob_interest.id}/matches")
+        assert response.status_code == 404, response.text
+        assert response.json()["error_class"] == "NotFound"

--- a/tests/test_f4b_deferred_surface_guard.py
+++ b/tests/test_f4b_deferred_surface_guard.py
@@ -1,10 +1,15 @@
-"""F4-B Core — Phase 5 deferred-feature surface guards.
+"""F4-B Core — Phase 5 surface guards (Q3 / Q7 / Q8 / scoped read-tools).
 
-The start prompt locks Q3 (Bot tools), Q7 (F11 watchlist), Q8 (F6 digest) as
-**deferred**: no ``workspace_id`` parameter on those subscription / tool
-signatures in this sprint. These tests fail loudly if a future commit
-accidentally promotes one of them — at which point the contract should be
-re-evaluated through a planning round-trip, not silently absorbed.
+Originally locked Q3/Q7/Q8 as deferred (no ``workspace_id`` on those
+signatures). Wave 1 step 3 commit 1/4 (ENH-9 + BUG-022 service-layer
+foundation) explicitly lifts Q7 + Q8 — see
+``docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`` §3 (Q-OPEN-3)
+and §8 PR shape table commit 1/4. The Q7/Q8 sections are inverted here:
+they now PIN ``workspace_id`` as part of the new contract so a future
+commit cannot drop the parameter silently. Q3 (bot exec fn Python
+signature) stays deferred — bot wrappers still take a single ``args``
+dict, and ``workspace_id`` is read from that dict rather than from the
+Python signature (per Q-OPEN-6).
 
 Cheap, signature-only inspections (no DB, no fixtures, no PG gate) so they
 run in the default ``pytest`` mode too.
@@ -20,9 +25,13 @@ def _parameter_names(fn) -> list[str]:
 
 
 class TestQ3BotToolsNoWorkspaceParam:
-    """Q3 = skip-Bot-MVP — bot tool exec functions must not accept
-    ``workspace_id`` in this sprint (would imply Bot UX work that's
-    deferred until UX-signal accumulates)."""
+    """Q3 = skip-Bot-MVP — bot tool exec **Python signatures** must not
+    accept ``workspace_id`` directly.
+
+    Wave 1 step 3 reads ``workspace_id`` from the JSON ``args`` dict
+    that bot wrappers already receive — this guard still holds because
+    no exec fn promotes the parameter to its own argument list.
+    """
 
     def test_bot_exec_functions_do_not_take_workspace_id(self):
         from tg_parser.bot import tools as bot_tools
@@ -38,55 +47,81 @@ class TestQ3BotToolsNoWorkspaceParam:
             if "workspace_id" in params:
                 offenders.append(f"{name}({', '.join(params)})")
         assert offenders == [], (
-            "Q3 was locked = skip-Bot-MVP but the following bot exec fns "
-            f"now accept workspace_id: {offenders}. Re-check planning before "
-            "promoting."
+            "Q3 was locked = skip-Bot-MVP and bot exec fns still must read "
+            "workspace_id from the args-dict (see Q-OPEN-6 in "
+            "docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md); "
+            f"offenders: {offenders}."
         )
 
 
-class TestQ7WatchlistSignatureUnchanged:
-    """Q7 = C — ``subscribe_watchlist`` MCP tool and ``WatchInterest`` schema
-    must NOT have ``workspace_id`` in F4-B Core."""
+class TestQ7WatchlistSignatureHasWorkspaceId:
+    """Q7 LIFTED in Wave 1 step 3 commit 1/4 (ENH-9).
 
-    def test_subscribe_watchlist_mcp_tool_has_no_workspace_id(self):
+    Pins ``workspace_id`` as part of the new contract for the F11
+    ``subscribe_watchlist`` MCP tool and the ``WatchInterest`` Pydantic
+    model. Default must remain ``None`` so legacy callers (no kwarg)
+    preserve bit-for-bit F4-A behaviour (NULL column).
+    """
+
+    def test_subscribe_watchlist_mcp_tool_accepts_workspace_id(self):
         from tg_parser.mcp_server import subscribe_watchlist
 
         params = _parameter_names(subscribe_watchlist)
-        assert "workspace_id" not in params, (
-            "Q7 locked = defer F11 + workspace_id integration; "
-            f"subscribe_watchlist now has params {params}"
+        assert "workspace_id" in params, (
+            "ENH-9 contract requires workspace_id on subscribe_watchlist; "
+            f"current params = {params}"
+        )
+        default = inspect.signature(subscribe_watchlist).parameters["workspace_id"].default
+        assert default is None, (
+            "workspace_id default must be None on subscribe_watchlist "
+            f"(legacy callers must keep bit-for-bit behaviour); got {default!r}"
         )
 
-    def test_watch_interest_model_has_no_workspace_id(self):
+    def test_watch_interest_model_has_workspace_id(self):
         from tg_parser.domain.models import WatchInterest
 
         fields = set(WatchInterest.model_fields.keys())
-        assert "workspace_id" not in fields, (
-            "Q7 locked = WatchInterest schema must stay workspace-free in F4-B Core; "
+        assert "workspace_id" in fields, (
+            "ENH-9 contract requires workspace_id field on WatchInterest; "
             f"current fields = {sorted(fields)}"
+        )
+        default = WatchInterest.model_fields["workspace_id"].default
+        assert default is None, (
+            "WatchInterest.workspace_id must default to None so legacy "
+            f"INSERTs leave the column NULL; got {default!r}"
         )
 
 
-class TestQ8DigestSignatureUnchanged:
-    """Q8 = C — ``subscribe_digest`` MCP tool and ``DigestSubscription``
-    schema keep F4-A shape."""
+class TestQ8DigestSignatureHasWorkspaceId:
+    """Q8 LIFTED in Wave 1 step 3 commit 1/4 (ENH-9).
 
-    def test_subscribe_digest_mcp_tool_has_no_workspace_id(self):
+    Mirrors ``TestQ7WatchlistSignatureHasWorkspaceId`` for the F6
+    ``subscribe_digest`` MCP tool and the ``DigestSubscription`` model.
+    """
+
+    def test_subscribe_digest_mcp_tool_accepts_workspace_id(self):
         from tg_parser.mcp_server import subscribe_digest
 
         params = _parameter_names(subscribe_digest)
-        assert "workspace_id" not in params, (
-            "Q8 locked = defer F6 + workspace_id integration; "
-            f"subscribe_digest now has params {params}"
+        assert "workspace_id" in params, (
+            f"ENH-9 contract requires workspace_id on subscribe_digest; current params = {params}"
+        )
+        default = inspect.signature(subscribe_digest).parameters["workspace_id"].default
+        assert default is None, (
+            f"workspace_id default must be None on subscribe_digest; got {default!r}"
         )
 
-    def test_digest_subscription_model_has_no_workspace_id(self):
+    def test_digest_subscription_model_has_workspace_id(self):
         from tg_parser.domain.models import DigestSubscription
 
         fields = set(DigestSubscription.model_fields.keys())
-        assert "workspace_id" not in fields, (
-            "Q8 locked = DigestSubscription schema must stay workspace-free in "
-            f"F4-B Core; current fields = {sorted(fields)}"
+        assert "workspace_id" in fields, (
+            "ENH-9 contract requires workspace_id field on DigestSubscription; "
+            f"current fields = {sorted(fields)}"
+        )
+        default = DigestSubscription.model_fields["workspace_id"].default
+        assert default is None, (
+            f"DigestSubscription.workspace_id must default to None; got {default!r}"
         )
 
 

--- a/tests/test_idempotency_cleanup_job.py
+++ b/tests/test_idempotency_cleanup_job.py
@@ -1,0 +1,152 @@
+"""Tests for the hourly Idempotency-Key cleanup tick (Wave 1 step 3 commit 4/4).
+
+Exercises :func:`tg_parser.services.scheduler_service.cleanup_stale_idempotency_keys`
+end-to-end against the real ingestion DB. The 24-hour TTL is bypassed by
+inserting rows with explicit ``created_at`` timestamps (no
+``freezegun`` / ``time_machine`` dependency — both are absent from
+``pyproject.toml`` and forbidden by AGENTS.md).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from tg_parser.api.metrics import IDEMPOTENCY_KEYS_TABLE_SIZE
+from tg_parser.services.scheduler_service import cleanup_stale_idempotency_keys
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def _idem_cleanup_db(test_db):
+    """Wipe the idempotency table + users for a clean slate."""
+    session = test_db.ingestion_state_session()
+    try:
+        await session.execute(text("DELETE FROM idempotency_keys"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db
+
+
+@pytest.fixture
+async def user_repo(_idem_cleanup_db):
+    session = _idem_cleanup_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+async def _insert_key(
+    db,
+    *,
+    key: str,
+    user_id: str,
+    created_at: datetime,
+) -> None:
+    """Insert a row with an explicit ``created_at`` so we can simulate age."""
+    session = db.ingestion_state_session()
+    try:
+        await session.execute(
+            text(
+                "INSERT INTO idempotency_keys "
+                "(key, user_id, request_hash, response_body, created_at) "
+                "VALUES (:key, :user_id, :hash, CAST(:body AS jsonb), :created_at)"
+            ),
+            {
+                "key": key,
+                "user_id": user_id,
+                "hash": "deadbeef",
+                "body": '{"status": 201, "body": {"ok": true}}',
+                "created_at": created_at,
+            },
+        )
+        await session.commit()
+    finally:
+        await session.close()
+
+
+async def _count_keys(db) -> int:
+    session = db.ingestion_state_session()
+    try:
+        row = (await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))).fetchone()
+        return int(row[0])
+    finally:
+        await session.close()
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+@pg_only
+async def test_cleanup_deletes_keys_older_than_24h(user_repo, _idem_cleanup_db):
+    """Rows older than 24h are deleted; fresh rows survive."""
+    owner = await user_repo.create_user("alice_cleanup")
+    now = datetime.now(UTC)
+    stale_ts = now - timedelta(hours=25)
+    fresh_ts = now - timedelta(minutes=10)
+
+    for n in range(5):
+        await _insert_key(
+            _idem_cleanup_db,
+            key=f"stale-{n}",
+            user_id=owner.id,
+            created_at=stale_ts,
+        )
+    for n in range(3):
+        await _insert_key(
+            _idem_cleanup_db,
+            key=f"fresh-{n}",
+            user_id=owner.id,
+            created_at=fresh_ts,
+        )
+
+    result = await cleanup_stale_idempotency_keys()
+    assert result["deleted"] == 5
+    assert result["table_size"] == 3
+    assert await _count_keys(_idem_cleanup_db) == 3
+
+
+@pg_only
+async def test_cleanup_emits_table_size_gauge(user_repo, _idem_cleanup_db):
+    """The gauge tracks the post-cleanup row count."""
+    owner = await user_repo.create_user("alice_gauge")
+    now = datetime.now(UTC)
+    fresh_ts = now - timedelta(minutes=5)
+
+    for n in range(7):
+        await _insert_key(
+            _idem_cleanup_db,
+            key=f"gauge-{n}",
+            user_id=owner.id,
+            created_at=fresh_ts,
+        )
+
+    await cleanup_stale_idempotency_keys()
+
+    # Read directly from the gauge — internal Prometheus client API.
+    sample_value = IDEMPOTENCY_KEYS_TABLE_SIZE._value.get()  # noqa: SLF001
+    assert sample_value == 7
+
+
+@pg_only
+async def test_cleanup_with_empty_table_is_noop(_idem_cleanup_db):
+    """Cleanup against an empty table returns 0 deleted + 0 size, no errors."""
+    result = await cleanup_stale_idempotency_keys()
+    assert result == {"deleted": 0, "table_size": 0}
+    assert IDEMPOTENCY_KEYS_TABLE_SIZE._value.get() == 0  # noqa: SLF001

--- a/tests/test_idempotency_key_middleware.py
+++ b/tests/test_idempotency_key_middleware.py
@@ -1,0 +1,429 @@
+"""HTTP API tests for the Idempotency-Key middleware (Wave 1 step 3 commit 4/4).
+
+Covers the Stripe-style ``Idempotency-Key`` dependency wired on
+``POST /api/v1/watchlists`` + ``POST /api/v1/digests`` per Q-OPEN-7
+(opt-in per endpoint). All scenarios from §F of the sprint prompt
+plus the explicit risk-mitigation tests (R-2 4xx-not-cached, R-4
+canonical-hash stability) and the cross-user scope isolation.
+
+PG-gated functional tests piggyback on ``test_db`` from
+``tests/conftest.py`` (same shape as ``test_api_watchlists.py``).
+Each test installs an auth-resolver override so the
+``X-API-Key`` chain is bypassed and the dependency receives the
+exact ``CurrentUser`` the scenario needs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.idempotency import canonicalize_body
+from tg_parser.api.main import create_app
+from tg_parser.auth.models import CurrentUser
+from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _user(user_id: str, *, name: str = "alice", role: str = "user") -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else [],
+        max_channels=100,
+    )
+
+
+def _override_user(app, user: CurrentUser) -> None:
+    async def _resolver() -> CurrentUser:
+        return user
+
+    app.dependency_overrides[resolve_current_user] = _resolver
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+async def _idem_db(test_db):
+    """Wipe F4 / F11 / F6 / idempotency tables for a clean per-test slate."""
+    session = test_db.ingestion_state_session()
+    try:
+        await session.execute(text("DELETE FROM idempotency_keys"))
+        await session.execute(text("DELETE FROM watch_matches"))
+        await session.execute(text("DELETE FROM watch_interests"))
+        await session.execute(text("DELETE FROM digest_subscriptions"))
+        await session.execute(text("DELETE FROM workspace_sources"))
+        await session.execute(text("DELETE FROM workspaces"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db
+
+
+@pytest.fixture
+async def user_repo(_idem_db):
+    session = _idem_db.ingestion_state_session()
+    try:
+        yield SAUserRepo(session)
+    finally:
+        await session.close()
+
+
+# ── Pure helper tests (no DB) ───────────────────────────────────────────────
+
+
+class TestCanonicalize:
+    """R-4 mitigation — canonical JSON encoding must be order-stable."""
+
+    def test_sorts_keys_for_stable_hash(self):
+        a = canonicalize_body(b'{"a": 1, "b": 2}')
+        b = canonicalize_body(b'{"b": 2, "a": 1}')
+        assert a == b == b'{"a":1,"b":2}'
+
+    def test_handles_empty_body(self):
+        assert canonicalize_body(b"") == b""
+
+    def test_passes_through_non_json(self):
+        """Non-JSON bodies pass through verbatim (no crash)."""
+        assert canonicalize_body(b"not json at all") == b"not json at all"
+
+    def test_strips_whitespace(self):
+        """Different whitespace shapes collapse to identical canonical form."""
+        a = canonicalize_body(b'{ "a": 1 , "b":  2 }')
+        b = canonicalize_body(b'{"a":1,"b":2}')
+        assert a == b
+
+
+# ── Functional tests — watchlist endpoint ──────────────────────────────────
+
+
+@pg_only
+class TestNoHeaderPassthrough:
+    """Without ``Idempotency-Key``, the endpoint runs unchanged and no cache row is written."""
+
+    async def test_first_request_no_header_passes_through(self, app, client, user_repo, _idem_db):
+        owner = await user_repo.create_user("alice_no_header")
+        _override_user(app, _user(owner.id))
+
+        response = await client.post(
+            "/api/v1/watchlists",
+            json={
+                "title": "MiCA",
+                "channel_ids": ["crypto_news"],
+                "chat_id": 12345,
+            },
+        )
+        assert response.status_code == 201, response.text
+        assert response.json()["created"] is True
+
+        # No header → no cache row written.
+        session = _idem_db.ingestion_state_session()
+        try:
+            result = await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+            assert result.fetchone()[0] == 0
+        finally:
+            await session.close()
+
+
+@pg_only
+class TestCacheHit:
+    """Same key + same body → cached response replayed, no second DB write."""
+
+    async def test_same_key_same_body_returns_cached_response(
+        self, app, client, user_repo, _idem_db
+    ):
+        owner = await user_repo.create_user("alice_cache_hit")
+        _override_user(app, _user(owner.id))
+
+        payload = {"title": "MiCA", "channel_ids": ["crypto_news"], "chat_id": 12345}
+        headers = {"Idempotency-Key": "k-cache-hit"}
+
+        first = await client.post("/api/v1/watchlists", json=payload, headers=headers)
+        second = await client.post("/api/v1/watchlists", json=payload, headers=headers)
+
+        assert first.status_code == 201, first.text
+        assert second.status_code == 201, second.text
+        assert first.json()["watchlist_id"] == second.json()["watchlist_id"]
+        assert first.json() == second.json()
+
+        # Exactly one cache row + one interest row.
+        session = _idem_db.ingestion_state_session()
+        try:
+            keys_count = (
+                await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+            ).fetchone()[0]
+            interests_count = (
+                await session.execute(text("SELECT COUNT(*) FROM watch_interests"))
+            ).fetchone()[0]
+        finally:
+            await session.close()
+        assert keys_count == 1
+        assert interests_count == 1
+
+
+@pg_only
+class TestBodyHashMismatch:
+    """Q-OPEN-1: same key + different body → 422 ``IdempotencyKeyMismatch``."""
+
+    async def test_same_key_different_body_returns_422_mismatch(
+        self, app, client, user_repo, _idem_db
+    ):
+        owner = await user_repo.create_user("alice_mismatch")
+        _override_user(app, _user(owner.id))
+
+        headers = {"Idempotency-Key": "k-mismatch"}
+
+        first = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "MiCA", "channel_ids": ["crypto_news"], "chat_id": 12345},
+            headers=headers,
+        )
+        assert first.status_code == 201, first.text
+
+        second = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "DIFFERENT", "channel_ids": ["crypto_news"], "chat_id": 12345},
+            headers=headers,
+        )
+
+        assert second.status_code == 422, second.text
+        body = second.json()
+        assert body["error_class"] == "IdempotencyKeyMismatch"
+        assert "different request body" in body["detail"].lower()
+
+        # No new interest row (mismatch never reached the service).
+        session = _idem_db.ingestion_state_session()
+        try:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM watch_interests"))
+            ).fetchone()[0]
+        finally:
+            await session.close()
+        assert count == 1
+
+
+@pg_only
+class TestNon2xxNotCached:
+    """R-2: only 2xx outcomes cached; 4xx pass through without writing a cache row."""
+
+    async def test_4xx_validation_response_not_cached(self, app, client, user_repo, _idem_db):
+        owner = await user_repo.create_user("alice_no_cache_4xx")
+        _override_user(app, _user(owner.id))
+
+        headers = {"Idempotency-Key": "k-r2"}
+
+        # First POST: validation fails (empty title → 422 from Pydantic).
+        first = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "", "channel_ids": ["crypto_news"], "chat_id": 12345},
+            headers=headers,
+        )
+        assert first.status_code == 422, first.text
+
+        # No cache row should be present.
+        session = _idem_db.ingestion_state_session()
+        try:
+            count_after_4xx = (
+                await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+            ).fetchone()[0]
+        finally:
+            await session.close()
+        assert count_after_4xx == 0
+
+        # Second POST same key + valid body → normal 201 (cache miss).
+        second = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "MiCA", "channel_ids": ["crypto_news"], "chat_id": 12345},
+            headers=headers,
+        )
+        assert second.status_code == 201, second.text
+        assert second.json()["created"] is True
+
+
+@pg_only
+class TestCanonicalHashStability:
+    """R-4 end-to-end: clients can re-serialize the body in different key order and still hit cache."""
+
+    async def test_canonical_body_hash_stable_across_key_order(
+        self, app, client, user_repo, _idem_db
+    ):
+        owner = await user_repo.create_user("alice_canonical")
+        _override_user(app, _user(owner.id))
+
+        headers = {"Idempotency-Key": "k-canonical"}
+
+        first = await client.post(
+            "/api/v1/watchlists",
+            content=b'{"title":"MiCA","channel_ids":["crypto_news"],"chat_id":12345}',
+            headers={**headers, "Content-Type": "application/json"},
+        )
+        assert first.status_code == 201, first.text
+
+        second = await client.post(
+            "/api/v1/watchlists",
+            content=b'{"chat_id":12345,"channel_ids":["crypto_news"],"title":"MiCA"}',
+            headers={**headers, "Content-Type": "application/json"},
+        )
+
+        assert second.status_code == 201, second.text
+        assert first.json()["watchlist_id"] == second.json()["watchlist_id"]
+        assert first.json() == second.json()
+
+
+@pg_only
+class TestPerUserScope:
+    """Keys are partitioned by ``user_id`` — Bob can never replay Alice's cached response.
+
+    Note on the schema: ``idempotency_keys`` PK is ``(key)`` alone (locked
+    by commit 1/4 migration ``f1a2b3c4d5e6``). Cross-user same-key
+    collisions therefore degrade gracefully — the second user's POST
+    proceeds through the normal flow (the ``find_by_key(user_id=...)``
+    filter never returns Alice's row to Bob, so no incorrect cache hit
+    is possible) but does not get a fresh cache row because the INSERT
+    runs ``ON CONFLICT (key) DO NOTHING``. That trade-off is acceptable:
+    the security-critical invariant — "Bob never gets Alice's cached
+    response" — holds; only the second user loses retry-caching
+    benefit, which is harmless given the service-layer natural-key
+    upsert collapses duplicates anyway.
+    """
+
+    async def test_idempotency_key_scoped_to_user(self, app, client, user_repo, _idem_db):
+        alice = await user_repo.create_user("alice_per_user")
+        bob = await user_repo.create_user("bob_per_user")
+
+        headers = {"Idempotency-Key": "shared-key"}
+
+        _override_user(app, _user(alice.id))
+        first = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "alice-topic", "channel_ids": ["chan"], "chat_id": 111},
+            headers=headers,
+        )
+        assert first.status_code == 201, first.text
+
+        _override_user(app, _user(bob.id))
+        second = await client.post(
+            "/api/v1/watchlists",
+            json={"title": "bob-topic", "channel_ids": ["chan"], "chat_id": 222},
+            headers=headers,
+        )
+        # Critical: Bob's POST proceeds with HIS payload (not Alice's
+        # cached response replayed). Different watchlist_id proves no
+        # cross-user leakage of the cached body.
+        assert second.status_code == 201, second.text
+        assert second.json()["watchlist_id"] != first.json()["watchlist_id"]
+        assert second.json()["created"] is True
+
+        # The single surviving cache row belongs to Alice (the first
+        # writer wins under the global ``UNIQUE(key)`` constraint). Bob
+        # retains correctness without retry-caching benefit.
+        session = _idem_db.ingestion_state_session()
+        try:
+            rows = (
+                await session.execute(
+                    text("SELECT user_id FROM idempotency_keys WHERE key = 'shared-key'")
+                )
+            ).fetchall()
+        finally:
+            await session.close()
+        assert len(rows) == 1
+        assert str(rows[0][0]) == alice.id
+
+
+@pg_only
+class TestDigestPropagation:
+    """Q-OPEN-7: digest POST is the second opt-in endpoint."""
+
+    async def test_idempotency_key_on_digest_endpoint(self, app, client, user_repo, _idem_db):
+        owner = await user_repo.create_user("alice_digest_idem")
+        _override_user(app, _user(owner.id))
+
+        payload = {
+            "name": "morning-roundup",
+            "channel_ids": ["crypto_news"],
+            "chat_id": 999,
+            "cron_expression": "0 9 * * *",
+            "timezone": "UTC",
+            "format": "summary",
+        }
+        headers = {"Idempotency-Key": "k-digest"}
+
+        first = await client.post("/api/v1/digests", json=payload, headers=headers)
+        second = await client.post("/api/v1/digests", json=payload, headers=headers)
+
+        assert first.status_code == 201, first.text
+        assert second.status_code == 201, second.text
+        assert first.json()["digest_id"] == second.json()["digest_id"]
+        assert second.json()["created"] in (True, False)  # cached replay
+
+        session = _idem_db.ingestion_state_session()
+        try:
+            keys_count = (
+                await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+            ).fetchone()[0]
+            digests_count = (
+                await session.execute(text("SELECT COUNT(*) FROM digest_subscriptions"))
+            ).fetchone()[0]
+        finally:
+            await session.close()
+        assert keys_count == 1
+        assert digests_count == 1
+
+
+@pg_only
+class TestNonOptedInEndpointUnaffected:
+    """Q-OPEN-7: other POST endpoints are NOT touched by the middleware.
+
+    GET /api/v1/watchlists is not a POST surface; this test confirms
+    sending ``Idempotency-Key`` on a non-opted-in endpoint has no effect
+    and never writes to ``idempotency_keys``.
+    """
+
+    async def test_get_endpoint_with_header_does_not_write_cache_row(
+        self, app, client, user_repo, _idem_db
+    ):
+        owner = await user_repo.create_user("alice_get_unaffected")
+        _override_user(app, _user(owner.id))
+
+        response = await client.get(
+            "/api/v1/watchlists",
+            headers={"Idempotency-Key": "k-on-get"},
+        )
+        assert response.status_code == 200, response.text
+
+        session = _idem_db.ingestion_state_session()
+        try:
+            count = (
+                await session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+            ).fetchone()[0]
+        finally:
+            await session.close()
+        assert count == 0

--- a/tests/test_subscribe_idempotency.py
+++ b/tests/test_subscribe_idempotency.py
@@ -1,0 +1,490 @@
+"""Service-layer tests for BUG-022 subscribe-idempotency (Wave 1 step 3 commit 1/4).
+
+Closes BUG-022 by exercising the new ``subscribe()`` upsert path on both
+:class:`WatchlistService` and :class:`DigestService`. Pure in-memory fakes
+(no Postgres). Race-condition tests use ``asyncio.gather`` against a fake
+that raises :class:`IntegrityError` from the first concurrent ``create()`` —
+the same shape the new DB ``UNIQUE`` constraint would emit.
+
+Canonical scenarios (per sprint prompt §5):
+
+1. ``test_subscribe_watchlist_idempotent_same_args``                — no-op replay
+2. ``test_subscribe_watchlist_upsert_different_args``               — diff
+3. ``test_subscribe_watchlist_different_titles_different_rows``     — disjoint keys
+4. ``test_subscribe_watchlist_race_condition``                      — concurrent INSERTs
+5. ``test_subscribe_watchlist_resurrects_soft_deleted_row``         — Edge 6 (soft-delete)
+6. ``test_subscribe_digest_idempotent_same_args``                   — Scenario 5 mirror
+7. ``test_subscribe_digest_upsert_different_args``
+8. ``test_subscribe_digest_race_condition``
+9. ``test_subscribe_digest_resurrects_inactive_row``                — Edge 6 mirror
+
+Sprint prompt §5 Edge 7 (whitespace / case-sensitivity on natural-key
+fields) is intentionally not exercised here — the domain models
+(``WatchInterest.title`` / ``DigestSubscription.name``) do not normalise
+their values, the DB ``UNIQUE`` constraint compares exact strings, and
+adding a pin for non-normalisation would freeze a behaviour we expect
+to evolve when locale-aware indexing lands.
+
+Backward-compat regression guards live in ``tests/test_f11_watchlist.py``
+and ``tests/test_f6_scheduled_digests.py``; this file only adds the new
+behaviour-level assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from test_watchlist_service import (  # type: ignore[import-not-found]  # noqa: E402
+    _FakeEmbeddingRepo,
+    _FakeInterestRepo,
+    _FakeMatchRepo,
+    _FakeProcessedDocRepo,
+)
+
+from tg_parser.domain.models import (  # noqa: E402
+    DigestFormat,
+    DigestSubscription,
+    NotifyMode,
+)
+from tg_parser.services.digest_service import DigestService  # noqa: E402
+from tg_parser.services.digest_service import (  # noqa: E402
+    SubscribeResult as DigestSubscribeResult,
+)
+from tg_parser.services.watchlist_service import (  # noqa: E402
+    SubscribeResult as WatchSubscribeResult,
+)
+from tg_parser.services.watchlist_service import WatchlistService  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# In-memory DigestSubscriptionRepo fake (BUG-022)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDigestSubscriptionRepo:
+    """Minimal in-memory repo with ``find_by_owner_and_name`` and a race
+    toggle that mimics the new ``UNIQUE (owner_id, name)`` DB constraint.
+
+    The ``simulate_race_on_create`` flag fires exactly once: on its first
+    invocation the repo writes the racing row under a synthetic id (so
+    a follow-up ``find_by_owner_and_name`` returns it) and raises
+    :class:`IntegrityError`. Subsequent calls behave normally — this
+    matches the worst-case shape the service must collapse to a single
+    row.
+    """
+
+    store: dict[str, DigestSubscription] = field(default_factory=dict)
+    simulate_race_on_create: bool = False
+    _race_fired: bool = False
+
+    async def create(self, sub: DigestSubscription) -> DigestSubscription:
+        if self.simulate_race_on_create:
+            collision = next(
+                (
+                    existing
+                    for existing in self.store.values()
+                    if existing.owner_id == sub.owner_id and existing.name == sub.name
+                ),
+                None,
+            )
+            if collision is not None:
+                raise IntegrityError(
+                    "duplicate key value violates unique constraint",
+                    params=None,
+                    orig=Exception("uq_digest_subscriptions_owner_name"),
+                )
+            if not self._race_fired:
+                self._race_fired = True
+        new_id = sub.id or str(uuid.uuid4())
+        stored = sub.model_copy(update={"id": new_id})
+        self.store[new_id] = stored
+        return stored
+
+    async def get(self, sub_id: str) -> DigestSubscription | None:
+        return self.store.get(sub_id)
+
+    async def find_by_owner_and_name(self, owner_id: str, name: str) -> DigestSubscription | None:
+        for sub in self.store.values():
+            if sub.owner_id == owner_id and sub.name == name:
+                return sub
+        return None
+
+    async def update(self, sub_id: str, **fields: Any) -> DigestSubscription | None:
+        existing = self.store.get(sub_id)
+        if existing is None:
+            return None
+        clean: dict[str, Any] = {}
+        for k, v in fields.items():
+            if k == "unset_workspace_id":
+                if v:
+                    clean["workspace_id"] = None
+                continue
+            if v is not None:
+                clean[k] = v
+        if not clean:
+            return existing
+        clean["updated_at"] = datetime.now(UTC)
+        new_row = existing.model_copy(update=clean)
+        self.store[sub_id] = new_row
+        return new_row
+
+    async def delete(self, sub_id: str) -> bool:
+        return self.store.pop(sub_id, None) is not None
+
+    async def list_by_owner(self, owner_id: str) -> list[DigestSubscription]:
+        return [s for s in self.store.values() if s.owner_id == owner_id]
+
+    async def list_all(self) -> list[DigestSubscription]:
+        return list(self.store.values())
+
+    async def list_active(self) -> list[DigestSubscription]:
+        return [s for s in self.store.values() if s.is_active]
+
+
+# ---------------------------------------------------------------------------
+# Service factories
+# ---------------------------------------------------------------------------
+
+
+def _make_watchlist_service(
+    *,
+    interest_repo: _FakeInterestRepo | None = None,
+    match_repo: _FakeMatchRepo | None = None,
+) -> tuple[WatchlistService, _FakeInterestRepo, _FakeMatchRepo]:
+    ir = interest_repo or _FakeInterestRepo()
+    mr = match_repo or _FakeMatchRepo()
+    svc = WatchlistService(
+        interest_repo=ir,
+        match_repo=mr,
+        processed_doc_repo=_FakeProcessedDocRepo([]),
+        embedding_repo=_FakeEmbeddingRepo(),
+        embedding_client=None,
+    )
+    return svc, ir, mr
+
+
+def _make_digest_service(
+    *,
+    sub_repo: _FakeDigestSubscriptionRepo | None = None,
+) -> tuple[DigestService, _FakeDigestSubscriptionRepo]:
+    repo = sub_repo or _FakeDigestSubscriptionRepo()
+    svc = DigestService(
+        processed_repo=None,
+        subscription_repo=repo,
+        prompt_loader=None,
+        llm_client_factory=None,
+        workspace_repo=None,
+    )
+    return svc, repo
+
+
+# ---------------------------------------------------------------------------
+# Watchlist idempotency tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubscribeWatchlistIdempotency:
+    async def test_subscribe_watchlist_idempotent_same_args(self) -> None:
+        svc, ir, _ = _make_watchlist_service()
+        kwargs: dict[str, Any] = {
+            "user_id": "user-1",
+            "chat_id": 12345,
+            "title": "MiCA / EU crypto regulation",
+            "channel_ids": ["crypto_news"],
+            "keywords": ["mica"],
+            "threshold": 0.6,
+            "notify_mode": NotifyMode.INSTANT,
+        }
+
+        first = await svc.subscribe(**kwargs)
+        second = await svc.subscribe(**kwargs)
+
+        assert isinstance(first, WatchSubscribeResult)
+        assert isinstance(second, WatchSubscribeResult)
+        assert first.created is True
+        assert first.changed_fields == []
+        assert second.created is False
+        assert second.changed_fields == []
+        # Same row — single insert by natural key.
+        assert first.interest.id == second.interest.id
+        assert len(ir.store) == 1
+
+    async def test_subscribe_watchlist_upsert_different_args(self) -> None:
+        svc, ir, _ = _make_watchlist_service()
+        base: dict[str, Any] = {
+            "user_id": "user-1",
+            "chat_id": 12345,
+            "title": "MiCA / EU crypto regulation",
+            "channel_ids": ["crypto_news"],
+            "keywords": ["mica"],
+            "threshold": 0.6,
+            "notify_mode": NotifyMode.INSTANT,
+        }
+
+        first = await svc.subscribe(**base)
+        second = await svc.subscribe(
+            **{
+                **base,
+                "keywords": ["mica", "dora"],
+                "description": "Watch MiCA + DORA",
+            }
+        )
+
+        assert first.created is True
+        assert second.created is False
+        assert first.interest.id == second.interest.id
+        assert set(second.changed_fields) == {"keywords", "description"}
+        # Repo state reflects the new payload, not the old one.
+        stored = await ir.get(second.interest.id)
+        assert stored is not None
+        assert stored.keywords == ["mica", "dora"]
+        assert stored.description == "Watch MiCA + DORA"
+
+    async def test_subscribe_watchlist_different_titles_different_rows(self) -> None:
+        svc, ir, _ = _make_watchlist_service()
+        base: dict[str, Any] = {
+            "user_id": "user-1",
+            "chat_id": 12345,
+            "channel_ids": ["crypto_news"],
+            "keywords": ["mica"],
+            "threshold": 0.6,
+            "notify_mode": NotifyMode.INSTANT,
+        }
+
+        first = await svc.subscribe(title="MiCA", **base)
+        second = await svc.subscribe(title="DORA", **base)
+
+        assert first.created is True
+        assert second.created is True
+        assert first.interest.id != second.interest.id
+        assert len(ir.store) == 2
+
+    async def test_subscribe_watchlist_race_condition(self) -> None:
+        """Concurrent INSERTs collapse to a single row via IntegrityError retry."""
+        ir = _FakeInterestRepo()
+        ir.simulate_race_on_create = True
+        svc, ir, _ = _make_watchlist_service(interest_repo=ir)
+
+        kwargs: dict[str, Any] = {
+            "user_id": "user-race",
+            "chat_id": 42,
+            "title": "Race target",
+            "channel_ids": ["crypto_news"],
+            "keywords": ["mica"],
+            "threshold": 0.6,
+            "notify_mode": NotifyMode.INSTANT,
+        }
+
+        results = await asyncio.gather(
+            *[svc.subscribe(**kwargs) for _ in range(10)],
+            return_exceptions=True,
+        )
+
+        # No exceptions leaked — every loser must have retried as UPDATE.
+        for r in results:
+            assert not isinstance(r, Exception), r
+
+        unique_ids = {r.interest.id for r in results}  # type: ignore[union-attr]
+        assert len(unique_ids) == 1, "race must collapse to a single row"
+        # Exactly one create-winner.
+        created_flags = [r.created for r in results]  # type: ignore[union-attr]
+        assert created_flags.count(True) == 1
+        assert created_flags.count(False) == len(results) - 1
+        # And the fake store holds exactly one row under that id.
+        assert len(ir.store) == 1
+
+    async def test_subscribe_watchlist_resurrects_soft_deleted_row(self) -> None:
+        """Soft-deleted (is_active=False) row + same (user_id, title) → resurrect.
+
+        Sprint prompt §5 Edge 6 — BUG-022 must preserve the row through
+        unsubscribe → subscribe cycle. The watch_matches history stays
+        attached (same id), is_active flips back to True, and ``is_active``
+        appears in ``changed_fields`` so the surface can render
+        "resurrected" rather than "no-op".
+        """
+        svc, ir, _ = _make_watchlist_service()
+        kwargs: dict[str, Any] = {
+            "user_id": "user-1",
+            "chat_id": 12345,
+            "title": "MiCA / EU crypto regulation",
+            "channel_ids": ["crypto_news"],
+            "keywords": ["mica"],
+            "threshold": 0.6,
+            "notify_mode": NotifyMode.INSTANT,
+        }
+
+        first = await svc.subscribe(**kwargs)
+        assert first.created is True
+        # Soft-delete the row (mirror unsubscribe).
+        deleted = await ir.soft_delete(first.interest.id)
+        assert deleted is True
+        soft_deleted = await ir.get(first.interest.id)
+        assert soft_deleted is not None
+        assert soft_deleted.is_active is False
+
+        second = await svc.subscribe(**kwargs)
+
+        assert second.created is False, (
+            "row must be reused, not re-CREATEd (preserves watch_matches FK)"
+        )
+        assert second.interest.id == first.interest.id
+        assert "is_active" in second.changed_fields, (
+            "is_active must surface in changed_fields so callers can render resurrection"
+        )
+        # The row is back to active state.
+        resurrected = await ir.get(first.interest.id)
+        assert resurrected is not None
+        assert resurrected.is_active is True
+        # And only one row exists for the natural key.
+        assert len(ir.store) == 1
+
+
+# ---------------------------------------------------------------------------
+# Digest idempotency tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubscribeDigestIdempotency:
+    async def test_subscribe_digest_idempotent_same_args(self) -> None:
+        svc, repo = _make_digest_service()
+        kwargs: dict[str, Any] = {
+            "owner_id": "user-1",
+            "chat_id": 12345,
+            "name": "morning",
+            "channel_ids": ["durov"],
+            "cron_expression": "0 9 * * *",
+            "timezone": "Europe/Moscow",
+            "format": DigestFormat.SUMMARY,
+            "language": "ru",
+        }
+
+        first = await svc.subscribe(**kwargs)
+        second = await svc.subscribe(**kwargs)
+
+        assert isinstance(first, DigestSubscribeResult)
+        assert isinstance(second, DigestSubscribeResult)
+        assert first.created is True
+        assert first.changed_fields == []
+        assert second.created is False
+        assert second.changed_fields == []
+        assert first.subscription.id == second.subscription.id
+        assert len(repo.store) == 1
+
+    async def test_subscribe_digest_upsert_different_args(self) -> None:
+        svc, repo = _make_digest_service()
+        base: dict[str, Any] = {
+            "owner_id": "user-1",
+            "chat_id": 12345,
+            "name": "morning",
+            "channel_ids": ["durov"],
+            "cron_expression": "0 9 * * *",
+            "timezone": "Europe/Moscow",
+            "format": DigestFormat.SUMMARY,
+            "language": "ru",
+        }
+
+        first = await svc.subscribe(**base)
+        second = await svc.subscribe(
+            **{
+                **base,
+                "cron_expression": "0 18 * * *",
+                "channel_ids": ["durov", "tginfo"],
+            }
+        )
+
+        assert first.created is True
+        assert second.created is False
+        assert first.subscription.id == second.subscription.id
+        assert set(second.changed_fields) == {"cron_expression", "channel_ids"}
+        stored = await repo.get(second.subscription.id)
+        assert stored is not None
+        assert stored.cron_expression == "0 18 * * *"
+        assert stored.channel_ids == ["durov", "tginfo"]
+
+    async def test_subscribe_digest_race_condition(self) -> None:
+        """Concurrent INSERTs collapse to a single row via IntegrityError retry."""
+        repo = _FakeDigestSubscriptionRepo()
+        repo.simulate_race_on_create = True
+        svc, repo = _make_digest_service(sub_repo=repo)
+
+        kwargs: dict[str, Any] = {
+            "owner_id": "user-race",
+            "chat_id": 42,
+            "name": "race-digest",
+            "channel_ids": ["durov"],
+            "cron_expression": "0 9 * * *",
+            "timezone": "UTC",
+            "format": DigestFormat.SUMMARY,
+            "language": "ru",
+        }
+
+        results = await asyncio.gather(
+            *[svc.subscribe(**kwargs) for _ in range(10)],
+            return_exceptions=True,
+        )
+
+        for r in results:
+            assert not isinstance(r, Exception), r
+
+        unique_ids = {r.subscription.id for r in results}  # type: ignore[union-attr]
+        assert len(unique_ids) == 1
+        created_flags = [r.created for r in results]  # type: ignore[union-attr]
+        assert created_flags.count(True) == 1
+        assert created_flags.count(False) == len(results) - 1
+        assert len(repo.store) == 1
+
+    async def test_subscribe_digest_resurrects_inactive_row(self) -> None:
+        """is_active=False digest row + same (owner_id, name) → resurrect.
+
+        Sprint prompt §5 Edge 6 mirror for F6 — DELETE on a digest is hard
+        (Q8 = A) in the HTTP/MCP surface, but the service layer must still
+        handle the case where an existing row was flipped to ``is_active
+        = False`` directly (e.g. orphaned-bot-block path mirroring F11).
+        Resurrection must surface ``is_active`` in ``changed_fields``.
+        """
+        svc, repo = _make_digest_service()
+        kwargs: dict[str, Any] = {
+            "owner_id": "user-1",
+            "chat_id": 12345,
+            "name": "morning",
+            "channel_ids": ["durov"],
+            "cron_expression": "0 9 * * *",
+            "timezone": "Europe/Moscow",
+            "format": DigestFormat.SUMMARY,
+            "language": "ru",
+        }
+
+        first = await svc.subscribe(**kwargs)
+        assert first.created is True
+
+        # Simulate the existing row going inactive (no public soft_delete
+        # on the digest repo — update is_active directly).
+        inactive = await repo.update(first.subscription.id, is_active=False)
+        assert inactive is not None
+        assert inactive.is_active is False
+
+        second = await svc.subscribe(**kwargs)
+
+        assert second.created is False
+        assert second.subscription.id == first.subscription.id
+        assert "is_active" in second.changed_fields, (
+            "is_active must surface in changed_fields so callers can render resurrection"
+        )
+        resurrected = await repo.get(first.subscription.id)
+        assert resurrected is not None
+        assert resurrected.is_active is True
+        assert len(repo.store) == 1

--- a/tests/test_watchlist_service.py
+++ b/tests/test_watchlist_service.py
@@ -38,8 +38,41 @@ class _FakeInterestRepo:
         self.store: dict[str, WatchInterest] = {}
         self.touch_checked_calls: list[tuple[str, datetime]] = []
         self.touch_match_calls: list[tuple[str, datetime]] = []
+        # BUG-022 (Wave 1 step 3): toggle to simulate a UNIQUE
+        # (user_id, title) race — the first create() raises and the
+        # next find_by_user_and_title returns the row another caller
+        # inserted in the meantime.
+        self.simulate_race_on_create: bool = False
+        self._race_already_fired: bool = False
 
     async def create(self, interest: WatchInterest) -> WatchInterest:
+        # BUG-022 (Wave 1 step 3): when ``simulate_race_on_create`` is on
+        # the fake mirrors the new ``UNIQUE (user_id, title)`` DB
+        # constraint — every call that would otherwise collide raises
+        # :class:`IntegrityError`, mirroring the real Postgres behaviour
+        # under concurrent INSERTs (the first winner stores; every
+        # subsequent caller gets the same conflict).
+        if self.simulate_race_on_create:
+            from sqlalchemy.exc import IntegrityError
+
+            collision = next(
+                (
+                    existing
+                    for existing in self.store.values()
+                    if existing.user_id == interest.user_id and existing.title == interest.title
+                ),
+                None,
+            )
+            if collision is not None:
+                raise IntegrityError(
+                    "duplicate key value violates unique constraint",
+                    params=None,
+                    orig=Exception("uq_watch_interests_user_title"),
+                )
+            if not self._race_already_fired:
+                # First call wins the race: store the row + signal that
+                # any later create() reaching the fake races against it.
+                self._race_already_fired = True
         new_id = interest.id or f"int-{len(self.store) + 1}"
         stored = interest.model_copy(update={"id": new_id})
         self.store[new_id] = stored
@@ -47,6 +80,57 @@ class _FakeInterestRepo:
 
     async def get(self, interest_id: str) -> WatchInterest | None:
         return self.store.get(interest_id)
+
+    async def find_by_user_and_title(self, user_id: str, title: str) -> WatchInterest | None:
+        for interest in self.store.values():
+            if interest.user_id == user_id and interest.title == title:
+                return interest
+        return None
+
+    async def update_subscribe_fields(
+        self,
+        interest_id: str,
+        *,
+        chat_id: int | None = None,
+        description: str | None = None,
+        keywords: list[str] | None = None,
+        exclude_keywords: list[str] | None = None,
+        channel_ids: list[str] | None = None,
+        threshold: float | None = None,
+        notify_mode: Any = None,
+        is_active: bool | None = None,
+        workspace_id: str | None = None,
+        unset_workspace_id: bool = False,
+    ) -> WatchInterest | None:
+        existing = self.store.get(interest_id)
+        if existing is None:
+            return None
+        updates: dict[str, Any] = {}
+        if chat_id is not None:
+            updates["chat_id"] = chat_id
+        if description is not None:
+            updates["description"] = description
+        if keywords is not None:
+            updates["keywords"] = list(keywords)
+        if exclude_keywords is not None:
+            updates["exclude_keywords"] = list(exclude_keywords)
+        if channel_ids is not None:
+            updates["channel_ids"] = list(channel_ids)
+        if threshold is not None:
+            updates["threshold"] = float(threshold)
+        if notify_mode is not None:
+            updates["notify_mode"] = notify_mode
+        if is_active is not None:
+            updates["is_active"] = is_active
+        if unset_workspace_id:
+            updates["workspace_id"] = None
+        elif workspace_id is not None:
+            updates["workspace_id"] = workspace_id
+        if not updates:
+            return existing
+        new_row = existing.model_copy(update=updates)
+        self.store[interest_id] = new_row
+        return new_row
 
     async def list_for_user(self, user_id: str) -> list[WatchInterest]:
         return [i for i in self.store.values() if i.user_id == user_id]

--- a/tests/test_watchlist_workspace_id.py
+++ b/tests/test_watchlist_workspace_id.py
@@ -1,0 +1,421 @@
+"""Service-layer tests for ENH-9 ``workspace_id`` on subscribe paths.
+
+Wave 1 step 3 commit 1/4 — service-layer half of ENH-9. HTTP/Bot/CLI
+integration tests land in commit 2/4+ (per sprint prompt §8).
+
+Canonical scenarios (per sprint prompt §5 — 8 base + admin-bypass mirror):
+
+Watchlist:
+
+* ``test_workspace_id_none``                              — Scenario 1
+* ``test_workspace_id_valid``                             — Scenario 2
+* ``test_workspace_id_foreign``                           — Scenario 3
+* ``test_workspace_id_unknown_uuid``                      — Scenario 4
+* ``test_workspace_deletion_sets_null``                   — Scenario 6
+* ``test_workspace_id_admin_bypasses_ownership_check``    — Scenario 8
+
+Digest (Scenario 7 mirror):
+
+* ``test_workspace_id_valid``
+* ``test_workspace_id_foreign``
+* ``test_workspace_id_unknown_uuid``
+* ``test_workspace_id_admin_bypasses_ownership_check``
+* ``test_workspace_deletion_sets_null``
+
+The deletion-cascade test uses a custom in-memory ``WorkspaceRepo`` to
+emulate the ``ON DELETE SET NULL`` behaviour of the new Alembic FK; the
+DB-level smoke for the same wiring lives in the integration test suite
+that picks up the migration head. The malformed-string scenario (#5 in
+the sprint prompt) is intentionally not covered here — at the service
+layer, a non-UUID string short-circuits through the same
+``workspace_repo.get()`` lookup miss as a random UUID and surfaces an
+identical ``WorkspaceNotFound``; format validation happens at the
+HTTP layer in commit 2/4+ via Pydantic ``UUID4`` parsing (422).
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from test_subscribe_idempotency import (  # type: ignore[import-not-found]  # noqa: E402
+    _FakeDigestSubscriptionRepo,
+)
+from test_watchlist_service import (  # type: ignore[import-not-found]  # noqa: E402
+    _FakeEmbeddingRepo,
+    _FakeInterestRepo,
+    _FakeMatchRepo,
+    _FakeProcessedDocRepo,
+)
+
+from tg_parser.auth.ownership import WorkspaceNotFound  # noqa: E402
+from tg_parser.domain.models import DigestFormat, NotifyMode, Workspace  # noqa: E402
+from tg_parser.services.digest_service import DigestService  # noqa: E402
+from tg_parser.services.watchlist_service import WatchlistService  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# In-memory WorkspaceRepo fake
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeWorkspaceRepo:
+    """Minimal in-memory ``WorkspaceRepo`` for ENH-9 service-layer tests.
+
+    Only the methods exercised by :meth:`WatchlistService.subscribe`
+    and :meth:`DigestService.subscribe` (``get``, ``delete``) are
+    implemented; the rest are intentionally absent so misuse fails
+    loudly.
+    """
+
+    store: dict[str, Workspace] = field(default_factory=dict)
+
+    def add(
+        self,
+        *,
+        owner_id: str,
+        workspace_id: str | None = None,
+        name: str = "default",
+    ) -> Workspace:
+        wid = workspace_id or str(uuid.uuid4())
+        now = datetime.now(UTC)
+        ws = Workspace(
+            id=wid,
+            owner_id=owner_id,
+            name=name,
+            description=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self.store[wid] = ws
+        return ws
+
+    async def get(self, workspace_id: str) -> Workspace | None:
+        return self.store.get(workspace_id)
+
+    async def delete(self, workspace_id: str) -> bool:
+        return self.store.pop(workspace_id, None) is not None
+
+
+# ---------------------------------------------------------------------------
+# Service factories
+# ---------------------------------------------------------------------------
+
+
+def _make_watchlist_service(
+    *,
+    workspace_repo: _FakeWorkspaceRepo | None = None,
+) -> tuple[WatchlistService, _FakeInterestRepo, _FakeMatchRepo, _FakeWorkspaceRepo]:
+    ir = _FakeInterestRepo()
+    mr = _FakeMatchRepo()
+    wsr = workspace_repo or _FakeWorkspaceRepo()
+    svc = WatchlistService(
+        interest_repo=ir,
+        match_repo=mr,
+        processed_doc_repo=_FakeProcessedDocRepo([]),
+        embedding_repo=_FakeEmbeddingRepo(),
+        embedding_client=None,
+        workspace_repo=wsr,  # type: ignore[arg-type]
+    )
+    return svc, ir, mr, wsr
+
+
+def _make_digest_service(
+    *,
+    workspace_repo: _FakeWorkspaceRepo | None = None,
+) -> tuple[DigestService, _FakeDigestSubscriptionRepo, _FakeWorkspaceRepo]:
+    repo = _FakeDigestSubscriptionRepo()
+    wsr = workspace_repo or _FakeWorkspaceRepo()
+    svc = DigestService(
+        processed_repo=None,
+        subscription_repo=repo,
+        prompt_loader=None,
+        llm_client_factory=None,
+        workspace_repo=wsr,  # type: ignore[arg-type]
+    )
+    return svc, repo, wsr
+
+
+# ---------------------------------------------------------------------------
+# Watchlist ENH-9 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubscribeWatchlistWorkspaceId:
+    """ENH-9 service-layer behaviour for ``WatchlistService.subscribe``."""
+
+    async def test_workspace_id_none(self) -> None:
+        """Default behaviour bit-for-bit: row.workspace_id IS NULL."""
+        svc, ir, _, _ = _make_watchlist_service()
+
+        result = await svc.subscribe(
+            user_id="user-1",
+            chat_id=12345,
+            title="MiCA",
+            channel_ids=["crypto_news"],
+            keywords=["mica"],
+            threshold=0.6,
+            notify_mode=NotifyMode.INSTANT,
+        )
+
+        assert result.created is True
+        assert result.interest.workspace_id is None
+        stored = await ir.get(result.interest.id)
+        assert stored is not None
+        assert stored.workspace_id is None
+
+    async def test_workspace_id_valid(self) -> None:
+        """Owned workspace → FK stored on the new row."""
+        wsr = _FakeWorkspaceRepo()
+        ws = wsr.add(owner_id="user-1", name="EU regulation")
+        svc, ir, _, _ = _make_watchlist_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(
+            user_id="user-1",
+            chat_id=12345,
+            title="MiCA",
+            channel_ids=["crypto_news"],
+            keywords=["mica"],
+            threshold=0.6,
+            notify_mode=NotifyMode.INSTANT,
+            workspace_id=ws.id,
+        )
+
+        assert result.created is True
+        assert result.interest.workspace_id == ws.id
+        stored = await ir.get(result.interest.id)
+        assert stored is not None
+        assert stored.workspace_id == ws.id
+
+    async def test_workspace_id_foreign(self) -> None:
+        """Workspace owned by another user → 404-like WorkspaceNotFound."""
+        wsr = _FakeWorkspaceRepo()
+        # Workspace owned by user-2; user-1 is trying to use it.
+        foreign_ws = wsr.add(owner_id="user-2", name="other tenant")
+        svc, ir, _, _ = _make_watchlist_service(workspace_repo=wsr)
+
+        with pytest.raises(WorkspaceNotFound):
+            await svc.subscribe(
+                user_id="user-1",
+                chat_id=12345,
+                title="MiCA",
+                channel_ids=["crypto_news"],
+                keywords=["mica"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                workspace_id=foreign_ws.id,
+            )
+
+        # No row was created — invariant: cross-tenant attempts never leak existence.
+        assert len(ir.store) == 0
+
+    async def test_workspace_id_unknown_uuid(self) -> None:
+        """Random UUID → WorkspaceNotFound (existence indistinguishable from foreign)."""
+        wsr = _FakeWorkspaceRepo()
+        svc, ir, _, _ = _make_watchlist_service(workspace_repo=wsr)
+
+        with pytest.raises(WorkspaceNotFound):
+            await svc.subscribe(
+                user_id="user-1",
+                chat_id=12345,
+                title="MiCA",
+                channel_ids=["crypto_news"],
+                keywords=["mica"],
+                threshold=0.6,
+                notify_mode=NotifyMode.INSTANT,
+                workspace_id=str(uuid.uuid4()),
+            )
+
+        assert len(ir.store) == 0
+
+    async def test_workspace_deletion_sets_null(self) -> None:
+        """Deleting the workspace clears the FK on existing rows (ON DELETE SET NULL).
+
+        The Alembic FK is defined as ``ON DELETE SET NULL``; this test
+        emulates the cascade at the service layer by deleting the
+        workspace and re-reading the watch interest. The fake repo
+        doesn't model the FK, so we simulate the cascade by manually
+        nulling the column on delete via the test helper below.
+        """
+        wsr = _FakeWorkspaceRepo()
+        ws = wsr.add(owner_id="user-1", name="EU regulation")
+        svc, ir, _, _ = _make_watchlist_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(
+            user_id="user-1",
+            chat_id=12345,
+            title="MiCA",
+            channel_ids=["crypto_news"],
+            keywords=["mica"],
+            threshold=0.6,
+            notify_mode=NotifyMode.INSTANT,
+            workspace_id=ws.id,
+        )
+        assert result.interest.workspace_id == ws.id
+
+        # Simulate ``ON DELETE SET NULL`` cascade: workspace_repo.delete()
+        # would trigger the FK cascade in real Postgres; for the in-memory
+        # fake we apply the same effect manually so the test still
+        # exercises the post-cascade observable state.
+        await wsr.delete(ws.id)
+        for interest_id, interest in list(ir.store.items()):
+            if interest.workspace_id == ws.id:
+                ir.store[interest_id] = interest.model_copy(update={"workspace_id": None})
+
+        post = await ir.get(result.interest.id)
+        assert post is not None
+        assert post.workspace_id is None
+
+    async def test_workspace_id_admin_bypasses_ownership_check(self) -> None:
+        """Admin (is_admin=True) can subscribe with another user's workspace.
+
+        Sprint prompt §5 ENH-9 Scenario 8: parity with
+        ``assert_workspace_access`` in ``tg_parser/auth/ownership.py``
+        — admin bypasses the cross-tenant ownership guard so support /
+        operator workflows can subscribe on behalf of arbitrary users.
+        Non-admin path is covered by ``test_workspace_id_foreign``.
+        """
+        wsr = _FakeWorkspaceRepo()
+        # Workspace owned by user-2; admin (user-admin) subscribes on behalf
+        # of user-1 (which here means admin acts as user-1 — see is_admin
+        # semantics on WatchlistService.subscribe).
+        foreign_ws = wsr.add(owner_id="user-2", name="other tenant")
+        svc, ir, _, _ = _make_watchlist_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(
+            user_id="user-1",
+            chat_id=12345,
+            title="MiCA",
+            channel_ids=["crypto_news"],
+            keywords=["mica"],
+            threshold=0.6,
+            notify_mode=NotifyMode.INSTANT,
+            workspace_id=foreign_ws.id,
+            is_admin=True,
+        )
+
+        assert result.created is True
+        assert result.interest.workspace_id == foreign_ws.id, (
+            "admin must be allowed to attach a foreign workspace_id "
+            "(mirrors assert_workspace_access admin-bypass branch)"
+        )
+        stored = await ir.get(result.interest.id)
+        assert stored is not None
+        assert stored.workspace_id == foreign_ws.id
+
+
+# ---------------------------------------------------------------------------
+# Digest ENH-9 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSubscribeDigestWorkspaceId:
+    """ENH-9 service-layer behaviour for ``DigestService.subscribe``."""
+
+    def _digest_kwargs(self, owner_id: str = "user-1") -> dict[str, Any]:
+        return {
+            "owner_id": owner_id,
+            "chat_id": 12345,
+            "name": "morning",
+            "channel_ids": ["durov"],
+            "cron_expression": "0 9 * * *",
+            "timezone": "UTC",
+            "format": DigestFormat.SUMMARY,
+            "language": "ru",
+        }
+
+    async def test_workspace_id_valid(self) -> None:
+        wsr = _FakeWorkspaceRepo()
+        ws = wsr.add(owner_id="user-1", name="EU regulation")
+        svc, repo, _ = _make_digest_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(**self._digest_kwargs(), workspace_id=ws.id)
+
+        assert result.created is True
+        assert result.subscription.workspace_id == ws.id
+        stored = await repo.get(result.subscription.id)
+        assert stored is not None
+        assert stored.workspace_id == ws.id
+
+    async def test_workspace_id_foreign(self) -> None:
+        wsr = _FakeWorkspaceRepo()
+        foreign_ws = wsr.add(owner_id="user-2", name="other tenant")
+        svc, repo, _ = _make_digest_service(workspace_repo=wsr)
+
+        with pytest.raises(WorkspaceNotFound):
+            await svc.subscribe(
+                **self._digest_kwargs(),
+                workspace_id=foreign_ws.id,
+            )
+
+        assert len(repo.store) == 0
+
+    async def test_workspace_id_unknown_uuid(self) -> None:
+        """Random UUID → WorkspaceNotFound (mirror of watchlist scenario).
+
+        Sprint prompt §5 ENH-9 Scenario 4 — digest must surface the
+        same 404-like behaviour so cross-tenant existence is never
+        leaked through error class.
+        """
+        wsr = _FakeWorkspaceRepo()
+        svc, repo, _ = _make_digest_service(workspace_repo=wsr)
+
+        with pytest.raises(WorkspaceNotFound):
+            await svc.subscribe(
+                **self._digest_kwargs(),
+                workspace_id=str(uuid.uuid4()),
+            )
+
+        assert len(repo.store) == 0
+
+    async def test_workspace_id_admin_bypasses_ownership_check(self) -> None:
+        """Admin (is_admin=True) can subscribe a digest under another user's ws.
+
+        Sprint prompt §5 ENH-9 Scenario 8 mirror for F6 — admin-bypass
+        parity with watchlist; the digest subscribe path must honour
+        the same ``assert_workspace_access`` admin branch.
+        """
+        wsr = _FakeWorkspaceRepo()
+        foreign_ws = wsr.add(owner_id="user-2", name="other tenant")
+        svc, repo, _ = _make_digest_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(
+            **self._digest_kwargs(),
+            workspace_id=foreign_ws.id,
+            is_admin=True,
+        )
+
+        assert result.created is True
+        assert result.subscription.workspace_id == foreign_ws.id
+        stored = await repo.get(result.subscription.id)
+        assert stored is not None
+        assert stored.workspace_id == foreign_ws.id
+
+    async def test_workspace_deletion_sets_null(self) -> None:
+        wsr = _FakeWorkspaceRepo()
+        ws = wsr.add(owner_id="user-1", name="EU regulation")
+        svc, repo, _ = _make_digest_service(workspace_repo=wsr)
+
+        result = await svc.subscribe(**self._digest_kwargs(), workspace_id=ws.id)
+        assert result.subscription.workspace_id == ws.id
+
+        # Simulate ``ON DELETE SET NULL`` cascade (see watchlist test).
+        await wsr.delete(ws.id)
+        for sid, sub in list(repo.store.items()):
+            if sub.workspace_id == ws.id:
+                repo.store[sid] = sub.model_copy(update={"workspace_id": None})
+
+        post = await repo.get(result.subscription.id)
+        assert post is not None
+        assert post.workspace_id is None

--- a/tg_parser/api/idempotency.py
+++ b/tg_parser/api/idempotency.py
@@ -1,0 +1,273 @@
+"""Stripe-style Idempotency-Key HTTP middleware (Wave 1 step 3 commit 4/4).
+
+Implements the HTTP arm of ADR 0009 Option C (hybrid): the service-layer
+natural-key upsert (commits 1/4 + 2/4 + 3/4) closes BUG-022 cross-surface;
+this dependency layers transient-retry safety on top for HTTP clients
+that follow Stripe / Square / Plaid conventions and send a client-
+generated ``Idempotency-Key`` header.
+
+Opt-in per endpoint (Q-OPEN-7) — wired only on
+``POST /api/v1/watchlists`` + ``POST /api/v1/digests`` in this commit;
+broadening to other POST endpoints is intentionally deferred to a
+future PR.
+
+Semantics (per ADR 0009 + sprint prompt locks):
+
+* Header absent → dependency returns ``None``; endpoint runs the normal
+  flow without any cache I/O.
+* Header present + record absent → ``IdempotencyContext(status='miss')``
+  with the canonical body-hash pre-computed; endpoint runs the normal
+  flow, then calls :meth:`IdempotencyContext.store` with its 2xx payload.
+* Header present + record exists + ``request_hash`` matches → 200/201/2xx
+  replay from cache; the endpoint short-circuits via
+  ``ctx.cached_status`` / ``ctx.cached_body`` and skips its own work.
+* Header present + record exists + ``request_hash`` differs → 422
+  ``IdempotencyKeyMismatch`` raised here, before the endpoint runs
+  (Q-OPEN-1 lean).
+
+Risk mitigations explicitly encoded:
+
+* **R-2 — only 2xx cached.** :meth:`IdempotencyContext.store` is a no-op
+  for any status outside ``[200, 300)``. 4xx / 5xx responses pass through
+  without polluting the cache so a transient validation failure can be
+  retried with a corrected body under the same key.
+* **R-4 — canonical body hashing.** :func:`canonicalize_body` sorts JSON
+  keys and strips whitespace before hashing so a client that re-serializes
+  the same logical body with different key order or formatting still
+  hits the cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import structlog
+from fastapi import Depends, Request
+from fastapi.responses import JSONResponse
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.metrics import record_idempotency_key_result
+from tg_parser.auth.models import CurrentUser
+from tg_parser.storage.ports import IdempotencyKeyRepo
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Constants ───────────────────────────────────────────────────────────────
+
+
+IDEMPOTENCY_HEADER = "Idempotency-Key"
+MISMATCH_ERROR_CLASS = "IdempotencyKeyMismatch"
+
+
+# ── Exceptions ──────────────────────────────────────────────────────────────
+
+
+class IdempotencyKeyMismatchError(Exception):
+    """Raised by :func:`idempotency_key_check` when same key + different body.
+
+    Caught by the FastAPI exception handler registered in
+    :mod:`tg_parser.api.main` which translates the exception into a
+    Q7-shaped ``{"detail": ..., "error_class": "IdempotencyKeyMismatch"}``
+    422 response — same envelope used by every other validation error on
+    the watchlist / digest surfaces.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def canonicalize_body(body: bytes) -> bytes:
+    """Return a deterministic canonical JSON encoding of ``body``.
+
+    Sorts keys + uses compact separators so the SHA-256 hash is stable
+    across client-side serialization variance (R-4 mitigation per
+    sprint prompt). Empty / non-JSON bodies pass through verbatim so
+    endpoints whose body is e.g. an empty POST still hash to a stable
+    value (the canonical form of "no body" is "no body").
+    """
+    if not body:
+        return b""
+    try:
+        parsed: Any = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+    return json.dumps(parsed, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _hash_body(body: bytes) -> str:
+    """SHA-256 hex digest of the canonical body — the request_hash stored in DB."""
+    return hashlib.sha256(canonicalize_body(body)).hexdigest()
+
+
+# ── Context object passed to endpoints ──────────────────────────────────────
+
+
+@dataclass
+class IdempotencyContext:
+    """Per-request state shared between the dependency and the endpoint.
+
+    The dependency builds this object (status = ``hit`` or ``miss``) and
+    returns it to the endpoint. The endpoint:
+
+    1. If ``status == "hit"`` and ``cached_body is not None`` — return
+       a :class:`~fastapi.responses.JSONResponse` from
+       :meth:`build_cached_response` and skip its own work.
+    2. Otherwise run normal flow, then call :meth:`store` with the final
+       status code + JSON-serializable body.
+
+    The ``status_to_log`` field is captured at dependency-resolution
+    time so the structlog ``idempotency_key`` bind survives even if the
+    endpoint forgets to call :meth:`store` (Karpathy principle 6 —
+    instrumentation is independent of endpoint discipline).
+    """
+
+    key: str
+    user_id: str
+    body_hash: str
+    repo: IdempotencyKeyRepo
+    status: Literal["hit", "miss"]
+    cached_status: int | None = None
+    cached_body: dict[str, Any] | None = None
+    _stored: bool = field(default=False, repr=False)
+
+    def build_cached_response(self) -> JSONResponse:
+        """Return a ``JSONResponse`` reproducing the cached 2xx outcome verbatim."""
+        assert self.cached_body is not None, "build_cached_response called on miss context"
+        return JSONResponse(
+            status_code=self.cached_status or 200,
+            content=self.cached_body,
+        )
+
+    async def store(self, *, body: dict[str, Any], status_code: int) -> None:
+        """Persist ``body`` as the cached response for ``(user_id, key)``.
+
+        No-op when:
+
+        * ``status_code`` is outside ``[200, 300)`` (R-2 — only 2xx
+          outcomes are cached so a transient validation failure can be
+          retried with a corrected body under the same key).
+        * Already stored once in this request lifecycle (defensive idempotency).
+        * Current status is ``"hit"`` (the row already exists; skipping
+          the INSERT avoids a redundant write).
+        """
+        if self._stored:
+            return
+        if not (200 <= status_code < 300):
+            logger.debug(
+                "idempotency_skip_non_2xx",
+                idempotency_key=self.key,
+                status_code=status_code,
+            )
+            return
+        if self.status == "hit":
+            self._stored = True
+            return
+        envelope: dict[str, Any] = {"status": int(status_code), "body": body}
+        await self.repo.insert(
+            key=self.key,
+            user_id=self.user_id,
+            request_hash=self.body_hash,
+            response_body=envelope,
+        )
+        record_idempotency_key_result(result="miss")
+        self._stored = True
+
+
+# ── DI factory for the repo ─────────────────────────────────────────────────
+
+
+async def get_idempotency_key_repo() -> IdempotencyKeyRepo:
+    """FastAPI dependency providing a short-lived ``IdempotencyKeyRepo`` session.
+
+    Each call opens a fresh ingestion-DB session and closes it when the
+    yielded generator is finalised — mirrors the per-request lifetime
+    of every other repo dependency in this surface.
+    """
+    from tg_parser.services.db_context import idempotency_key_repo
+
+    async with idempotency_key_repo() as (repo, _db):
+        yield repo
+
+
+# ── Main dependency ─────────────────────────────────────────────────────────
+
+
+async def idempotency_key_check(
+    request: Request,
+    user: CurrentUser = Depends(resolve_current_user),
+    repo: IdempotencyKeyRepo = Depends(get_idempotency_key_repo),
+) -> IdempotencyContext | None:
+    """FastAPI dependency that implements the Stripe-style replay check.
+
+    See the module docstring for the full state machine. Header absent
+    → ``None`` (endpoint runs normal flow); same key + matching body
+    → ``IdempotencyContext(status='hit')`` with cached payload pre-loaded;
+    same key + different body → :class:`HTTPException(422)`.
+
+    The body is read once via :meth:`fastapi.Request.body` and stored
+    on ``request._body`` by FastAPI internals, so the downstream
+    endpoint's Pydantic request-model deserialisation re-uses the cached
+    bytes (no double-read penalty).
+    """
+    key = request.headers.get(IDEMPOTENCY_HEADER)
+    if not key:
+        return None
+
+    structlog.contextvars.bind_contextvars(idempotency_key=key)
+
+    body_bytes = await request.body()
+    body_hash = _hash_body(body_bytes)
+
+    existing = await repo.find_by_key(key=key, user_id=user.id)
+
+    if existing is None:
+        logger.debug("idempotency_miss", idempotency_key=key, user_id=user.id)
+        return IdempotencyContext(
+            key=key,
+            user_id=user.id,
+            body_hash=body_hash,
+            repo=repo,
+            status="miss",
+        )
+
+    if existing.request_hash != body_hash:
+        record_idempotency_key_result(result="mismatch")
+        logger.info(
+            "idempotency_mismatch",
+            idempotency_key=key,
+            user_id=user.id,
+            stored_hash_prefix=existing.request_hash[:8],
+            incoming_hash_prefix=body_hash[:8],
+        )
+        raise IdempotencyKeyMismatchError(
+            "Idempotency-Key reused with a different request body. "
+            "Generate a new key or replay the original body."
+        )
+
+    record_idempotency_key_result(result="hit")
+    envelope = existing.response_body or {}
+    cached_status = int(envelope.get("status", 200)) if isinstance(envelope, dict) else 200
+    cached_body = envelope.get("body") if isinstance(envelope, dict) else None
+    logger.info(
+        "idempotency_hit",
+        idempotency_key=key,
+        user_id=user.id,
+        cached_status=cached_status,
+    )
+    return IdempotencyContext(
+        key=key,
+        user_id=user.id,
+        body_hash=body_hash,
+        repo=repo,
+        status="hit",
+        cached_status=cached_status,
+        cached_body=cached_body if isinstance(cached_body, dict) else None,
+    )

--- a/tg_parser/api/main.py
+++ b/tg_parser/api/main.py
@@ -34,6 +34,7 @@ from tg_parser.api.routes import (
     rag_router,
     topics_router,
     users_router,
+    watchlists_router,
 )
 from tg_parser.api.schemas import ErrorResponse
 from tg_parser.config import settings
@@ -253,6 +254,7 @@ def create_app() -> FastAPI:
     app.include_router(documents_router)
     app.include_router(llm_config_router)
     app.include_router(users_router)
+    app.include_router(watchlists_router)
 
     # PermissionDenied -> 403 handler
     from tg_parser.auth.ownership import PermissionDenied

--- a/tg_parser/api/main.py
+++ b/tg_parser/api/main.py
@@ -26,6 +26,7 @@ from tg_parser.api.middleware import RequestLoggingMiddleware, limiter
 from tg_parser.api.routes import (
     agents_router,
     channels_router,
+    digests_router,
     documents_router,
     export_router,
     health_router,
@@ -255,6 +256,7 @@ def create_app() -> FastAPI:
     app.include_router(llm_config_router)
     app.include_router(users_router)
     app.include_router(watchlists_router)
+    app.include_router(digests_router)
 
     # PermissionDenied -> 403 handler
     from tg_parser.auth.ownership import PermissionDenied

--- a/tg_parser/api/main.py
+++ b/tg_parser/api/main.py
@@ -265,6 +265,21 @@ def create_app() -> FastAPI:
     async def permission_denied_handler(request: Request, exc: PermissionDenied) -> JSONResponse:
         return JSONResponse(status_code=403, content={"detail": exc.message})
 
+    # IdempotencyKeyMismatchError -> 422 handler (Q-OPEN-1 + ADR 0009)
+    from tg_parser.api.idempotency import (
+        MISMATCH_ERROR_CLASS,
+        IdempotencyKeyMismatchError,
+    )
+
+    @app.exception_handler(IdempotencyKeyMismatchError)
+    async def idempotency_mismatch_handler(
+        request: Request, exc: IdempotencyKeyMismatchError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": exc.message, "error_class": MISMATCH_ERROR_CLASS},
+        )
+
     # Global exception handler
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/tg_parser/api/metrics.py
+++ b/tg_parser/api/metrics.py
@@ -646,3 +646,60 @@ def bump_workspace_total(delta: int) -> None:
         WORKSPACE_TOTAL.inc(delta)
     elif delta < 0:
         WORKSPACE_TOTAL.dec(-delta)
+
+
+# ============================================================================
+# Wave 1 step 3 — Idempotency-Key HTTP middleware (ADR 0009 Option C)
+# ============================================================================
+#
+# Karpathy-7 principle 6 (observability). Two metrics:
+#
+# * Counter ``tg_idempotency_keys_hit_total`` — fixed cardinality on
+#   ``result`` ∈ {hit, miss, mismatch}. Tracks how often clients actually
+#   replay (``hit``), how often the middleware records a fresh row
+#   (``miss``), and how often a re-used key with a different body
+#   triggers 422 (``mismatch``). The latter is the canary for client
+#   bugs (key reuse across different intents).
+#
+# * Gauge ``tg_idempotency_keys_table_size`` — current row count in
+#   ``idempotency_keys``. Refreshed on each hourly cleanup tick so
+#   operators can alert on runaway cache growth (which would indicate
+#   either a TTL misconfiguration or a degenerate client retry storm).
+#
+# Per-user / per-key labels are intentionally OMITTED — both are
+# unbounded over time and would blow up label cardinality.
+IDEMPOTENCY_KEYS_HIT_TOTAL = Counter(
+    "tg_idempotency_keys_hit_total",
+    "HTTP Idempotency-Key middleware outcome counter (Wave 1 step 3, ADR 0009).",
+    ["result"],
+)
+
+IDEMPOTENCY_KEYS_TABLE_SIZE = Gauge(
+    "tg_idempotency_keys_table_size",
+    "Current row count in idempotency_keys table (refreshed by hourly cleanup tick).",
+)
+
+
+def record_idempotency_key_result(*, result: str) -> None:
+    """Record one Idempotency-Key middleware outcome.
+
+    ``result`` ∈ {``hit``, ``miss``, ``mismatch``}:
+
+    * ``hit`` — same ``(user_id, key)`` + matching body-hash → cached
+      response replayed, no service-layer work performed.
+    * ``miss`` — first request for this key OR record absent (cleaned
+      out of TTL); fresh row INSERTed after the endpoint produced 2xx.
+    * ``mismatch`` — same key + DIFFERENT body → 422 ``IdempotencyKeyMismatch``;
+      no DB row written, no cached response served.
+    """
+    IDEMPOTENCY_KEYS_HIT_TOTAL.labels(result=result).inc()
+
+
+def set_idempotency_keys_table_size(count: int) -> None:
+    """Set the ``tg_idempotency_keys_table_size`` gauge to ``count``.
+
+    Called by the hourly cleanup tick after each
+    ``DELETE ... WHERE created_at < now() - 24h`` sweep so the gauge
+    tracks the real-world cache footprint without an extra cron beat.
+    """
+    IDEMPOTENCY_KEYS_TABLE_SIZE.set(max(count, 0))

--- a/tg_parser/api/routes/__init__.py
+++ b/tg_parser/api/routes/__init__.py
@@ -12,6 +12,7 @@ from tg_parser.api.routes.process import router as process_router
 from tg_parser.api.routes.rag import router as rag_router
 from tg_parser.api.routes.topics import router as topics_router
 from tg_parser.api.routes.users import router as users_router
+from tg_parser.api.routes.watchlists import router as watchlists_router
 
 __all__ = [
     "health_router",
@@ -24,4 +25,5 @@ __all__ = [
     "documents_router",
     "llm_config_router",
     "users_router",
+    "watchlists_router",
 ]

--- a/tg_parser/api/routes/__init__.py
+++ b/tg_parser/api/routes/__init__.py
@@ -4,6 +4,7 @@ API routes module.
 
 from tg_parser.api.routes.agents import router as agents_router
 from tg_parser.api.routes.channels import router as channels_router
+from tg_parser.api.routes.digests import router as digests_router
 from tg_parser.api.routes.documents import router as documents_router
 from tg_parser.api.routes.export import router as export_router
 from tg_parser.api.routes.health import router as health_router
@@ -26,4 +27,5 @@ __all__ = [
     "llm_config_router",
     "users_router",
     "watchlists_router",
+    "digests_router",
 ]

--- a/tg_parser/api/routes/digests.py
+++ b/tg_parser/api/routes/digests.py
@@ -43,6 +43,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
 
 from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.idempotency import IdempotencyContext, idempotency_key_check
 from tg_parser.api.schemas import (
     DigestCreateRequest,
     DigestListResponse,
@@ -179,6 +180,7 @@ def _validate_cron_timezone(cron_expression: str, timezone: str) -> str | None:
 async def create_digest(
     request: DigestCreateRequest,
     user: CurrentUser = Depends(resolve_current_user),
+    idempotency: IdempotencyContext | None = Depends(idempotency_key_check),
 ):
     """Create (or idempotently upsert) a digest subscription.
 
@@ -201,6 +203,11 @@ async def create_digest(
     path) so an invalid spec returns 422 with
     ``error_class="InvalidCron"`` before the upsert runs.
 
+    Idempotency-Key middleware (ADR 0009 Option C): when the client
+    sends an ``Idempotency-Key`` header, a same-key + same-body retry
+    returns the cached 2xx response verbatim (no second DB write);
+    same-key + different body raises 422 ``IdempotencyKeyMismatch``.
+
     Note: scheduler registration (``register_digest_subscription``)
     is intentionally NOT performed here. The HTTP surface persists
     the row; the next scheduler reconciliation tick picks it up.
@@ -209,6 +216,13 @@ async def create_digest(
     """
     from tg_parser.services.db_context import digest_subscription_repo, workspace_repo
     from tg_parser.services.digest_service import DigestService
+
+    if (
+        idempotency is not None
+        and idempotency.status == "hit"
+        and idempotency.cached_body is not None
+    ):
+        return idempotency.build_cached_response()
 
     logger.info(
         "digests_create",
@@ -271,11 +285,16 @@ async def create_digest(
     except WorkspaceNotFound as exc:
         return _error(404, exc.message, "WorkspaceNotFound")
 
-    return DigestSubscribeResponse(
-        digest_id=str(result.subscription.id),
-        created=result.created,
-        changed_fields=list(result.changed_fields),
-    )
+    response_body = {
+        "digest_id": str(result.subscription.id),
+        "created": result.created,
+        "changed_fields": list(result.changed_fields),
+    }
+
+    if idempotency is not None:
+        await idempotency.store(body=response_body, status_code=201)
+
+    return DigestSubscribeResponse(**response_body)
 
 
 @router.get(

--- a/tg_parser/api/routes/digests.py
+++ b/tg_parser/api/routes/digests.py
@@ -1,0 +1,388 @@
+"""
+Digest HTTP API routes (P-2 Surface Parity MVP — Wave 1 step 3 commit 3/4).
+
+Four endpoints under ``/api/v1/digests`` per sprint prompt §2:
+
+* ``POST   /api/v1/digests``               — subscribe (idempotent upsert
+  per BUG-022 on the ``(owner_id, name)`` natural key; returns
+  ``{digest_id, created, changed_fields}`` per Q-OPEN-1).
+* ``GET    /api/v1/digests``               — list current user's
+  subscriptions with offset/limit pagination (default ``limit=50``, max 200).
+* ``GET    /api/v1/digests/{digest_id}``   — single detail, emits
+  ``workspace_id`` + ``workspace_name`` via a single workspaces JOIN
+  (Q-OPEN-3). Foreign id returns 404-like, NEVER 403 (mirror F4-B).
+* ``DELETE /api/v1/digests/{digest_id}``   — HARD DELETE (Q8 digest
+  variant). Row is physically removed; the **second** DELETE on the
+  same id returns 404 (REST-strict per parent Q-OPEN-8 lock —
+  **ASYMMETRIC** vs the watchlist soft-delete 204+204 pattern).
+
+Authentication piggybacks on the existing ``X-API-Key`` dependency
+(``resolve_current_user``) — no new auth surface (Q1).
+
+Idempotency-Key HTTP middleware is **not** wired in this commit (lands
+in commit 4/4). Service-layer natural-key upsert (commit 1/4) already
+guarantees that same-args POST replays collapse to a single row, so
+this surface is safe for clients today.
+
+Asymmetries vs the P-1 watchlist surface (sprint prompt §3):
+
+* **Label field**: digests use ``name``, not ``title`` (Q6).
+* **DELETE semantics**: hard delete, second→404 (Q8 + parent Q-OPEN-8).
+* **No /matches sub-resource**: a digest's "matches" are scheduled
+  Telegram sends, not online matches — out of scope per sprint §2.
+
+The cron/timezone pair is **pre-validated at the router layer** (same
+pattern as ``mcp_server.subscribe_digest``) so an invalid spec returns
+422 *before* the upsert runs and never leaves a half-written row behind.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, Query, Response
+from fastapi.responses import JSONResponse
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.schemas import (
+    DigestCreateRequest,
+    DigestListResponse,
+    DigestResponse,
+    DigestSubscribeResponse,
+)
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import WorkspaceNotFound
+from tg_parser.domain.models import DigestFormat, DigestSubscription
+
+router = APIRouter(prefix="/api/v1/digests", tags=["Digests"])
+logger = structlog.get_logger(__name__)
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+
+def _error(status_code: int, detail: str, error_class: str) -> JSONResponse:
+    """Build a Q7-shaped error response.
+
+    ``{"detail": ..., "error_class": ...}`` is the locked HTTP error
+    shape for this surface (sprint prompt §3 Q7). Centralised here so
+    every endpoint emits an identical body — clients can branch on
+    ``error_class`` to distinguish ``WorkspaceNotFound`` (caller
+    referenced an unknown / foreign workspace) from ``NotFound``
+    (caller referenced an unknown / foreign digest) and
+    ``InvalidCron`` (cron/timezone pre-validation rejected the spec)
+    without parsing free-form text.
+    """
+    return JSONResponse(
+        status_code=status_code,
+        content={"detail": detail, "error_class": error_class},
+    )
+
+
+def _digest_to_response(
+    sub: DigestSubscription,
+    workspace_name: str | None,
+) -> DigestResponse:
+    """Project a domain ``DigestSubscription`` onto :class:`DigestResponse`.
+
+    Centralises the field mapping (``format`` Enum → string,
+    ``workspace_name`` JOIN-injected) so both GET endpoints stay in
+    sync.
+    """
+    return DigestResponse(
+        id=sub.id,
+        owner_id=sub.owner_id,
+        chat_id=sub.chat_id,
+        name=sub.name,
+        workspace_id=sub.workspace_id,
+        workspace_name=workspace_name,
+        channel_ids=list(sub.channel_ids),
+        cron_expression=sub.cron_expression,
+        timezone=sub.timezone,
+        format=sub.format.value,
+        language=sub.language,
+        is_active=sub.is_active,
+        last_sent_at=sub.last_sent_at,
+        last_digest_cursor=sub.last_digest_cursor,
+        created_at=sub.created_at,
+        updated_at=sub.updated_at,
+    )
+
+
+async def _resolve_workspace_names(
+    subscriptions: list[DigestSubscription],
+) -> dict[str, str]:
+    """Fetch ``workspaces.name`` for every distinct non-NULL ``workspace_id``.
+
+    Performs at most ``N`` ``WorkspaceRepo.get(...)`` calls where ``N``
+    is the count of unique workspace ids on the page — typically 0–5
+    for a paginated list (Q-OPEN-3 ``workspace_name`` JOIN). Returns
+    a dict keyed by ``workspace_id``. Workspaces that were deleted
+    out-of-band (race against ON DELETE SET NULL) silently drop out —
+    the row still renders with ``workspace_name=None``.
+    """
+    distinct_ids: set[str] = {s.workspace_id for s in subscriptions if s.workspace_id is not None}
+    if not distinct_ids:
+        return {}
+
+    from tg_parser.services.db_context import workspace_repo
+
+    names: dict[str, str] = {}
+    async with workspace_repo() as (ws_repo, _db):
+        for wid in distinct_ids:
+            ws = await ws_repo.get(wid)
+            if ws is not None:
+                names[wid] = ws.name
+    return names
+
+
+def _validate_cron_timezone(cron_expression: str, timezone: str) -> str | None:
+    """Pre-validate the cron expression + timezone pair.
+
+    Mirrors :func:`tg_parser.mcp_server.subscribe_digest` so the HTTP
+    surface and the MCP surface reject the same invalid specs with
+    parity error messages — invalid cron should never sneak past the
+    HTTP boundary and explode later inside
+    ``register_digest_subscription``. Returns ``None`` on success or
+    a human-readable error string on failure (so the router can wrap
+    it into the Q7 JSON shape with ``error_class="InvalidCron"``).
+
+    APScheduler / zoneinfo are import-guarded so test environments that
+    strip APScheduler still pass — same fallback shape as the MCP path.
+    """
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        from apscheduler.triggers.cron import CronTrigger
+    except ImportError:
+        logger.debug("digest.cron_prevalidate_skipped", exc_info=True)
+        return None
+
+    try:
+        CronTrigger.from_crontab(cron_expression, timezone=ZoneInfo(timezone))
+    except (ValueError, ZoneInfoNotFoundError) as exc:
+        return (
+            f"cron/timezone validation failed: invalid cron task spec "
+            f"({cron_expression!r} / tz={timezone!r}): {exc}"
+        )
+    return None
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_model=DigestSubscribeResponse,
+    status_code=201,
+    summary="Subscribe to a scheduled digest (idempotent upsert)",
+)
+async def create_digest(
+    request: DigestCreateRequest,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Create (or idempotently upsert) a digest subscription.
+
+    Idempotency contract (BUG-022 + Q-OPEN-1):
+
+    * Same ``(owner_id, name)`` + identical payload → no-op replay;
+      response carries ``created=False`` and ``changed_fields=[]``.
+    * Same ``(owner_id, name)`` + different mutable args → UPDATE
+      the changed columns; response is ``created=False`` with
+      ``changed_fields=[<field names>]``.
+    * New ``(owner_id, name)`` → INSERT; ``created=True`` and
+      ``changed_fields=[]``.
+
+    ENH-9: ``workspace_id`` may reference any workspace the caller
+    owns (admin: any workspace). Unknown / foreign UUIDs raise a
+    404-like ``WorkspaceNotFound`` to avoid leaking existence
+    (mirror F4-B Q2 EC2).
+
+    Cron / timezone are pre-validated at the router (same as the MCP
+    path) so an invalid spec returns 422 with
+    ``error_class="InvalidCron"`` before the upsert runs.
+
+    Note: scheduler registration (``register_digest_subscription``)
+    is intentionally NOT performed here. The HTTP surface persists
+    the row; the next scheduler reconciliation tick picks it up.
+    This keeps the API process decoupled from the bot's APScheduler
+    state and matches the MCP architecture (sprint prompt §2 P-2).
+    """
+    from tg_parser.services.db_context import digest_subscription_repo, workspace_repo
+    from tg_parser.services.digest_service import DigestService
+
+    logger.info(
+        "digests_create",
+        user_id=user.id,
+        name_len=len(request.name),
+        channel_count=len(request.channel_ids),
+        has_workspace_id=request.workspace_id is not None,
+    )
+
+    cron_error = _validate_cron_timezone(request.cron_expression, request.timezone)
+    if cron_error is not None:
+        return _error(422, cron_error, "InvalidCron")
+
+    format_enum = DigestFormat(request.format)
+    language = request.language if request.language is not None else "ru"
+
+    try:
+        async with digest_subscription_repo() as (sub_repo, _db):
+            if request.workspace_id is not None:
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = DigestService(
+                        processed_repo=None,
+                        subscription_repo=sub_repo,
+                        prompt_loader=None,
+                        llm_client_factory=None,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    result = await service.subscribe(
+                        owner_id=user.id,
+                        chat_id=request.chat_id,
+                        name=request.name,
+                        channel_ids=list(request.channel_ids),
+                        cron_expression=request.cron_expression,
+                        timezone=request.timezone,
+                        format=format_enum,
+                        language=language,
+                        workspace_id=request.workspace_id,
+                        is_admin=user.is_admin,
+                    )
+            else:
+                service = DigestService(
+                    processed_repo=None,
+                    subscription_repo=sub_repo,
+                    prompt_loader=None,
+                    llm_client_factory=None,
+                    workspace_repo=None,
+                )
+                result = await service.subscribe(
+                    owner_id=user.id,
+                    chat_id=request.chat_id,
+                    name=request.name,
+                    channel_ids=list(request.channel_ids),
+                    cron_expression=request.cron_expression,
+                    timezone=request.timezone,
+                    format=format_enum,
+                    language=language,
+                    workspace_id=None,
+                    is_admin=user.is_admin,
+                )
+    except WorkspaceNotFound as exc:
+        return _error(404, exc.message, "WorkspaceNotFound")
+
+    return DigestSubscribeResponse(
+        digest_id=str(result.subscription.id),
+        created=result.created,
+        changed_fields=list(result.changed_fields),
+    )
+
+
+@router.get(
+    "",
+    response_model=DigestListResponse,
+    summary="List the caller's digest subscriptions",
+)
+async def list_digests(
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    limit: int = Query(default=50, ge=1, le=200, description="Pagination limit"),
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """List digest subscriptions owned by the caller.
+
+    Pagination is offset/limit at the application layer — the repo
+    returns the full list and the router slices, which keeps memory
+    bounded by ``CurrentUser`` subscription count (operator-scale, not
+    user-scale). Inactive subscriptions are included so the caller
+    can re-subscribe them via the idempotent POST without a separate
+    "deleted" endpoint.
+
+    ``workspace_name`` is JOIN-fetched per Q-OPEN-3: one
+    :class:`WorkspaceRepo.get` per distinct ``workspace_id`` on the
+    page (typically ≤ 5 calls).
+    """
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    logger.info("digests_list", user_id=user.id, offset=offset, limit=limit)
+
+    async with digest_subscription_repo() as (sub_repo, _db):
+        subs = await sub_repo.list_by_owner(user.id)
+
+    total = len(subs)
+    page = subs[offset : offset + limit]
+    workspace_names = await _resolve_workspace_names(page)
+    items = [_digest_to_response(s, workspace_names.get(s.workspace_id or "")) for s in page]
+    return DigestListResponse(items=items, total=total)
+
+
+@router.get(
+    "/{digest_id}",
+    response_model=DigestResponse,
+    summary="Get a single digest subscription",
+)
+async def get_digest(
+    digest_id: str,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Fetch a single digest subscription by id.
+
+    Ownership rules (mirror F4-B Q2 EC2):
+
+    * Caller owns the row → 200 with the full payload (including
+      ``workspace_id`` + ``workspace_name``).
+    * Admin → 200 for ANY row (parity with F4-A admin scope).
+    * Non-admin caller asks for someone else's id → 404, NEVER 403
+      (existence is never leaked).
+    * Unknown id → 404.
+    """
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    logger.info("digests_get", user_id=user.id, digest_id=digest_id)
+
+    async with digest_subscription_repo() as (sub_repo, _db):
+        sub = await sub_repo.get(digest_id)
+
+    if sub is None or (not user.is_admin and sub.owner_id != user.id):
+        return _error(404, f"Digest {digest_id!r} not found", "NotFound")
+
+    workspace_names = await _resolve_workspace_names([sub])
+    return _digest_to_response(sub, workspace_names.get(sub.workspace_id or ""))
+
+
+@router.delete(
+    "/{digest_id}",
+    status_code=204,
+    summary="Delete a digest subscription (HARD delete)",
+)
+async def delete_digest(
+    digest_id: str,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """HARD delete a digest subscription (Q8 digest variant).
+
+    REST-strict per parent Q-OPEN-8 lock — **ASYMMETRIC** vs the
+    P-1 watchlist soft-delete pattern:
+
+    * First DELETE on an own row → ``DigestSubscriptionRepo.delete``
+      physically removes the row, returns 204 with no body.
+    * Second DELETE on the same id → 404 (row no longer exists; we
+      cannot distinguish "deleted by you a moment ago" from "never
+      existed", and per REST-strict that's the correct shape).
+    * Foreign / unknown id → 404, never 403 (existence not leaked).
+
+    Note: scheduler unregistration (``unregister_digest_subscription``)
+    is NOT performed here — same rationale as create: the HTTP
+    process is decoupled from the bot's APScheduler state and the
+    reconciliation tick removes the orphan job within the next cycle.
+    """
+    from tg_parser.services.db_context import digest_subscription_repo
+
+    logger.info("digests_delete", user_id=user.id, digest_id=digest_id)
+
+    async with digest_subscription_repo() as (sub_repo, _db):
+        existing = await sub_repo.get(digest_id)
+        if existing is None or (not user.is_admin and existing.owner_id != user.id):
+            return _error(404, f"Digest {digest_id!r} not found", "NotFound")
+        await sub_repo.delete(digest_id)
+
+    return Response(status_code=204)

--- a/tg_parser/api/routes/watchlists.py
+++ b/tg_parser/api/routes/watchlists.py
@@ -1,0 +1,430 @@
+"""
+Watchlist HTTP API routes (P-1 Surface Parity MVP — Wave 1 step 3 commit 2/4).
+
+Five endpoints under ``/api/v1/watchlists`` per sprint prompt §2:
+
+* ``POST   /api/v1/watchlists``                       — subscribe (idempotent
+  upsert per BUG-022 on the ``(user_id, title)`` natural key; returns
+  ``{watchlist_id, created, changed_fields}`` per Q-OPEN-1).
+* ``GET    /api/v1/watchlists``                       — list current user's
+  interests with offset/limit pagination (default ``limit=50``, max 200).
+* ``GET    /api/v1/watchlists/{watchlist_id}``        — single detail, emits
+  ``workspace_id`` + ``workspace_name`` via a single workspaces JOIN
+  (Q-OPEN-3). Foreign id returns 404-like, NEVER 403 (mirror F4-B).
+* ``DELETE /api/v1/watchlists/{watchlist_id}``        — soft-delete (Q8
+  watchlist variant). 204 No Content; preserves ``watch_matches``.
+  Idempotent: a second DELETE on an already-inactive own row also
+  returns 204 (REST-strict per parent Q-OPEN-8 lock).
+* ``GET    /api/v1/watchlists/{watchlist_id}/matches`` — match history with
+  optional ``?since=ISO8601`` + offset/limit pagination (Q-OPEN-4).
+  Owner-only; soft-deleted interest still serves history.
+
+Authentication piggybacks on the existing ``X-API-Key`` dependency
+(``resolve_current_user``) — no new auth surface (Q1).
+
+Idempotency-Key HTTP middleware is **not** wired in this commit (lands
+in commit 4/4). Service-layer natural-key upsert (commit 1/4) already
+guarantees that same-args POST replays collapse to a single row, so
+this surface is safe for clients today.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import structlog
+from fastapi import APIRouter, Depends, Query, Response
+from fastapi.responses import JSONResponse
+
+from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.schemas import (
+    WatchlistCreateRequest,
+    WatchlistListResponse,
+    WatchlistMatchesResponse,
+    WatchlistMatchItem,
+    WatchlistResponse,
+    WatchlistSubscribeResponse,
+)
+from tg_parser.auth.models import CurrentUser
+from tg_parser.auth.ownership import WorkspaceNotFound
+from tg_parser.domain.models import WatchInterest
+
+router = APIRouter(prefix="/api/v1/watchlists", tags=["Watchlists"])
+logger = structlog.get_logger(__name__)
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+
+def _error(status_code: int, detail: str, error_class: str) -> JSONResponse:
+    """Build a Q7-shaped error response.
+
+    ``{"detail": ..., "error_class": ...}`` is the locked HTTP error
+    shape for this surface (sprint prompt §3 Q7). Centralised here so
+    every endpoint emits an identical body — clients can branch on
+    ``error_class`` to distinguish ``WorkspaceNotFound`` (caller
+    referenced an unknown / foreign workspace) from a plain ``NotFound``
+    (caller referenced an unknown / foreign watchlist) without parsing
+    free-form text.
+    """
+    return JSONResponse(
+        status_code=status_code,
+        content={"detail": detail, "error_class": error_class},
+    )
+
+
+def _interest_to_response(
+    interest: WatchInterest,
+    workspace_name: str | None,
+) -> WatchlistResponse:
+    """Project a domain ``WatchInterest`` onto :class:`WatchlistResponse`.
+
+    Centralises the field mapping (``notify_mode`` Enum → string,
+    ``embedding`` elided, ``workspace_name`` JOIN-injected) so all
+    three GET endpoints (single + list + matches' owner shape) stay
+    in sync.
+    """
+    return WatchlistResponse(
+        id=interest.id,
+        user_id=interest.user_id,
+        chat_id=interest.chat_id,
+        title=interest.title,
+        workspace_id=interest.workspace_id,
+        workspace_name=workspace_name,
+        description=interest.description,
+        keywords=list(interest.keywords),
+        exclude_keywords=list(interest.exclude_keywords),
+        channel_ids=list(interest.channel_ids),
+        threshold=interest.threshold,
+        notify_mode=interest.notify_mode.value,
+        is_active=interest.is_active,
+        last_checked_at=interest.last_checked_at,
+        last_match_at=interest.last_match_at,
+        created_at=interest.created_at,
+        updated_at=interest.updated_at,
+    )
+
+
+async def _resolve_workspace_names(
+    interests: list[WatchInterest],
+) -> dict[str, str]:
+    """Fetch ``workspaces.name`` for every distinct non-NULL ``workspace_id``.
+
+    Performs at most ``N`` ``WorkspaceRepo.get(...)`` calls where ``N``
+    is the count of unique workspace ids on the page — typically 0–5
+    for a paginated list (Q-OPEN-3 ``workspace_name`` JOIN). Returns
+    a dict keyed by ``workspace_id`` so callers can build response
+    objects without juggling per-row queries. Workspaces that were
+    deleted out-of-band (race against ON DELETE SET NULL) silently
+    drop out — the row still renders with ``workspace_name=None``.
+    """
+    distinct_ids: set[str] = {i.workspace_id for i in interests if i.workspace_id is not None}
+    if not distinct_ids:
+        return {}
+
+    from tg_parser.services.db_context import workspace_repo
+
+    names: dict[str, str] = {}
+    async with workspace_repo() as (ws_repo, _db):
+        for wid in distinct_ids:
+            ws = await ws_repo.get(wid)
+            if ws is not None:
+                names[wid] = ws.name
+    return names
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_model=WatchlistSubscribeResponse,
+    status_code=201,
+    summary="Subscribe to a watchlist (idempotent upsert)",
+)
+async def create_watchlist(
+    request: WatchlistCreateRequest,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Create (or idempotently upsert) a watchlist interest.
+
+    Idempotency contract (BUG-022 + Q-OPEN-1):
+
+    * Same ``(user_id, title)`` + identical payload → no-op replay;
+      response carries ``created=False`` and ``changed_fields=[]``.
+    * Same ``(user_id, title)`` + different mutable args → UPDATE
+      the changed columns; response is ``created=False`` with
+      ``changed_fields=[<field names>]``.
+    * New ``(user_id, title)`` → INSERT; ``created=True`` and
+      ``changed_fields=[]``.
+
+    ENH-9: ``workspace_id`` may reference any workspace the caller
+    owns (admin: any workspace). Unknown / foreign UUIDs raise a
+    404-like ``WorkspaceNotFound`` to avoid leaking existence
+    (mirror F4-B Q2 EC2).
+    """
+    from tg_parser.services.db_context import watchlist_repos, workspace_repo
+    from tg_parser.services.watchlist_service import make_watchlist_service
+
+    logger.info(
+        "watchlists_create",
+        user_id=user.id,
+        title_len=len(request.title),
+        channel_count=len(request.channel_ids),
+        has_workspace_id=request.workspace_id is not None,
+    )
+
+    try:
+        async with watchlist_repos() as (
+            interest_repo,
+            match_repo,
+            processed_doc_repo,
+            embedding_repo,
+            _db,
+        ):
+            if request.workspace_id is not None:
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = make_watchlist_service(
+                        interest_repo=interest_repo,
+                        match_repo=match_repo,
+                        processed_doc_repo=processed_doc_repo,
+                        embedding_repo=embedding_repo,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    try:
+                        result = await service.subscribe(
+                            user_id=user.id,
+                            chat_id=request.chat_id,
+                            title=request.title,
+                            channel_ids=request.channel_ids,
+                            keywords=request.keywords,
+                            description=request.description,
+                            exclude_keywords=request.exclude_keywords,
+                            threshold=request.threshold,
+                            workspace_id=request.workspace_id,
+                            is_admin=user.is_admin,
+                        )
+                    finally:
+                        await service.aclose()
+            else:
+                service = make_watchlist_service(
+                    interest_repo=interest_repo,
+                    match_repo=match_repo,
+                    processed_doc_repo=processed_doc_repo,
+                    embedding_repo=embedding_repo,
+                )
+                try:
+                    result = await service.subscribe(
+                        user_id=user.id,
+                        chat_id=request.chat_id,
+                        title=request.title,
+                        channel_ids=request.channel_ids,
+                        keywords=request.keywords,
+                        description=request.description,
+                        exclude_keywords=request.exclude_keywords,
+                        threshold=request.threshold,
+                        workspace_id=None,
+                        is_admin=user.is_admin,
+                    )
+                finally:
+                    await service.aclose()
+    except WorkspaceNotFound as exc:
+        return _error(404, exc.message, "WorkspaceNotFound")
+
+    return WatchlistSubscribeResponse(
+        watchlist_id=str(result.interest.id),
+        created=result.created,
+        changed_fields=list(result.changed_fields),
+    )
+
+
+@router.get(
+    "",
+    response_model=WatchlistListResponse,
+    summary="List the caller's watchlists",
+)
+async def list_watchlists(
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    limit: int = Query(default=50, ge=1, le=200, description="Pagination limit"),
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """List active + paused watchlists owned by the caller.
+
+    Pagination is offset/limit at the application layer — the repo
+    returns the full list and the router slices, which keeps memory
+    bounded by ``CurrentUser`` interest count (operator-scale, not
+    user-scale). Soft-deleted interests are included so the caller
+    can re-subscribe them via the idempotent POST without first
+    listing inactive rows from a separate endpoint.
+
+    ``workspace_name`` is JOIN-fetched per Q-OPEN-3: one
+    :class:`WorkspaceRepo.get` per distinct ``workspace_id`` on the
+    page (typically ≤ 5 calls).
+    """
+    from tg_parser.services.db_context import watchlist_repos
+
+    logger.info("watchlists_list", user_id=user.id, offset=offset, limit=limit)
+
+    async with watchlist_repos() as (
+        interest_repo,
+        _match_repo,
+        _proc_repo,
+        _emb_repo,
+        _db,
+    ):
+        interests = await interest_repo.list_for_user(user.id)
+
+    total = len(interests)
+    page = interests[offset : offset + limit]
+    workspace_names = await _resolve_workspace_names(page)
+    items = [_interest_to_response(i, workspace_names.get(i.workspace_id or "")) for i in page]
+    return WatchlistListResponse(items=items, total=total)
+
+
+@router.get(
+    "/{watchlist_id}",
+    response_model=WatchlistResponse,
+    summary="Get a single watchlist",
+)
+async def get_watchlist(
+    watchlist_id: str,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Fetch a single watchlist by id.
+
+    Ownership rules (mirror F4-B Q2 EC2):
+
+    * Caller owns the row → 200 with the full payload (including
+      ``workspace_id`` + ``workspace_name``).
+    * Admin → 200 for ANY row (parity with F4-A admin scope).
+    * Non-admin caller asks for someone else's id → 404, NEVER 403
+      (existence is never leaked).
+    * Unknown id → 404.
+    """
+    from tg_parser.services.db_context import watchlist_repos
+
+    logger.info("watchlists_get", user_id=user.id, watchlist_id=watchlist_id)
+
+    async with watchlist_repos() as (
+        interest_repo,
+        _match_repo,
+        _proc_repo,
+        _emb_repo,
+        _db,
+    ):
+        interest = await interest_repo.get(watchlist_id)
+
+    if interest is None or (not user.is_admin and interest.user_id != user.id):
+        return _error(404, f"Watchlist {watchlist_id!r} not found", "NotFound")
+
+    workspace_names = await _resolve_workspace_names([interest])
+    return _interest_to_response(interest, workspace_names.get(interest.workspace_id or ""))
+
+
+@router.delete(
+    "/{watchlist_id}",
+    status_code=204,
+    summary="Soft-delete a watchlist (idempotent)",
+)
+async def delete_watchlist(
+    watchlist_id: str,
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Soft-delete a watchlist (Q8 watchlist variant).
+
+    REST-strict idempotency per parent Q-OPEN-8 lock:
+
+    * First DELETE on an active own row → flips ``is_active=False``,
+      returns 204 with no body. ``watch_matches`` rows are preserved
+      (the matches endpoint continues to serve history).
+    * Second DELETE on the same already-inactive row → 204 (no-op).
+    * Foreign / unknown id → 404, never 403 (existence not leaked).
+    """
+    from tg_parser.services.db_context import watchlist_repos
+
+    logger.info("watchlists_delete", user_id=user.id, watchlist_id=watchlist_id)
+
+    async with watchlist_repos() as (
+        interest_repo,
+        _match_repo,
+        _proc_repo,
+        _emb_repo,
+        _db,
+    ):
+        existing = await interest_repo.get(watchlist_id)
+        if existing is None or (not user.is_admin and existing.user_id != user.id):
+            return _error(404, f"Watchlist {watchlist_id!r} not found", "NotFound")
+        if existing.is_active:
+            await interest_repo.soft_delete(watchlist_id)
+
+    return Response(status_code=204)
+
+
+@router.get(
+    "/{watchlist_id}/matches",
+    response_model=WatchlistMatchesResponse,
+    summary="Get match history for a watchlist",
+)
+async def get_watchlist_matches(
+    watchlist_id: str,
+    since: datetime | None = Query(
+        default=None,
+        description="ISO-8601 cutoff; only matches with created_at > since are returned",
+    ),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    limit: int = Query(default=50, ge=1, le=200, description="Pagination limit"),
+    user: CurrentUser = Depends(resolve_current_user),
+):
+    """Return ``WatchMatch`` rows for a watchlist (owner-only).
+
+    Visibility mirrors :func:`get_watchlist`: caller must own the
+    interest (admin bypasses). Soft-deleted interests still serve
+    history — by design (Q8 watchlist variant), so historical
+    analytics keep working after an unsubscribe.
+
+    ``?since=ISO8601`` is a strict ``>`` filter on ``created_at``
+    (parsed by FastAPI / Pydantic from the query string). Q-OPEN-4
+    locks ``since`` + offset/limit as the *only* filters for v1; any
+    richer filtering (score range, channel filter, …) is intentionally
+    deferred so the surface stays minimal.
+    """
+    from tg_parser.services.db_context import watchlist_repos
+
+    logger.info(
+        "watchlists_matches",
+        user_id=user.id,
+        watchlist_id=watchlist_id,
+        since=since.isoformat() if since else None,
+        offset=offset,
+        limit=limit,
+    )
+
+    async with watchlist_repos() as (
+        interest_repo,
+        match_repo,
+        _proc_repo,
+        _emb_repo,
+        _db,
+    ):
+        existing = await interest_repo.get(watchlist_id)
+        if existing is None or (not user.is_admin and existing.user_id != user.id):
+            return _error(404, f"Watchlist {watchlist_id!r} not found", "NotFound")
+        matches = await match_repo.list_for_interest(watchlist_id, since=since)
+
+    total = len(matches)
+    page = matches[offset : offset + limit]
+    items = [
+        WatchlistMatchItem(
+            match_id=m.id,
+            interest_id=m.interest_id,
+            source_ref=m.source_ref,
+            channel_id=m.channel_id,
+            keyword_score=m.keyword_score,
+            semantic_score=m.semantic_score,
+            combined_score=m.combined_score,
+            notified=m.notified,
+            created_at=m.created_at,
+        )
+        for m in page
+    ]
+    return WatchlistMatchesResponse(items=items, total=total)

--- a/tg_parser/api/routes/watchlists.py
+++ b/tg_parser/api/routes/watchlists.py
@@ -37,6 +37,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
 
 from tg_parser.api.auth import resolve_current_user
+from tg_parser.api.idempotency import IdempotencyContext, idempotency_key_check
 from tg_parser.api.schemas import (
     WatchlistCreateRequest,
     WatchlistListResponse,
@@ -145,6 +146,7 @@ async def _resolve_workspace_names(
 async def create_watchlist(
     request: WatchlistCreateRequest,
     user: CurrentUser = Depends(resolve_current_user),
+    idempotency: IdempotencyContext | None = Depends(idempotency_key_check),
 ):
     """Create (or idempotently upsert) a watchlist interest.
 
@@ -162,9 +164,23 @@ async def create_watchlist(
     owns (admin: any workspace). Unknown / foreign UUIDs raise a
     404-like ``WorkspaceNotFound`` to avoid leaking existence
     (mirror F4-B Q2 EC2).
+
+    Idempotency-Key middleware (ADR 0009 Option C): when the client
+    sends an ``Idempotency-Key`` header, a same-key + same-body retry
+    returns the cached 2xx response verbatim (no second DB write);
+    same-key + different body raises 422 ``IdempotencyKeyMismatch``.
+    Absence of the header is fully supported (service-layer natural-key
+    upsert already collapses replays).
     """
     from tg_parser.services.db_context import watchlist_repos, workspace_repo
     from tg_parser.services.watchlist_service import make_watchlist_service
+
+    if (
+        idempotency is not None
+        and idempotency.status == "hit"
+        and idempotency.cached_body is not None
+    ):
+        return idempotency.build_cached_response()
 
     logger.info(
         "watchlists_create",
@@ -231,11 +247,16 @@ async def create_watchlist(
     except WorkspaceNotFound as exc:
         return _error(404, exc.message, "WorkspaceNotFound")
 
-    return WatchlistSubscribeResponse(
-        watchlist_id=str(result.interest.id),
-        created=result.created,
-        changed_fields=list(result.changed_fields),
-    )
+    response_body = {
+        "watchlist_id": str(result.interest.id),
+        "created": result.created,
+        "changed_fields": list(result.changed_fields),
+    }
+
+    if idempotency is not None:
+        await idempotency.store(body=response_body, status_code=201)
+
+    return WatchlistSubscribeResponse(**response_body)
 
 
 @router.get(

--- a/tg_parser/api/schemas.py
+++ b/tg_parser/api/schemas.py
@@ -38,6 +38,12 @@ __all__ = [
     "ExportRequest",
     "ExportResponse",
     "ErrorResponse",
+    "WatchlistCreateRequest",
+    "WatchlistSubscribeResponse",
+    "WatchlistResponse",
+    "WatchlistListResponse",
+    "WatchlistMatchItem",
+    "WatchlistMatchesResponse",
 ]
 
 
@@ -226,3 +232,142 @@ class ErrorResponse(BaseModel):
     error: str = Field(description="Error type")
     message: str = Field(description="Error message")
     details: dict[str, Any] | None = Field(default=None, description="Additional error details")
+
+
+# ============================================================================
+# Watchlist (P-1 Surface Parity MVP — Wave 1 step 3 commit 2/4)
+# ============================================================================
+#
+# Schemas mirror the F11 ``WatchInterest`` / ``WatchMatch`` domain models
+# (see :mod:`tg_parser.domain.models`) while keeping the public HTTP
+# surface decoupled from the storage layer. They live in this flat
+# ``schemas.py`` module per Q7 (sprint prompt §3) — no ``schemas/``
+# package split. The Q-OPEN-3 contract requires the GET responses to
+# emit ``workspace_id`` *plus* ``workspace_name`` (single JOIN at the
+# router level), so :class:`WatchlistResponse` carries both.
+
+
+class WatchlistCreateRequest(BaseModel):
+    """POST /api/v1/watchlists request body.
+
+    Mirrors :class:`tg_parser.domain.models.WatchInterest` with the
+    request-side defaults locked by Wave 1 step 3 §3 Q-locks:
+
+    * ``title`` — natural key for the (user_id, title) idempotent upsert
+      (BUG-022); min_length matches the domain validator so a blank
+      payload surfaces as a 422 at the HTTP boundary.
+    * ``channel_ids`` — non-empty (min_length=1) to mirror the domain
+      ``_channel_ids_nonempty`` validator; an empty list returns 422
+      rather than a 500 from the service layer.
+    * ``chat_id`` — Q6 lock: int only (polymorphic targets deferred).
+    * ``workspace_id`` — ENH-9: optional FK to a workspace owned by the
+      caller (admin: any workspace). Unknown / foreign → 404-like
+      ``WorkspaceNotFound`` at the service layer.
+    """
+
+    title: str = Field(min_length=1, max_length=300, description="Short human label")
+    channel_ids: list[str] = Field(
+        min_length=1,
+        description="Channels to watch (non-empty, mirrors domain constraint)",
+    )
+    chat_id: int = Field(description="Telegram chat_id for notification delivery")
+    keywords: list[str] = Field(default_factory=list, description="Positive keywords")
+    description: str | None = Field(default=None, description="Free-form description")
+    exclude_keywords: list[str] = Field(
+        default_factory=list, description="Negative filter — any match zeroes the score"
+    )
+    threshold: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description="Combined-score cutoff (default 0.6)",
+    )
+    workspace_id: str | None = Field(
+        default=None,
+        description="Optional workspace context FK (ENH-9)",
+    )
+
+
+class WatchlistSubscribeResponse(BaseModel):
+    """POST response per Q-OPEN-1 / Q7 (sprint prompt §3).
+
+    Same-args replay → ``created=False, changed_fields=[]``.
+    Same key with different args → ``created=False`` and
+    ``changed_fields`` lists the Pydantic field names that the
+    service layer rewrote on the existing row (subset of
+    ``WatchInterest`` fields like ``keywords``, ``threshold``,
+    ``workspace_id`` …).
+    """
+
+    watchlist_id: str = Field(description="Server-assigned interest UUID")
+    created: bool = Field(description="True on first INSERT; False on idempotent replay/update")
+    changed_fields: list[str] = Field(
+        default_factory=list,
+        description="Pydantic field names rewritten on upsert; empty on no-op replay",
+    )
+
+
+class WatchlistResponse(BaseModel):
+    """GET single response — full ``WatchInterest`` shape minus ``embedding``.
+
+    Per Q-OPEN-3 emits both ``workspace_id`` and ``workspace_name``
+    (the latter from a single ``workspaces.name`` JOIN at the router
+    layer). ``workspace_name`` is ``null`` when ``workspace_id`` is
+    NULL (pre-ENH-9 rows + un-scoped interests).
+
+    The 1536-dim ``embedding`` is intentionally elided from the HTTP
+    surface — it bloats the payload, is opaque to clients, and the
+    service layer manages it lazily.
+    """
+
+    id: str
+    user_id: str
+    chat_id: int
+    title: str
+    workspace_id: str | None = None
+    workspace_name: str | None = None
+    description: str | None = None
+    keywords: list[str]
+    exclude_keywords: list[str]
+    channel_ids: list[str]
+    threshold: float
+    notify_mode: str = Field(description="``instant`` | ``batch`` | ``silent``")
+    is_active: bool
+    last_checked_at: datetime | None = None
+    last_match_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WatchlistListResponse(BaseModel):
+    """GET list response (Q7 — ``{items, total}`` envelope)."""
+
+    items: list[WatchlistResponse]
+    total: int = Field(ge=0, description="Total interests for the caller (pre-pagination)")
+
+
+class WatchlistMatchItem(BaseModel):
+    """Single ``WatchMatch`` row projection for the matches endpoint.
+
+    Mirrors the domain ``WatchMatch`` model. ``match_id`` is the
+    underlying ``BIGSERIAL`` surfaced as a string so the JSON contract
+    stays language-agnostic; downstream typed clients deserialise it
+    back to an integer if they want one.
+    """
+
+    match_id: int = Field(description="BIGSERIAL row id from ``watch_matches``")
+    interest_id: str
+    source_ref: str
+    channel_id: str
+    keyword_score: float = Field(ge=0.0, le=1.0)
+    semantic_score: float = Field(ge=0.0, le=1.0)
+    combined_score: float = Field(ge=0.0, le=1.0)
+    notified: bool
+    created_at: datetime
+
+
+class WatchlistMatchesResponse(BaseModel):
+    """GET matches response (Q-OPEN-4 — ``?since=`` + offset/limit pagination)."""
+
+    items: list[WatchlistMatchItem]
+    total: int = Field(ge=0, description="Total matches for the interest (after ``since`` filter)")

--- a/tg_parser/api/schemas.py
+++ b/tg_parser/api/schemas.py
@@ -4,7 +4,7 @@ Pydantic schemas for HTTP API requests and responses.
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -44,6 +44,10 @@ __all__ = [
     "WatchlistListResponse",
     "WatchlistMatchItem",
     "WatchlistMatchesResponse",
+    "DigestCreateRequest",
+    "DigestSubscribeResponse",
+    "DigestResponse",
+    "DigestListResponse",
 ]
 
 
@@ -371,3 +375,137 @@ class WatchlistMatchesResponse(BaseModel):
 
     items: list[WatchlistMatchItem]
     total: int = Field(ge=0, description="Total matches for the interest (after ``since`` filter)")
+
+
+# ============================================================================
+# Digest (P-2 Surface Parity MVP — Wave 1 step 3 commit 3/4)
+# ============================================================================
+#
+# Schemas mirror the F6 ``DigestSubscription`` domain model (see
+# :mod:`tg_parser.domain.models`). Asymmetries vs the watchlist surface
+# (sprint prompt §3 Q6 + Q8):
+#
+# * **Label field is ``name``**, not ``title`` — domain pin.
+# * **DELETE semantics is HARD DELETE** — the second DELETE on the same
+#   id returns 404 (REST-strict per parent Q-OPEN-8 lock). The HTTP
+#   surface inherits this asymmetry from :meth:`DigestSubscriptionRepo.delete`
+#   which physically removes the row (no ``is_active`` flip).
+#
+# Q-OPEN-3 contract is identical to P-1: GET responses emit
+# ``workspace_id`` *plus* ``workspace_name`` (single JOIN at the router
+# level). ``language`` is intentionally exposed nullable on the request
+# (``str | None``) so the service-layer default (``"ru"``) flows through
+# untouched when the caller omits it; the response always carries the
+# stored value (never NULL — the column has a NOT NULL default).
+
+
+class DigestCreateRequest(BaseModel):
+    """POST /api/v1/digests request body.
+
+    Mirrors :class:`tg_parser.domain.models.DigestSubscription` with the
+    request-side defaults locked by Wave 1 step 3 §3 Q-locks:
+
+    * ``name`` — natural key for the (owner_id, name) idempotent upsert
+      (BUG-022); min_length matches the domain validator so a blank
+      payload surfaces as a 422 at the HTTP boundary.
+    * ``channel_ids`` — non-empty (min_length=1) to mirror the domain
+      ``_channel_ids_nonempty`` validator; an empty list returns 422
+      rather than a 500 from the service layer.
+    * ``chat_id`` — Q6 lock: int only (polymorphic targets deferred).
+    * ``format`` — Literal narrows the input to the three
+      :class:`DigestFormat` values so an unknown enum surfaces as 422
+      before reaching the service layer.
+    * ``language`` — nullable: ``None`` lets the service fall back to
+      its own default (``"ru"``) instead of forcing the client to
+      hardcode a locale.
+    * ``cron_expression`` / ``timezone`` — pre-validated at the router
+      layer (mirror of the MCP tool path) so an invalid spec returns
+      422 *before* the upsert runs and never leaves a half-written row
+      behind.
+    * ``workspace_id`` — ENH-9: optional FK to a workspace owned by the
+      caller (admin: any workspace). Unknown / foreign → 404-like
+      ``WorkspaceNotFound`` at the service layer.
+    """
+
+    name: str = Field(min_length=1, max_length=200, description="Human label (natural key)")
+    channel_ids: list[str] = Field(
+        min_length=1,
+        description="Channels to digest (non-empty, mirrors domain constraint)",
+    )
+    chat_id: int = Field(description="Telegram chat_id for digest delivery")
+    cron_expression: str = Field(
+        default="0 9 * * *",
+        max_length=100,
+        description="Standard 5-field cron expression evaluated in ``timezone``",
+    )
+    timezone: str = Field(
+        default="UTC",
+        max_length=50,
+        description="IANA timezone name (e.g. ``Europe/Moscow``)",
+    )
+    format: Literal["summary", "bullets", "detailed"] = Field(
+        default="summary",
+        description="Output style",
+    )
+    language: str | None = Field(
+        default=None,
+        max_length=10,
+        description="Output language code; ``None`` defers to the service default",
+    )
+    workspace_id: str | None = Field(
+        default=None,
+        description="Optional workspace context FK (ENH-9)",
+    )
+
+
+class DigestSubscribeResponse(BaseModel):
+    """POST response per Q-OPEN-1 / Q7 (sprint prompt §3).
+
+    Note the label is ``digest_id`` (Q6 asymmetry vs the watchlist
+    surface's ``watchlist_id``). Same-args replay →
+    ``created=False, changed_fields=[]``; same key + different args →
+    ``created=False`` with ``changed_fields`` listing the
+    :class:`DigestSubscription` field names rewritten on the existing
+    row.
+    """
+
+    digest_id: str = Field(description="Server-assigned subscription UUID")
+    created: bool = Field(description="True on first INSERT; False on idempotent replay/update")
+    changed_fields: list[str] = Field(
+        default_factory=list,
+        description="DigestSubscription field names rewritten on upsert; empty on no-op replay",
+    )
+
+
+class DigestResponse(BaseModel):
+    """GET single response — full ``DigestSubscription`` shape + ``workspace_name``.
+
+    Per Q-OPEN-3 emits both ``workspace_id`` and ``workspace_name``
+    (the latter from a single ``workspaces.name`` JOIN at the router
+    layer). ``workspace_name`` is ``null`` when ``workspace_id`` is
+    NULL (pre-ENH-9 rows + un-scoped subscriptions).
+    """
+
+    id: str
+    owner_id: str
+    chat_id: int
+    name: str
+    workspace_id: str | None = None
+    workspace_name: str | None = None
+    channel_ids: list[str]
+    cron_expression: str
+    timezone: str
+    format: str = Field(description="``summary`` | ``bullets`` | ``detailed``")
+    language: str
+    is_active: bool
+    last_sent_at: datetime | None = None
+    last_digest_cursor: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DigestListResponse(BaseModel):
+    """GET list response (Q7 — ``{items, total}`` envelope)."""
+
+    items: list[DigestResponse]
+    total: int = Field(ge=0, description="Total subscriptions for the caller (pre-pagination)")

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -688,6 +688,14 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
                     "type": "STRING",
                     "description": "Output language code (default 'ru')",
                 },
+                "workspace_id": {
+                    "type": "STRING",
+                    "description": (
+                        "Optional workspace UUID context (ENH-9). NULL by default; "
+                        "valid only when the caller owns the workspace (admin: any). "
+                        "Unknown / foreign workspace_id raises WorkspaceNotFound."
+                    ),
+                },
             },
             "required": ["name", "channel_ids"],
         },
@@ -764,6 +772,14 @@ TOOL_DECLARATIONS: list[dict[str, Any]] = [
                 "threshold": {
                     "type": "NUMBER",
                     "description": "Combined-score cutoff in [0, 1] (default 0.6)",
+                },
+                "workspace_id": {
+                    "type": "STRING",
+                    "description": (
+                        "Optional workspace UUID context (ENH-9). NULL by default; "
+                        "valid only when the caller owns the workspace (admin: any). "
+                        "Unknown / foreign workspace_id raises WorkspaceNotFound."
+                    ),
                 },
             },
             "required": ["title", "channel_ids"],
@@ -2361,23 +2377,33 @@ async def _exec_subscribe_digest(
     bot: Bot | None = None,
     chat_id: int | None = None,
 ) -> dict[str, Any]:
-    """Create a new digest subscription and register it with the scheduler.
+    """Create or update a digest subscription and register the scheduler job.
 
     The subscription is owned by ``current_user`` and delivered to the
     current chat (``chat_id`` from the message context). Each ``channel_id``
-    must be accessible by the user (``assert_channel_access``). Cron
-    expression and timezone are validated by the scheduler before persisting
-    so an invalid spec yields a clean error rather than a half-saved row.
+    must be accessible by the user (``assert_channel_access``).
+
+    Wave 1 step 3 (BUG-022 + ENH-9):
+    - Idempotent on ``(owner_id, name)``; re-running the tool with the same
+      ``name`` updates the existing subscription.
+    - Optional ``workspace_id`` arg validated against the caller's workspaces;
+      ``WorkspaceNotFound`` returns a 404-like error.
     """
-    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.auth.ownership import (
+        PermissionDenied,
+        WorkspaceNotFound,
+        assert_channel_access,
+    )
     from tg_parser.auth.resolvers import get_default_admin
     from tg_parser.config import settings
-    from tg_parser.domain.models import DigestFormat, DigestSubscription
+    from tg_parser.domain.models import DigestFormat
     from tg_parser.services.background_scheduler import (
         get_scheduler,
         register_digest_subscription,
+        unregister_digest_subscription,
     )
-    from tg_parser.services.db_context import digest_subscription_repo
+    from tg_parser.services.db_context import digest_subscription_repo, workspace_repo
+    from tg_parser.services.digest_service import DigestService
 
     user = current_user or await get_default_admin()
 
@@ -2405,6 +2431,12 @@ async def _exec_subscribe_digest(
     timezone = (args.get("timezone") or settings.digest_default_timezone or "UTC").strip()
     format_raw = (args.get("format") or "summary").strip()
     language = (args.get("language") or "ru").strip()
+    workspace_id_arg = args.get("workspace_id")
+    workspace_id: str | None = (
+        workspace_id_arg.strip()
+        if isinstance(workspace_id_arg, str) and workspace_id_arg.strip()
+        else None
+    )
 
     try:
         format_enum = DigestFormat(format_raw)
@@ -2416,50 +2448,95 @@ async def _exec_subscribe_digest(
             )
         }
 
-    import uuid as _uuid
-    from datetime import UTC as _UTC
-    from datetime import datetime as _dt
+    # Pre-validate cron/timezone before the DB write so a bad spec
+    # never leaves a half-written row behind (mirrors the legacy
+    # contract pre Wave 1 step 3).
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-    subscription = DigestSubscription(
-        id=str(_uuid.uuid4()),
-        owner_id=user.id,
-        chat_id=chat_id,
-        name=name,
-        channel_ids=channel_ids,
-        cron_expression=cron_expression,
-        timezone=timezone,
-        format=format_enum,
-        language=language,
-        is_active=True,
-        last_sent_at=None,
-        last_digest_cursor=None,
-        created_at=_dt.now(_UTC),
-        updated_at=_dt.now(_UTC),
-    )
+        from apscheduler.triggers.cron import CronTrigger
+
+        try:
+            CronTrigger.from_crontab(cron_expression, timezone=ZoneInfo(timezone))
+        except (ValueError, ZoneInfoNotFoundError) as exc:
+            return {
+                "error": (
+                    f"cron/timezone validation failed: invalid cron task spec "
+                    f"({cron_expression!r} / tz={timezone!r}): {exc}"
+                )
+            }
+    except ImportError:
+        logger.debug("subscribe_digest_cron_prevalidate_skipped", exc_info=True)
 
     try:
-        register_digest_subscription(subscription, get_scheduler())
-    except ValueError as exc:
-        return {"error": f"cron/timezone validation failed: {exc}"}
-
-    try:
-        async with digest_subscription_repo() as (repo, _db):
-            created = await repo.create(subscription)
+        async with digest_subscription_repo() as (sub_repo, _db):
+            if workspace_id is not None:
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = DigestService(
+                        processed_repo=None,
+                        subscription_repo=sub_repo,
+                        prompt_loader=None,
+                        llm_client_factory=None,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    result = await service.subscribe(
+                        owner_id=user.id,
+                        chat_id=chat_id,
+                        name=name,
+                        channel_ids=channel_ids,
+                        cron_expression=cron_expression,
+                        timezone=timezone,
+                        format=format_enum,
+                        language=language,
+                        workspace_id=workspace_id,
+                        is_admin=user.is_admin,
+                    )
+            else:
+                service = DigestService(
+                    processed_repo=None,
+                    subscription_repo=sub_repo,
+                    prompt_loader=None,
+                    llm_client_factory=None,
+                    workspace_repo=None,
+                )
+                result = await service.subscribe(
+                    owner_id=user.id,
+                    chat_id=chat_id,
+                    name=name,
+                    channel_ids=channel_ids,
+                    cron_expression=cron_expression,
+                    timezone=timezone,
+                    format=format_enum,
+                    language=language,
+                    workspace_id=None,
+                    is_admin=user.is_admin,
+                )
+    except WorkspaceNotFound as exc:
+        return {"error": exc.message, "workspace_id": workspace_id}
     except Exception as exc:
-        from tg_parser.services.background_scheduler import unregister_digest_subscription
-
-        unregister_digest_subscription(subscription.id)
         logger.exception("subscribe_digest_persist_failed")
         return {"error": f"failed to persist subscription: {exc}"}
 
+    created_sub = result.subscription
+    try:
+        unregister_digest_subscription(created_sub.id)
+    except Exception:
+        logger.debug("subscribe_digest_unregister_pre_register_failed", exc_info=True)
+    try:
+        register_digest_subscription(created_sub, get_scheduler())
+    except ValueError as exc:
+        return {"error": f"cron/timezone validation failed: {exc}"}
+
     if bot is not None:
+        verb_ru = "создана" if result.created else "обновлена"
         try:
             await bot.send_message(
                 chat_id=chat_id,
                 text=(
-                    f"📰 Подписка <b>{created.name}</b> создана. "
-                    f"Расписание: <code>{created.cron_expression}</code> ({created.timezone}). "
-                    f"Каналов: {len(created.channel_ids)}."
+                    f"📰 Подписка <b>{created_sub.name}</b> {verb_ru}. "
+                    f"Расписание: <code>{created_sub.cron_expression}</code> "
+                    f"({created_sub.timezone}). "
+                    f"Каналов: {len(created_sub.channel_ids)}."
                 ),
                 parse_mode="HTML",
             )
@@ -2467,15 +2544,19 @@ async def _exec_subscribe_digest(
             logger.debug("subscribe_digest_confirmation_failed", exc_info=True)
 
     return {
-        "subscription_id": created.id,
-        "name": created.name,
-        "chat_id": created.chat_id,
-        "channel_ids": created.channel_ids,
-        "cron_expression": created.cron_expression,
-        "timezone": created.timezone,
-        "format": created.format.value,
-        "language": created.language,
-        "is_active": created.is_active,
+        "subscription_id": created_sub.id,
+        "digest_id": created_sub.id,
+        "name": created_sub.name,
+        "chat_id": created_sub.chat_id,
+        "channel_ids": created_sub.channel_ids,
+        "cron_expression": created_sub.cron_expression,
+        "timezone": created_sub.timezone,
+        "format": created_sub.format.value,
+        "language": created_sub.language,
+        "is_active": created_sub.is_active,
+        "workspace_id": created_sub.workspace_id,
+        "created": result.created,
+        "changed_fields": list(result.changed_fields),
     }
 
 
@@ -2587,6 +2668,7 @@ def _watch_interest_to_dict(interest: Any) -> dict[str, Any]:
         "threshold": interest.threshold,
         "notify_mode": interest.notify_mode.value,
         "is_active": interest.is_active,
+        "workspace_id": getattr(interest, "workspace_id", None),
         "last_checked_at": (
             interest.last_checked_at.isoformat() if interest.last_checked_at else None
         ),
@@ -2614,16 +2696,26 @@ async def _exec_subscribe_watchlist(
     bot: Bot | None = None,
     chat_id: int | None = None,
 ) -> dict[str, Any]:
-    """Create a F11 Topic Watchlist interest from the bot context.
+    """Create or update a F11 Topic Watchlist interest from the bot context.
 
     The chat_id is taken from the message context (so the bot delivers
     notifications back to the same chat the user typed from). Each
     channel_id is checked via ``assert_channel_access`` so non-admins
     cannot subscribe to channels they do not own.
+
+    Wave 1 step 3 (BUG-022 + ENH-9):
+    - Idempotent on ``(user_id, title)``; re-running the tool with the
+      same ``title`` updates the existing interest.
+    - Optional ``workspace_id`` arg validated against the caller's
+      workspaces; ``WorkspaceNotFound`` returns a 404-like error.
     """
-    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
+    from tg_parser.auth.ownership import (
+        PermissionDenied,
+        WorkspaceNotFound,
+        assert_channel_access,
+    )
     from tg_parser.auth.resolvers import get_default_admin
-    from tg_parser.services.db_context import watchlist_repos
+    from tg_parser.services.db_context import watchlist_repos, workspace_repo
     from tg_parser.services.watchlist_service import make_watchlist_service
 
     user = current_user or await get_default_admin()
@@ -2658,6 +2750,13 @@ async def _exec_subscribe_watchlist(
         except PermissionDenied as exc:
             return {"error": exc.message, "channel_id": cid}
 
+    workspace_id_arg = args.get("workspace_id")
+    workspace_id: str | None = (
+        workspace_id_arg.strip()
+        if isinstance(workspace_id_arg, str) and workspace_id_arg.strip()
+        else None
+    )
+
     try:
         async with watchlist_repos() as (
             interest_repo,
@@ -2666,43 +2765,80 @@ async def _exec_subscribe_watchlist(
             embedding_repo,
             _db,
         ):
-            service = make_watchlist_service(
-                interest_repo=interest_repo,
-                match_repo=match_repo,
-                processed_doc_repo=processed_doc_repo,
-                embedding_repo=embedding_repo,
-            )
-            try:
-                created = await service.create_interest(
-                    user_id=user.id,
-                    chat_id=chat_id,
-                    title=title,
-                    channel_ids=channel_ids,
-                    keywords=list(args.get("keywords") or []),
-                    description=args.get("description"),
-                    exclude_keywords=list(args.get("exclude_keywords") or []),
-                    threshold=threshold,
+            if workspace_id is not None:
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = make_watchlist_service(
+                        interest_repo=interest_repo,
+                        match_repo=match_repo,
+                        processed_doc_repo=processed_doc_repo,
+                        embedding_repo=embedding_repo,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    try:
+                        result = await service.subscribe(
+                            user_id=user.id,
+                            chat_id=chat_id,
+                            title=title,
+                            channel_ids=channel_ids,
+                            keywords=list(args.get("keywords") or []),
+                            description=args.get("description"),
+                            exclude_keywords=list(args.get("exclude_keywords") or []),
+                            threshold=threshold,
+                            workspace_id=workspace_id,
+                            is_admin=user.is_admin,
+                        )
+                    finally:
+                        await service.aclose()
+            else:
+                service = make_watchlist_service(
+                    interest_repo=interest_repo,
+                    match_repo=match_repo,
+                    processed_doc_repo=processed_doc_repo,
+                    embedding_repo=embedding_repo,
                 )
-            finally:
-                await service.aclose()
+                try:
+                    result = await service.subscribe(
+                        user_id=user.id,
+                        chat_id=chat_id,
+                        title=title,
+                        channel_ids=channel_ids,
+                        keywords=list(args.get("keywords") or []),
+                        description=args.get("description"),
+                        exclude_keywords=list(args.get("exclude_keywords") or []),
+                        threshold=threshold,
+                        workspace_id=None,
+                        is_admin=user.is_admin,
+                    )
+                finally:
+                    await service.aclose()
+    except WorkspaceNotFound as exc:
+        return {"error": exc.message, "workspace_id": workspace_id}
     except Exception as exc:
         logger.exception("subscribe_watchlist_persist_failed")
         return {"error": f"failed to persist interest: {exc}"}
 
+    created_interest = result.interest
     if bot is not None:
+        verb_ru = "создан" if result.created else "обновлён"
         try:
             await bot.send_message(
                 chat_id=chat_id,
                 text=(
-                    f"🔔 Watchlist <b>{created.title}</b> создан.\n"
-                    f"Каналов: {len(created.channel_ids)}, threshold: {created.threshold}."
+                    f"🔔 Watchlist <b>{created_interest.title}</b> {verb_ru}.\n"
+                    f"Каналов: {len(created_interest.channel_ids)}, "
+                    f"threshold: {created_interest.threshold}."
                 ),
                 parse_mode="HTML",
             )
         except Exception:
             logger.debug("subscribe_watchlist_confirmation_failed", exc_info=True)
 
-    return _watch_interest_to_dict(created)
+    out = _watch_interest_to_dict(created_interest)
+    out["watchlist_id"] = created_interest.id
+    out["created"] = result.created
+    out["changed_fields"] = list(result.changed_fields)
+    out["workspace_id"] = created_interest.workspace_id
+    return out
 
 
 async def _exec_list_watchlists(

--- a/tg_parser/cli/watchlist_cmd.py
+++ b/tg_parser/cli/watchlist_cmd.py
@@ -119,8 +119,16 @@ def add(
         "--user",
         help="UUID of the user that owns the interest (default: system admin)",
     ),
+    workspace_id: str = typer.Option(
+        None,
+        "--workspace-id",
+        help=(
+            "Optional workspace UUID context (ENH-9). Validated against the "
+            "acting user's workspaces; admin can pass any UUID."
+        ),
+    ),
 ) -> None:
-    """Create a new Topic Watchlist interest."""
+    """Create or update a Topic Watchlist interest (idempotent on (user, title))."""
     if threshold < 0.0 or threshold > 1.0:
         typer.echo(f"❌ threshold must be in [0.0, 1.0], got {threshold}", err=True)
         raise typer.Exit(code=1)
@@ -133,9 +141,11 @@ def add(
     keyword_list = _split_csv(keywords)
     exclude_list = _split_csv(exclude_keywords)
     description_arg = description.strip() or None
+    workspace_arg = (workspace_id or "").strip() or None
 
     async def _run() -> Any:
-        from tg_parser.services.db_context import watchlist_repos
+        from tg_parser.auth.ownership import WorkspaceNotFound
+        from tg_parser.services.db_context import watchlist_repos, workspace_repo
         from tg_parser.services.watchlist_service import make_watchlist_service
         from tg_parser.storage.sqlalchemy.database import Database
 
@@ -148,6 +158,32 @@ def add(
                 embedding_repo,
                 _db,
             ):
+                if workspace_arg is not None:
+                    async with workspace_repo() as (ws_repo_inst, _db2):
+                        service = make_watchlist_service(
+                            interest_repo=interest_repo,
+                            match_repo=match_repo,
+                            processed_doc_repo=processed_doc_repo,
+                            embedding_repo=embedding_repo,
+                            workspace_repo=ws_repo_inst,
+                        )
+                        try:
+                            return await service.subscribe(
+                                user_id=acting.id,
+                                chat_id=chat_id,
+                                title=title.strip(),
+                                channel_ids=channel_list,
+                                keywords=keyword_list,
+                                description=description_arg,
+                                exclude_keywords=exclude_list,
+                                threshold=threshold,
+                                workspace_id=workspace_arg,
+                                is_admin=acting.is_admin,
+                            )
+                        except WorkspaceNotFound as exc:
+                            raise typer.BadParameter(exc.message) from exc
+                        finally:
+                            await service.aclose()
                 service = make_watchlist_service(
                     interest_repo=interest_repo,
                     match_repo=match_repo,
@@ -155,7 +191,7 @@ def add(
                     embedding_repo=embedding_repo,
                 )
                 try:
-                    return await service.create_interest(
+                    return await service.subscribe(
                         user_id=acting.id,
                         chat_id=chat_id,
                         title=title.strip(),
@@ -164,24 +200,31 @@ def add(
                         description=description_arg,
                         exclude_keywords=exclude_list,
                         threshold=threshold,
+                        workspace_id=None,
+                        is_admin=acting.is_admin,
                     )
                 finally:
                     await service.aclose()
         finally:
             await Database.close_instance()
 
-    typer.echo(f"🔔 Создание watchlist '{title.strip()}' для chat_id={chat_id}\n")
+    typer.echo(f"🔔 Подписка watchlist '{title.strip()}' для chat_id={chat_id}\n")
 
     try:
-        created = asyncio.run(_run())
+        result = asyncio.run(_run())
     except typer.BadParameter:
         raise
     except Exception as exc:
         typer.echo(f"\n❌ Ошибка: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    typer.echo("✅ Watchlist создан:")
-    _print_interest(created)
+    verb = "создан" if result.created else "обновлён"
+    typer.echo(f"✅ Watchlist {verb}:")
+    _print_interest(result.interest)
+    if not result.created:
+        typer.echo(
+            f"      changed:     {', '.join(result.changed_fields) if result.changed_fields else '(no-op)'}"
+        )
 
 
 @app.command("list")

--- a/tg_parser/domain/models.py
+++ b/tg_parser/domain/models.py
@@ -641,6 +641,14 @@ class DigestSubscription(BaseModel):
     chat_id: int = Field(description="Telegram chat_id where the digest is delivered")
     name: str = Field(min_length=1, max_length=200, description="Human label")
     channel_ids: list[str] = Field(min_length=1, description="Channels included in the digest")
+    workspace_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional workspace context FK (ENH-9, Wave 1 step 3). NULL = behaviour "
+            "identical to pre-ENH-9 (no workspace association). ON DELETE SET NULL: "
+            "workspace removal does not delete the subscription."
+        ),
+    )
     cron_expression: str = Field(
         default="0 9 * * *",
         max_length=100,
@@ -723,6 +731,14 @@ class WatchInterest(BaseModel):
     user_id: str = Field(description="User UUID owning the interest")
     chat_id: int = Field(description="Telegram chat_id where notifications are delivered")
     title: str = Field(min_length=1, max_length=300, description="Short human label")
+    workspace_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional workspace context FK (ENH-9, Wave 1 step 3). NULL = behaviour "
+            "identical to pre-ENH-9 (no workspace association). ON DELETE SET NULL: "
+            "workspace removal preserves the interest with workspace_id = NULL."
+        ),
+    )
     description: str | None = Field(
         default=None,
         description="Free-form description; primary input for semantic embedding",

--- a/tg_parser/domain/models.py
+++ b/tg_parser/domain/models.py
@@ -847,3 +847,67 @@ class WatchMatch(BaseModel):
             ]
         }
     )
+
+
+# ============================================================================
+# IdempotencyKey (Wave 1 step 3 — HTTP API idempotency middleware)
+# ============================================================================
+
+
+class IdempotencyKey(BaseModel):
+    """Persisted Idempotency-Key record for the HTTP API (ADR 0009 Option C).
+
+    Stored in ``idempotency_keys`` (ingestion DB, table seeded by migration
+    ``f1a2b3c4d5e6`` — Wave 1 step 3 commit 1/4). The Stripe-style HTTP
+    middleware records exactly one row per ``(user_id, key)`` reaching a
+    POST endpoint that opts in via ``Depends(idempotency_key_check)``.
+
+    Cache invariants:
+
+    * ``response_body`` is the **full serialized response envelope**
+      ``{"status": <int>, "body": <jsonable>}`` so a cache hit can
+      reproduce both the status code and the body verbatim.
+    * Only 2xx outcomes are persisted (R-2 mitigation — 4xx / 5xx pass
+      through without caching so transient validation failures don't
+      poison the key).
+    * ``request_hash`` is SHA-256 over the canonical JSON serialisation
+      of the request body (sorted keys, no whitespace) — see
+      :func:`tg_parser.api.idempotency.canonicalize_body` — guaranteeing
+      hash stability across client-side key-order changes (R-4 mitigation).
+    """
+
+    key: str = Field(description="Client-supplied Idempotency-Key header value")
+    user_id: str = Field(description="Owner user UUID (scope partition)")
+    request_hash: str = Field(
+        description="SHA-256 over canonical-JSON request body for body-hash check (Q-OPEN-1)",
+    )
+    response_body: dict[str, Any] = Field(
+        description=(
+            "Cached response envelope: {'status': int, 'body': dict}. Only "
+            "set for 2xx outcomes (R-2)."
+        ),
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(),
+        description="Insertion timestamp; cleaned by hourly cron after 24h TTL (Q-OPEN-2)",
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "key": "f6c3b4d5-7e2a-4f88-90b2-1a2b3c4d5e6f",
+                    "user_id": "00000000-0000-0000-0000-000000000002",
+                    "request_hash": "a1b2c3d4e5...",
+                    "response_body": {
+                        "status": 201,
+                        "body": {
+                            "watchlist_id": "00000000-0000-0000-0000-000000000010",
+                            "created": True,
+                            "changed_fields": [],
+                        },
+                    },
+                }
+            ]
+        }
+    )

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -655,14 +655,24 @@ class DigestSubscriptionInfo(BaseModel):
     is_active: bool
     last_sent_at: str | None = None
     last_digest_cursor: str | None = None
+    workspace_id: str | None = None
 
 
 class SubscribeDigestResult(BaseModel):
-    """Result of ``subscribe_digest``."""
+    """Result of ``subscribe_digest``.
+
+    Wave 1 step 3 / BUG-022: adds ``digest_id`` / ``created`` /
+    ``changed_fields`` for the natural-key idempotency contract. The
+    legacy ``subscription`` payload is preserved so existing callers
+    (tests, MCP-only consumers) keep working bit-for-bit.
+    """
 
     success: bool
     subscription: DigestSubscriptionInfo | None = None
     message: str
+    digest_id: str | None = None
+    created: bool | None = None
+    changed_fields: list[str] | None = None
 
 
 class ListDigestsResult(BaseModel):
@@ -702,6 +712,7 @@ class WatchInterestInfo(BaseModel):
     last_checked_at: str | None = None
     last_match_at: str | None = None
     created_at: str | None = None
+    workspace_id: str | None = None
 
 
 class WatchMatchInfo(BaseModel):
@@ -719,11 +730,20 @@ class WatchMatchInfo(BaseModel):
 
 
 class SubscribeWatchlistResult(BaseModel):
-    """Result of ``subscribe_watchlist``."""
+    """Result of ``subscribe_watchlist``.
+
+    Wave 1 step 3 / BUG-022: adds ``watchlist_id`` / ``created`` /
+    ``changed_fields`` for the natural-key idempotency contract. The
+    legacy ``interest`` payload is preserved so existing callers
+    (tests, MCP-only consumers) keep working bit-for-bit.
+    """
 
     success: bool
     interest: WatchInterestInfo | None = None
     message: str
+    watchlist_id: str | None = None
+    created: bool | None = None
+    changed_fields: list[str] | None = None
 
 
 class ListWatchlistsResult(BaseModel):
@@ -2470,6 +2490,7 @@ def _digest_to_info(sub: Any) -> DigestSubscriptionInfo:
         is_active=sub.is_active,
         last_sent_at=sub.last_sent_at.isoformat() if sub.last_sent_at else None,
         last_digest_cursor=sub.last_digest_cursor.isoformat() if sub.last_digest_cursor else None,
+        workspace_id=getattr(sub, "workspace_id", None),
     )
 
 
@@ -2482,9 +2503,10 @@ async def subscribe_digest(
     timezone: str = "UTC",
     format: str = "summary",
     language: str = "ru",
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> SubscribeDigestResult:
-    """Create a recurring digest subscription (F6).
+    """Create or update a recurring digest subscription (F6).
 
     The subscription is owned by the calling user and delivered to ``chat_id``
     on the cron schedule. For private chats ``chat_id`` equals the user's
@@ -2492,27 +2514,40 @@ async def subscribe_digest(
     convention). Each ``channel_id`` must be accessible by the caller
     (admin sees all, regular user sees only owned channels).
 
+    Wave 1 step 3 (BUG-022 + ENH-9):
+
+    - Idempotent on the ``(owner_id, name)`` natural key. Re-calling
+      with the same ``name`` updates the existing subscription instead
+      of creating a duplicate; response carries ``created=False`` and
+      ``changed_fields=[...]`` listing the Pydantic fields that
+      changed.
+    - ``workspace_id`` is an optional FK to an existing workspace the
+      caller owns (admin: any workspace). Unknown / foreign
+      ``workspace_id`` yields a 404-like ``WorkspaceNotFound`` error.
+
     Args:
-        name: Human-readable subscription name (used by list/unsubscribe).
+        name: Human-readable subscription name (natural-key idempotent).
         channel_ids: One or more channel ids (or @usernames) to digest.
         chat_id: Telegram chat id to deliver into.
         cron_expression: Standard 5-field cron (default '0 9 * * *' = 09:00 daily).
         timezone: IANA timezone for the cron (default 'UTC').
         format: 'summary' | 'bullets' | 'detailed' (default 'summary').
         language: Output language code (default 'ru').
+        workspace_id: Optional workspace UUID context (ENH-9).
     """
-    import uuid as _uuid
-    from datetime import UTC as _UTC
-    from datetime import datetime as _dt
-
-    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
-    from tg_parser.domain.models import DigestFormat, DigestSubscription
+    from tg_parser.auth.ownership import (
+        PermissionDenied,
+        WorkspaceNotFound,
+        assert_channel_access,
+    )
+    from tg_parser.domain.models import DigestFormat
     from tg_parser.services.background_scheduler import (
         get_scheduler,
         register_digest_subscription,
         unregister_digest_subscription,
     )
-    from tg_parser.services.db_context import digest_subscription_repo
+    from tg_parser.services.db_context import digest_subscription_repo, workspace_repo
+    from tg_parser.services.digest_service import DigestService
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
 
@@ -2552,37 +2587,80 @@ async def subscribe_digest(
             ),
         )
 
-    subscription = DigestSubscription(
-        id=str(_uuid.uuid4()),
-        owner_id=user.id,
-        chat_id=chat_id,
-        name=name.strip(),
-        channel_ids=normalized,
-        cron_expression=cron_expression.strip(),
-        timezone=timezone.strip(),
-        format=format_enum,
-        language=language.strip(),
-        is_active=True,
-        last_sent_at=None,
-        last_digest_cursor=None,
-        created_at=_dt.now(_UTC),
-        updated_at=_dt.now(_UTC),
-    )
+    # Pre-validate cron/timezone before the DB write so a bad spec
+    # never leaves a half-written row behind.
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        from apscheduler.triggers.cron import CronTrigger
+
+        try:
+            CronTrigger.from_crontab(cron_expression, timezone=ZoneInfo(timezone))
+        except (ValueError, ZoneInfoNotFoundError) as exc:
+            return SubscribeDigestResult(
+                success=False,
+                subscription=None,
+                message=(
+                    f"cron/timezone validation failed: invalid cron task spec "
+                    f"({cron_expression!r} / tz={timezone!r}): {exc}"
+                ),
+            )
+    except ImportError:
+        logger.debug("mcp_subscribe_digest_cron_prevalidate_skipped", exc_info=True)
 
     try:
-        register_digest_subscription(subscription, get_scheduler())
-    except ValueError as exc:
+        async with digest_subscription_repo() as (sub_repo, _db):
+            if workspace_id is not None:
+                # workspace_repo() opens its own session against the same
+                # ingestion DB; the validation runs in a short-lived
+                # context to avoid leaking the session beyond subscribe().
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = DigestService(
+                        processed_repo=None,
+                        subscription_repo=sub_repo,
+                        prompt_loader=None,
+                        llm_client_factory=None,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    result = await service.subscribe(
+                        owner_id=user.id,
+                        chat_id=chat_id,
+                        name=name.strip(),
+                        channel_ids=normalized,
+                        cron_expression=cron_expression.strip(),
+                        timezone=timezone.strip(),
+                        format=format_enum,
+                        language=language.strip(),
+                        workspace_id=workspace_id,
+                        is_admin=user.is_admin,
+                    )
+            else:
+                service = DigestService(
+                    processed_repo=None,
+                    subscription_repo=sub_repo,
+                    prompt_loader=None,
+                    llm_client_factory=None,
+                    workspace_repo=None,
+                )
+                result = await service.subscribe(
+                    owner_id=user.id,
+                    chat_id=chat_id,
+                    name=name.strip(),
+                    channel_ids=normalized,
+                    cron_expression=cron_expression.strip(),
+                    timezone=timezone.strip(),
+                    format=format_enum,
+                    language=language.strip(),
+                    workspace_id=None,
+                    is_admin=user.is_admin,
+                )
+    except WorkspaceNotFound as exc:
         return SubscribeDigestResult(
             success=False,
             subscription=None,
-            message=f"cron/timezone validation failed: {exc}",
+            message=exc.message,
         )
-
-    try:
-        async with digest_subscription_repo() as (repo, _db):
-            created = await repo.create(subscription)
     except SQLAlchemyError as exc:
-        unregister_digest_subscription(subscription.id)
         logger.exception("mcp_subscribe_digest_persist_failed")
         return SubscribeDigestResult(
             success=False,
@@ -2590,20 +2668,48 @@ async def subscribe_digest(
             message=f"failed to persist subscription: {exc}",
         )
 
+    # (Re-)register the scheduler job on every successful subscribe so
+    # cron/timezone edits propagate to the running scheduler. If the
+    # validation fails we surface the error and roll the row back to
+    # the pre-subscribe state where possible.
+    try:
+        unregister_digest_subscription(result.subscription.id)
+    except Exception:
+        logger.debug("mcp_subscribe_digest_unregister_pre_register_failed", exc_info=True)
+    try:
+        register_digest_subscription(result.subscription, get_scheduler())
+    except ValueError as exc:
+        return SubscribeDigestResult(
+            success=False,
+            subscription=_digest_to_info(result.subscription),
+            message=f"cron/timezone validation failed: {exc}",
+            digest_id=result.subscription.id,
+            created=result.created,
+            changed_fields=list(result.changed_fields),
+        )
+
     logger.info(
-        "mcp_subscribe_digest_created",
-        subscription_id=created.id,
-        owner_id=created.owner_id,
-        channel_count=len(created.channel_ids),
+        "mcp_subscribe_digest_done",
+        subscription_id=result.subscription.id,
+        owner_id=result.subscription.owner_id,
+        channel_count=len(result.subscription.channel_ids),
+        created=result.created,
+        changed_fields=result.changed_fields,
+        workspace_id=workspace_id,
     )
+    verb = "created" if result.created else "updated"
     return SubscribeDigestResult(
         success=True,
-        subscription=_digest_to_info(created),
+        subscription=_digest_to_info(result.subscription),
         message=(
-            f"Subscription '{created.name}' created. "
-            f"Schedule: {created.cron_expression} ({created.timezone}). "
-            f"Channels: {len(created.channel_ids)}."
+            f"Subscription '{result.subscription.name}' {verb}. "
+            f"Schedule: {result.subscription.cron_expression} "
+            f"({result.subscription.timezone}). "
+            f"Channels: {len(result.subscription.channel_ids)}."
         ),
+        digest_id=result.subscription.id,
+        created=result.created,
+        changed_fields=list(result.changed_fields),
     )
 
 
@@ -2707,6 +2813,7 @@ def _interest_to_info(interest: Any) -> WatchInterestInfo:
         last_checked_at=interest.last_checked_at.isoformat() if interest.last_checked_at else None,
         last_match_at=interest.last_match_at.isoformat() if interest.last_match_at else None,
         created_at=interest.created_at.isoformat() if interest.created_at else None,
+        workspace_id=getattr(interest, "workspace_id", None),
     )
 
 
@@ -2733,9 +2840,10 @@ async def subscribe_watchlist(
     description: str | None = None,
     exclude_keywords: list[str] | None = None,
     threshold: float = 0.6,
+    workspace_id: str | None = None,
     ctx: Context | None = None,
 ) -> SubscribeWatchlistResult:
-    """Create a persistent thematic alert (F11 Topic Watchlist).
+    """Create or update a persistent thematic alert (F11 Topic Watchlist).
 
     The interest is owned by the calling user. After every incremental
     pipeline tick, new ProcessedDocuments from the listed channels are
@@ -2743,8 +2851,18 @@ async def subscribe_watchlist(
     scores at or above ``threshold`` are saved in ``watch_matches`` and
     pushed to ``chat_id`` via the bot (notify_mode=instant).
 
+    Wave 1 step 3 (BUG-022 + ENH-9):
+
+    - Idempotent on the ``(user_id, title)`` natural key. Re-calling
+      with the same ``title`` updates the existing interest instead
+      of creating a duplicate; response carries ``created=False`` and
+      ``changed_fields=[...]``.
+    - ``workspace_id`` is an optional FK to an existing workspace the
+      caller owns (admin: any workspace). Unknown / foreign
+      ``workspace_id`` yields a 404-like ``WorkspaceNotFound`` error.
+
     Args:
-        title: Short human label (used in push notifications).
+        title: Short human label (natural-key idempotent).
         channel_ids: Non-empty list of channels to watch (must be accessible).
         chat_id: Telegram chat to deliver pushes into. For private chats this
             equals the user's Telegram id; for groups/supergroups the bot must
@@ -2756,9 +2874,14 @@ async def subscribe_watchlist(
             the score for that document.
         threshold: Combined-score cutoff in [0, 1] (default 0.6). Lower =
             more matches (less precise); higher = fewer (more precise).
+        workspace_id: Optional workspace UUID context (ENH-9).
     """
-    from tg_parser.auth.ownership import PermissionDenied, assert_channel_access
-    from tg_parser.services.db_context import watchlist_repos
+    from tg_parser.auth.ownership import (
+        PermissionDenied,
+        WorkspaceNotFound,
+        assert_channel_access,
+    )
+    from tg_parser.services.db_context import watchlist_repos, workspace_repo
     from tg_parser.services.watchlist_service import make_watchlist_service
 
     user = await resolve_mcp_user(_extract_authenticated_user_id(ctx))
@@ -2802,25 +2925,58 @@ async def subscribe_watchlist(
             embedding_repo,
             _db,
         ):
-            service = make_watchlist_service(
-                interest_repo=interest_repo,
-                match_repo=match_repo,
-                processed_doc_repo=processed_doc_repo,
-                embedding_repo=embedding_repo,
-            )
-            try:
-                created = await service.create_interest(
-                    user_id=user.id,
-                    chat_id=chat_id,
-                    title=title.strip(),
-                    channel_ids=normalized,
-                    keywords=list(keywords or []),
-                    description=description,
-                    exclude_keywords=list(exclude_keywords or []),
-                    threshold=threshold,
+            if workspace_id is not None:
+                async with workspace_repo() as (ws_repo_inst, _db2):
+                    service = make_watchlist_service(
+                        interest_repo=interest_repo,
+                        match_repo=match_repo,
+                        processed_doc_repo=processed_doc_repo,
+                        embedding_repo=embedding_repo,
+                        workspace_repo=ws_repo_inst,
+                    )
+                    try:
+                        result = await service.subscribe(
+                            user_id=user.id,
+                            chat_id=chat_id,
+                            title=title.strip(),
+                            channel_ids=normalized,
+                            keywords=list(keywords or []),
+                            description=description,
+                            exclude_keywords=list(exclude_keywords or []),
+                            threshold=threshold,
+                            workspace_id=workspace_id,
+                            is_admin=user.is_admin,
+                        )
+                    finally:
+                        await service.aclose()
+            else:
+                service = make_watchlist_service(
+                    interest_repo=interest_repo,
+                    match_repo=match_repo,
+                    processed_doc_repo=processed_doc_repo,
+                    embedding_repo=embedding_repo,
                 )
-            finally:
-                await service.aclose()
+                try:
+                    result = await service.subscribe(
+                        user_id=user.id,
+                        chat_id=chat_id,
+                        title=title.strip(),
+                        channel_ids=normalized,
+                        keywords=list(keywords or []),
+                        description=description,
+                        exclude_keywords=list(exclude_keywords or []),
+                        threshold=threshold,
+                        workspace_id=None,
+                        is_admin=user.is_admin,
+                    )
+                finally:
+                    await service.aclose()
+    except WorkspaceNotFound as exc:
+        return SubscribeWatchlistResult(
+            success=False,
+            interest=None,
+            message=exc.message,
+        )
     except SQLAlchemyError as exc:
         logger.exception("mcp_subscribe_watchlist_persist_failed")
         return SubscribeWatchlistResult(
@@ -2830,18 +2986,26 @@ async def subscribe_watchlist(
         )
 
     logger.info(
-        "mcp_subscribe_watchlist_created",
-        interest_id=created.id,
-        owner_id=created.user_id,
-        channel_count=len(created.channel_ids),
+        "mcp_subscribe_watchlist_done",
+        interest_id=result.interest.id,
+        owner_id=result.interest.user_id,
+        channel_count=len(result.interest.channel_ids),
+        created=result.created,
+        changed_fields=result.changed_fields,
+        workspace_id=workspace_id,
     )
+    verb = "created" if result.created else "updated"
     return SubscribeWatchlistResult(
         success=True,
-        interest=_interest_to_info(created),
+        interest=_interest_to_info(result.interest),
         message=(
-            f"Interest {created.title!r} created. "
-            f"Channels: {len(created.channel_ids)}, threshold: {created.threshold}."
+            f"Interest {result.interest.title!r} {verb}. "
+            f"Channels: {len(result.interest.channel_ids)}, "
+            f"threshold: {result.interest.threshold}."
         ),
+        watchlist_id=result.interest.id,
+        created=result.created,
+        changed_fields=list(result.changed_fields),
     )
 
 

--- a/tg_parser/services/background_scheduler.py
+++ b/tg_parser/services/background_scheduler.py
@@ -384,8 +384,23 @@ def setup_default_tasks(
         interval_seconds=interval,
     )
 
+    # Idempotency-Key cleanup (Wave 1 step 3 commit 4/4, ADR 0009 Q-OPEN-2).
+    # Hourly cron at the top of every hour: DELETE rows older than 24h +
+    # update the ``tg_idempotency_keys_table_size`` gauge. Cron (vs interval)
+    # is used so the deploy timestamp doesn't shift the cleanup phase
+    # day-over-day — predictable cadence helps operators correlate
+    # cleanup beats with cache-size dips on dashboards.
+    from tg_parser.services.scheduler_service import cleanup_stale_idempotency_keys
+
+    scheduler.add_cron_task(
+        task_id="idempotency_keys_cleanup",
+        func=cleanup_stale_idempotency_keys,
+        cron_expression="0 * * * *",
+        timezone="UTC",
+    )
+
     logger.info(
-        "Default background tasks configured (incl. incremental pipeline + embedding, interval=%ds)",
+        "Default background tasks configured (incl. incremental pipeline + embedding + idempotency cleanup, interval=%ds)",
         interval,
     )
 

--- a/tg_parser/services/db_context.py
+++ b/tg_parser/services/db_context.py
@@ -15,6 +15,7 @@ from tg_parser.storage.sqlalchemy.digest_subscription_repo import (
     SADigestSubscriptionRepo,
 )
 from tg_parser.storage.sqlalchemy.embedding_repo import SAEmbeddingRepo
+from tg_parser.storage.sqlalchemy.idempotency_key_repo import SAIdempotencyKeyRepo
 from tg_parser.storage.sqlalchemy.ingestion_state_repo import SAIngestionStateRepo
 from tg_parser.storage.sqlalchemy.job_repo import SAJobRepo
 from tg_parser.storage.sqlalchemy.processed_document_repo import (
@@ -142,6 +143,23 @@ async def workspace_repo() -> "AsyncIterator[tuple[SAWorkspaceRepo, Database]]":
     session = db.ingestion_state_session()
     try:
         yield SAWorkspaceRepo(session), db
+    finally:
+        await session.close()
+
+
+@asynccontextmanager
+async def idempotency_key_repo() -> "AsyncIterator[tuple[SAIdempotencyKeyRepo, Database]]":
+    """Context manager for IdempotencyKeyRepo (Wave 1 step 3 commit 4/4).
+
+    Lives on the ingestion DB session — same partition as the
+    ``users``/``watch_interests``/``digest_subscriptions`` rows whose
+    POST endpoints opt into the Idempotency-Key middleware (ADR 0009
+    Option C).
+    """
+    db = await _get_db()
+    session = db.ingestion_state_session()
+    try:
+        yield SAIdempotencyKeyRepo(session), db
     finally:
         await session.close()
 

--- a/tg_parser/services/digest_service.py
+++ b/tg_parser/services/digest_service.py
@@ -23,13 +23,16 @@ Key invariants:
 from __future__ import annotations
 
 import re
+import uuid as _uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import structlog
+from sqlalchemy.exc import IntegrityError
 
+from tg_parser.auth.ownership import WorkspaceNotFound
 from tg_parser.domain.models import (
     DigestFormat,
     DigestSubscription,
@@ -39,6 +42,7 @@ from tg_parser.processing.prompt_loader import PromptLoader, PromptLoaderError
 from tg_parser.storage.ports import (
     DigestSubscriptionRepo,
     ProcessedDocumentRepo,
+    WorkspaceRepo,
 )
 
 if TYPE_CHECKING:
@@ -93,6 +97,21 @@ class DigestResult:
     per_channel_counts: dict[str, int] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class SubscribeResult:
+    """Outcome of a :meth:`DigestService.subscribe` call (Wave 1 step 3).
+
+    Mirrors :class:`tg_parser.services.watchlist_service.SubscribeResult`
+    but carries a :class:`DigestSubscription`. ``changed_fields`` is the
+    list of Pydantic field names whose values differ between the stored
+    row and the new payload (empty on true no-op replay).
+    """
+
+    subscription: DigestSubscription
+    created: bool
+    changed_fields: list[str]
+
+
 # ----------------------------------------------------------------------------
 # Service
 # ----------------------------------------------------------------------------
@@ -106,16 +125,17 @@ class DigestService:
 
     def __init__(
         self,
-        processed_repo: ProcessedDocumentRepo,
+        processed_repo: ProcessedDocumentRepo | None,
         subscription_repo: DigestSubscriptionRepo,
-        prompt_loader: PromptLoader,
-        llm_client_factory: LLMClientFactory,
+        prompt_loader: PromptLoader | None,
+        llm_client_factory: LLMClientFactory | None,
         *,
         max_docs_per_run: int = 50,
         first_run_lookback_hours: int = 24,
         message_max_chars: int = 4096,
         max_message_parts: int = 10,
         prompt_name: str = "digest",
+        workspace_repo: WorkspaceRepo | None = None,
     ):
         self._processed_repo = processed_repo
         self._subscription_repo = subscription_repo
@@ -126,10 +146,162 @@ class DigestService:
         self._message_max_chars = max(512, int(message_max_chars))
         self._max_message_parts = max(1, int(max_message_parts))
         self._prompt_name = prompt_name
+        self._workspace_repo = workspace_repo
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    async def subscribe(
+        self,
+        *,
+        owner_id: str,
+        chat_id: int,
+        name: str,
+        channel_ids: list[str],
+        cron_expression: str = "0 9 * * *",
+        timezone: str = "UTC",
+        format: DigestFormat = DigestFormat.SUMMARY,
+        language: str = "ru",
+        workspace_id: str | None = None,
+        is_admin: bool = False,
+    ) -> SubscribeResult:
+        """Idempotent upsert on the ``(owner_id, name)`` natural key (BUG-022).
+
+        Wave 1 step 3 commit 1/4 — closes BUG-022. Mirrors
+        :meth:`tg_parser.services.watchlist_service.WatchlistService.subscribe`
+        but on the digest natural key (table column ``owner_id`` + label
+        column ``name`` — see Q6 asymmetry in sprint prompt). Scheduler
+        registration is intentionally NOT performed here: surfaces
+        (MCP, Bot) call ``register_digest_subscription`` separately so
+        the cron/timezone validation stays at the call-site.
+
+        ``workspace_id`` semantics (ENH-9):
+
+        - ``None`` (default) → identical to pre-ENH-9 behaviour
+          (column stays NULL on INSERT; left untouched on UPDATE).
+        - Valid UUID → validated via the injected ``workspace_repo``;
+          unknown or foreign UUIDs raise :class:`WorkspaceNotFound`.
+        - ``is_admin=True`` bypasses the cross-tenant ownership check.
+        - When ``workspace_repo`` is not configured (e.g. unit tests
+          that don't need workspace validation) the value is stored
+          as-is without validation.
+
+        Race condition: a concurrent INSERT from two surfaces is
+        caught via :class:`IntegrityError` from the new
+        ``UNIQUE (owner_id, name)`` constraint and the path retries
+        as UPDATE so the result still collapses to a single row.
+        """
+        if workspace_id is not None and self._workspace_repo is not None:
+            workspace = await self._workspace_repo.get(workspace_id)
+            if workspace is None:
+                raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+            if not is_admin and workspace.owner_id != owner_id:
+                raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+
+        existing = await self._subscription_repo.find_by_owner_and_name(owner_id, name)
+        if existing is not None:
+            return await self._apply_digest_upsert(
+                existing=existing,
+                chat_id=chat_id,
+                channel_ids=channel_ids,
+                cron_expression=cron_expression,
+                timezone=timezone,
+                format=format,
+                language=language,
+                workspace_id=workspace_id,
+            )
+
+        draft = DigestSubscription(
+            id=str(_uuid.uuid4()),
+            owner_id=owner_id,
+            chat_id=chat_id,
+            name=name,
+            channel_ids=list(channel_ids),
+            workspace_id=workspace_id,
+            cron_expression=cron_expression,
+            timezone=timezone,
+            format=format,
+            language=language,
+            is_active=True,
+            last_sent_at=None,
+            last_digest_cursor=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        try:
+            created = await self._subscription_repo.create(draft)
+        except IntegrityError:
+            logger.info(
+                "digest.subscribe_race_retry_update",
+                owner_id=owner_id,
+                name=name,
+            )
+            existing = await self._subscription_repo.find_by_owner_and_name(owner_id, name)
+            if existing is None:
+                raise
+            return await self._apply_digest_upsert(
+                existing=existing,
+                chat_id=chat_id,
+                channel_ids=channel_ids,
+                cron_expression=cron_expression,
+                timezone=timezone,
+                format=format,
+                language=language,
+                workspace_id=workspace_id,
+            )
+        return SubscribeResult(subscription=created, created=True, changed_fields=[])
+
+    async def _apply_digest_upsert(
+        self,
+        *,
+        existing: DigestSubscription,
+        chat_id: int,
+        channel_ids: list[str],
+        cron_expression: str,
+        timezone: str,
+        format: DigestFormat,
+        language: str,
+        workspace_id: str | None,
+    ) -> SubscribeResult:
+        """Diff existing row vs payload, UPDATE changed columns only."""
+        new_channels = list(channel_ids)
+
+        update_kwargs: dict[str, Any] = {}
+        changed_fields: list[str] = []
+
+        if existing.chat_id != chat_id:
+            update_kwargs["chat_id"] = chat_id
+            changed_fields.append("chat_id")
+        if list(existing.channel_ids) != new_channels:
+            update_kwargs["channel_ids"] = new_channels
+            changed_fields.append("channel_ids")
+        if existing.cron_expression != cron_expression:
+            update_kwargs["cron_expression"] = cron_expression
+            changed_fields.append("cron_expression")
+        if existing.timezone != timezone:
+            update_kwargs["timezone"] = timezone
+            changed_fields.append("timezone")
+        if existing.format != format:
+            update_kwargs["format"] = format
+            changed_fields.append("format")
+        if existing.language != language:
+            update_kwargs["language"] = language
+            changed_fields.append("language")
+        if not existing.is_active:
+            update_kwargs["is_active"] = True
+            changed_fields.append("is_active")
+        if workspace_id is not None and existing.workspace_id != workspace_id:
+            update_kwargs["workspace_id"] = workspace_id
+            changed_fields.append("workspace_id")
+
+        if not update_kwargs:
+            return SubscribeResult(subscription=existing, created=False, changed_fields=[])
+
+        updated = await self._subscription_repo.update(existing.id, **update_kwargs)
+        if updated is None:
+            updated = existing
+        return SubscribeResult(subscription=updated, created=False, changed_fields=changed_fields)
 
     async def generate(self, sub: DigestSubscription) -> DigestResult:
         """Fetch new docs, summarise via LLM, return ``DigestResult``."""

--- a/tg_parser/services/scheduler_service.py
+++ b/tg_parser/services/scheduler_service.py
@@ -773,6 +773,40 @@ async def reconcile_digest_subscriptions() -> dict[str, Any]:
     }
 
 
+async def cleanup_stale_idempotency_keys(*, ttl_hours: int = 24) -> dict[str, int]:
+    """Hourly cleanup tick for the ``idempotency_keys`` table (ADR 0009, Q-OPEN-2).
+
+    Deletes rows older than ``ttl_hours`` (default 24h; not env-configurable per
+    sprint lock — KISS) and updates the ``tg_idempotency_keys_table_size``
+    gauge with the post-cleanup row count so operators can alert on
+    runaway cache growth.
+
+    Returns a small status dict suitable for structured logging:
+    ``{"deleted": int, "table_size": int}``. The cleanup is best-effort —
+    a transient DB hiccup raises and the next tick will retry; we do
+    not back-off ourselves because the cron trigger handles cadence.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from tg_parser.api.metrics import set_idempotency_keys_table_size
+    from tg_parser.services.db_context import idempotency_key_repo
+
+    cutoff = datetime.now(UTC) - timedelta(hours=ttl_hours)
+    async with idempotency_key_repo() as (repo, _db):
+        deleted = await repo.delete_older_than(cutoff)
+        table_size = await repo.count()
+
+    set_idempotency_keys_table_size(table_size)
+    logger.info(
+        "idempotency_keys_cleanup",
+        deleted=deleted,
+        table_size=table_size,
+        ttl_hours=ttl_hours,
+        cutoff=cutoff.isoformat(),
+    )
+    return {"deleted": deleted, "table_size": table_size}
+
+
 async def incremental_pipeline_task() -> dict:
     """
     Periodic task: run incremental pipeline for all active sources.

--- a/tg_parser/services/watchlist_service.py
+++ b/tg_parser/services/watchlist_service.py
@@ -36,12 +36,14 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
+from sqlalchemy.exc import IntegrityError
 
 from tg_parser.api.metrics import (
     record_watchlist_delivery,
     record_watchlist_match,
     set_watchlist_active,
 )
+from tg_parser.auth.ownership import WorkspaceNotFound
 from tg_parser.domain.models import (
     NotifyMode,
     ProcessedDocument,
@@ -53,6 +55,7 @@ from tg_parser.storage.ports import (
     ProcessedDocumentRepo,
     WatchInterestRepo,
     WatchMatchRepo,
+    WorkspaceRepo,
 )
 from tg_parser.utils.channel_id import normalize_channel_id
 
@@ -116,6 +119,24 @@ _BOT_PERMANENT_FAILURE_FRAGMENTS: tuple[str, ...] = (
 # ----------------------------------------------------------------------------
 # Score model
 # ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubscribeResult:
+    """Outcome of a :meth:`WatchlistService.subscribe` call.
+
+    Wave 1 step 3 / BUG-022: returned by the service-layer upsert so
+    every surface (MCP, Bot, CLI, HTTP) can render the locked
+    ``{watchlist_id, created, changed_fields}`` shape without
+    duplicating the diff logic. ``changed_fields`` is a list of
+    Pydantic field names that differ between the stored row and the
+    payload (empty on a true no-op replay, populated on
+    same-key/different-args).
+    """
+
+    interest: WatchInterest
+    created: bool
+    changed_fields: list[str]
 
 
 @dataclass(frozen=True)
@@ -401,12 +422,14 @@ class WatchlistService:
         processed_doc_repo: ProcessedDocumentRepo,
         embedding_repo: EmbeddingRepo,
         embedding_client: EmbeddingClient | None,
+        workspace_repo: WorkspaceRepo | None = None,
     ) -> None:
         self.interest_repo = interest_repo
         self.match_repo = match_repo
         self.processed_doc_repo = processed_doc_repo
         self.embedding_repo = embedding_repo
         self.embedding_client = embedding_client
+        self.workspace_repo = workspace_repo
 
     # ---- High-level CRUD helpers (used by bot/MCP/CLI in commit 2/2) ----
 
@@ -422,12 +445,17 @@ class WatchlistService:
         exclude_keywords: list[str] | None = None,
         threshold: float = 0.6,
         notify_mode: NotifyMode = NotifyMode.INSTANT,
+        workspace_id: str | None = None,
     ) -> WatchInterest:
         """Persist a new interest and eagerly compute its embedding.
 
         The eager embedding keeps the first scheduler tick fast (no first-tick
         embed latency) and is safe because :func:`build_canonical_interest_text`
         guarantees a non-empty input.
+
+        Kept for backward compatibility with callers that do not need the
+        idempotent upsert (test fixtures, scheduler re-creation). New code
+        should call :meth:`subscribe` which closes BUG-022.
         """
         draft = WatchInterest(
             id="",
@@ -438,6 +466,7 @@ class WatchlistService:
             keywords=list(keywords or []),
             exclude_keywords=list(exclude_keywords or []),
             channel_ids=list(channel_ids),
+            workspace_id=workspace_id,
             threshold=threshold,
             notify_mode=notify_mode,
             is_active=True,
@@ -451,6 +480,186 @@ class WatchlistService:
             stored = stored.model_copy(update={"embedding": embedding})
 
         return stored
+
+    async def subscribe(
+        self,
+        *,
+        user_id: str,
+        chat_id: int,
+        title: str,
+        channel_ids: list[str],
+        description: str | None = None,
+        keywords: list[str] | None = None,
+        exclude_keywords: list[str] | None = None,
+        threshold: float = 0.6,
+        notify_mode: NotifyMode = NotifyMode.INSTANT,
+        workspace_id: str | None = None,
+        is_admin: bool = False,
+    ) -> SubscribeResult:
+        """Idempotent upsert on the ``(user_id, title)`` natural key (BUG-022).
+
+        Wave 1 step 3 commit 1/4 — closes BUG-022. Behaviour:
+
+        - Same ``(user_id, title)`` and identical payload → no-op replay;
+          returns the existing row with ``created=False`` and
+          ``changed_fields=[]``.
+        - Same ``(user_id, title)`` but different mutable args → UPDATE
+          the changed columns, return the row with ``created=False``
+          and ``changed_fields=[...]`` (list of Pydantic field names).
+        - Soft-deleted interest with the same key → resurrected
+          (``is_active`` flipped to True) and merged with the new
+          payload; ``is_active`` is included in ``changed_fields`` to
+          make the resurrection observable.
+        - Race condition (concurrent INSERTs from two surfaces) →
+          ``IntegrityError`` from the new ``UNIQUE (user_id, title)``
+          DB constraint is caught and the path retries as UPDATE.
+
+        ``workspace_id``:
+
+        - ``None`` (default) → identical to pre-ENH-9 behaviour
+          (column stays NULL on INSERT; left untouched on UPDATE).
+        - Valid UUID → validated via the injected ``workspace_repo``;
+          unknown or foreign UUIDs raise :class:`WorkspaceNotFound`
+          (mirror F4-B Q2 EC2). ``is_admin=True`` bypasses the
+          ownership check.
+        - When ``workspace_repo`` is not configured (e.g. unit tests
+          that don't need workspace validation) a non-None
+          ``workspace_id`` is stored as-is without validation.
+        """
+        if workspace_id is not None and self.workspace_repo is not None:
+            workspace = await self.workspace_repo.get(workspace_id)
+            if workspace is None:
+                raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+            if not is_admin and workspace.owner_id != user_id:
+                raise WorkspaceNotFound(f"Workspace {workspace_id} not found")
+
+        existing = await self.interest_repo.find_by_user_and_title(user_id, title)
+        if existing is not None:
+            return await self._apply_upsert(
+                existing=existing,
+                chat_id=chat_id,
+                description=description,
+                keywords=keywords,
+                exclude_keywords=exclude_keywords,
+                channel_ids=channel_ids,
+                threshold=threshold,
+                notify_mode=notify_mode,
+                workspace_id=workspace_id,
+            )
+
+        draft = WatchInterest(
+            id="",
+            user_id=user_id,
+            chat_id=chat_id,
+            title=title,
+            description=description,
+            keywords=list(keywords or []),
+            exclude_keywords=list(exclude_keywords or []),
+            channel_ids=list(channel_ids),
+            workspace_id=workspace_id,
+            threshold=threshold,
+            notify_mode=notify_mode,
+            is_active=True,
+            embedding=None,
+        )
+        try:
+            stored = await self.interest_repo.create(draft)
+        except IntegrityError:
+            # Race: a concurrent caller won the INSERT between our
+            # find_by_user_and_title and create. Reload and apply as
+            # UPDATE so the result still collapses to a single row.
+            logger.info(
+                "watchlist.subscribe_race_retry_update",
+                user_id=user_id,
+                title=title,
+            )
+            existing = await self.interest_repo.find_by_user_and_title(user_id, title)
+            if existing is None:
+                raise
+            return await self._apply_upsert(
+                existing=existing,
+                chat_id=chat_id,
+                description=description,
+                keywords=keywords,
+                exclude_keywords=exclude_keywords,
+                channel_ids=channel_ids,
+                threshold=threshold,
+                notify_mode=notify_mode,
+                workspace_id=workspace_id,
+            )
+
+        embedding = await self._embed_interest(stored)
+        if embedding is not None:
+            await self.interest_repo.update_embedding(stored.id, embedding)
+            stored = stored.model_copy(update={"embedding": embedding})
+
+        return SubscribeResult(interest=stored, created=True, changed_fields=[])
+
+    async def _apply_upsert(
+        self,
+        *,
+        existing: WatchInterest,
+        chat_id: int,
+        description: str | None,
+        keywords: list[str] | None,
+        exclude_keywords: list[str] | None,
+        channel_ids: list[str],
+        threshold: float,
+        notify_mode: NotifyMode,
+        workspace_id: str | None,
+    ) -> SubscribeResult:
+        """Compute the diff between ``existing`` and the new payload, then UPDATE.
+
+        ``changed_fields`` mirrors Pydantic field names (Q-OPEN-1 from
+        sprint prompt §8 — locked at execution time to ``list[str]``).
+        ``workspace_id`` participates in the diff but is never
+        "unset to NULL" by this path: only an explicit None-arg with
+        ENH-9 semantics future-extension would do so. Today, passing
+        ``workspace_id=None`` to subscribe means "leave whatever the
+        row currently has" — matches the additive-only contract Q3-A.
+        """
+        new_keywords = list(keywords or [])
+        new_exclude = list(exclude_keywords or [])
+        new_channels = list(channel_ids)
+
+        update_kwargs: dict[str, object] = {}
+        changed_fields: list[str] = []
+
+        if existing.chat_id != chat_id:
+            update_kwargs["chat_id"] = chat_id
+            changed_fields.append("chat_id")
+        if (existing.description or None) != (description or None):
+            update_kwargs["description"] = description
+            changed_fields.append("description")
+        if list(existing.keywords) != new_keywords:
+            update_kwargs["keywords"] = new_keywords
+            changed_fields.append("keywords")
+        if list(existing.exclude_keywords) != new_exclude:
+            update_kwargs["exclude_keywords"] = new_exclude
+            changed_fields.append("exclude_keywords")
+        if list(existing.channel_ids) != new_channels:
+            update_kwargs["channel_ids"] = new_channels
+            changed_fields.append("channel_ids")
+        if abs(existing.threshold - threshold) > 1e-9:
+            update_kwargs["threshold"] = threshold
+            changed_fields.append("threshold")
+        if existing.notify_mode != notify_mode:
+            update_kwargs["notify_mode"] = notify_mode
+            changed_fields.append("notify_mode")
+        if not existing.is_active:
+            update_kwargs["is_active"] = True
+            changed_fields.append("is_active")
+        if workspace_id is not None and existing.workspace_id != workspace_id:
+            update_kwargs["workspace_id"] = workspace_id
+            changed_fields.append("workspace_id")
+
+        if not update_kwargs:
+            return SubscribeResult(interest=existing, created=False, changed_fields=[])
+
+        updated = await self.interest_repo.update_subscribe_fields(existing.id, **update_kwargs)
+        if updated is None:
+            updated = existing
+        return SubscribeResult(interest=updated, created=False, changed_fields=changed_fields)
 
     async def soft_delete_interest(self, interest_id: str) -> bool:
         """Mark an interest inactive while preserving its match history."""
@@ -791,6 +1000,7 @@ def make_watchlist_service(
     match_repo: WatchMatchRepo,
     processed_doc_repo: ProcessedDocumentRepo,
     embedding_repo: EmbeddingRepo,
+    workspace_repo: WorkspaceRepo | None = None,
     with_embedding_client: bool = True,
 ) -> WatchlistService:
     """Construct a :class:`WatchlistService` with an optional embedding client.
@@ -800,6 +1010,11 @@ def make_watchlist_service(
     using global settings. If ``OPENAI_API_KEY`` is missing, the factory falls
     back to keyword-only mode (``embedding_client=None``) instead of raising —
     the watchlist must keep working even on an OpenAI outage.
+
+    ``workspace_repo`` is optional — pass it through when calling
+    :meth:`WatchlistService.subscribe` with a non-None ``workspace_id``
+    so the ENH-9 validation (Wave 1 step 3) can raise
+    :class:`WorkspaceNotFound` for unknown / foreign workspaces.
     """
     embedding_client: EmbeddingClient | None = None
     if with_embedding_client:
@@ -819,4 +1034,5 @@ def make_watchlist_service(
         processed_doc_repo=processed_doc_repo,
         embedding_repo=embedding_repo,
         embedding_client=embedding_client,
+        workspace_repo=workspace_repo,
     )

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -15,6 +15,7 @@ from tg_parser.domain.models import (
     BundleItem,
     DigestFormat,
     DigestSubscription,
+    IdempotencyKey,
     NotifyMode,
     ProcessedDocument,
     RawTelegramMessage,
@@ -1675,5 +1676,72 @@ class WorkspaceRepo(ABC):
 
         Returns ``None`` when no matching source exists; the service layer
         translates that to a :class:`WorkspaceSourceNotFound`.
+        """
+        pass
+
+
+# ============================================================================
+# Idempotency Keys (Wave 1 step 3 — HTTP API idempotency middleware, ADR 0009)
+# ============================================================================
+
+
+class IdempotencyKeyRepo(ABC):
+    """Repository for Stripe-style HTTP Idempotency-Key cache records.
+
+    Storage: PostgreSQL ``idempotency_keys`` in the ingestion DB. The
+    table is created by migration ``f1a2b3c4d5e6`` (Wave 1 step 3 commit
+    1/4); this repo and its FastAPI dependency wrapper land in commit
+    4/4. Visible only to the HTTP surface — MCP / Bot / CLI rely solely
+    on the service-layer natural-key upsert (Option A in ADR 0009).
+
+    Per-user scope is enforced via the ``user_id`` FK column on every
+    read/write so a malicious or buggy client cannot inadvertently
+    leak / poison another tenant's idempotency state.
+    """
+
+    @abstractmethod
+    async def find_by_key(self, *, key: str, user_id: str) -> IdempotencyKey | None:
+        """Return the row for ``(user_id, key)``, or ``None`` if absent.
+
+        Lookup is scoped to the caller's ``user_id`` (Q-OPEN-7 — keys
+        partitioned per-tenant) so two unrelated tenants colliding on
+        the same client-generated key get independent cache slots.
+        """
+        pass
+
+    @abstractmethod
+    async def insert(
+        self,
+        *,
+        key: str,
+        user_id: str,
+        request_hash: str,
+        response_body: dict[str, Any],
+    ) -> None:
+        """Persist a fresh cache row.
+
+        Called by the middleware AFTER the endpoint produces a 2xx
+        response. ``response_body`` carries the full
+        ``{"status": int, "body": jsonable}`` envelope so a future cache
+        hit can reproduce both status and body verbatim.
+        """
+        pass
+
+    @abstractmethod
+    async def delete_older_than(self, cutoff: datetime) -> int:
+        """Delete rows with ``created_at < cutoff``. Returns deleted row count.
+
+        Backbone of the hourly cleanup tick (Q-OPEN-2). The migration
+        adds an index on ``created_at`` so this scan stays cheap even
+        at production scale.
+        """
+        pass
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Return the total number of rows currently in the table.
+
+        Powers the ``tg_idempotency_keys_table_size`` Prometheus gauge
+        (Karpathy principle 6 — observability of the cache footprint).
         """
         pass

--- a/tg_parser/storage/ports.py
+++ b/tg_parser/storage/ports.py
@@ -15,6 +15,7 @@ from tg_parser.domain.models import (
     BundleItem,
     DigestFormat,
     DigestSubscription,
+    NotifyMode,
     ProcessedDocument,
     RawTelegramMessage,
     TopicBundle,
@@ -1367,6 +1368,8 @@ class DigestSubscriptionRepo(ABC):
         chat_id: int | None = None,
         name: str | None = None,
         channel_ids: list[str] | None = None,
+        workspace_id: str | None = None,
+        unset_workspace_id: bool = False,
     ) -> DigestSubscription | None:
         """
         Partial update. Pass only fields that should change; omitted fields retain their value.
@@ -1380,6 +1383,19 @@ class DigestSubscriptionRepo(ABC):
     @abstractmethod
     async def delete(self, subscription_id: str) -> bool:
         """Delete a subscription. Returns True if a row was removed."""
+        pass
+
+    @abstractmethod
+    async def find_by_owner_and_name(self, owner_id: str, name: str) -> DigestSubscription | None:
+        """Look up a subscription by its natural key ``(owner_id, name)``.
+
+        Wave 1 step 3 / BUG-022: the service-layer upsert in
+        :meth:`tg_parser.services.digest_service.DigestService.subscribe`
+        uses this finder for the pre-flight lookup before deciding
+        whether to INSERT or UPDATE the row. Mirrors the new
+        ``UNIQUE (owner_id, name)`` constraint added by migration
+        ``f1a2b3c4d5e6``.
+        """
         pass
 
     @abstractmethod
@@ -1417,6 +1433,50 @@ class WatchInterestRepo(ABC):
     @abstractmethod
     async def get(self, interest_id: str) -> WatchInterest | None:
         """Look up an interest by id; returns None if absent."""
+        pass
+
+    @abstractmethod
+    async def find_by_user_and_title(self, user_id: str, title: str) -> WatchInterest | None:
+        """Look up an interest by its natural key ``(user_id, title)``.
+
+        Wave 1 step 3 / BUG-022: the service-layer upsert in
+        :meth:`tg_parser.services.watchlist_service.WatchlistService.subscribe`
+        uses this finder for the pre-flight lookup before deciding
+        whether to INSERT a new row or UPDATE the existing one. Mirrors
+        the new ``UNIQUE (user_id, title)`` constraint added by
+        migration ``f1a2b3c4d5e6``. Returns the row regardless of
+        ``is_active`` so soft-deleted interests can be resurrected on
+        re-subscribe.
+        """
+        pass
+
+    @abstractmethod
+    async def update_subscribe_fields(
+        self,
+        interest_id: str,
+        *,
+        chat_id: int | None = None,
+        description: str | None = None,
+        keywords: list[str] | None = None,
+        exclude_keywords: list[str] | None = None,
+        channel_ids: list[str] | None = None,
+        threshold: float | None = None,
+        notify_mode: NotifyMode | None = None,
+        is_active: bool | None = None,
+        workspace_id: str | None = None,
+        unset_workspace_id: bool = False,
+    ) -> WatchInterest | None:
+        """Partial update of the subscribable fields on an interest.
+
+        Wave 1 step 3 / BUG-022 upsert path: when the natural-key
+        finder hits an existing row, the service updates only the
+        mutable subscribe-payload fields (``embedding`` /
+        ``last_*_at`` are NOT touched here — those have their own
+        update endpoints). Pass ``unset_workspace_id=True`` to set the
+        column back to ``NULL`` (Python ``None`` is otherwise treated
+        as "leave unchanged" to mirror :meth:`update` on the digest
+        repo).
+        """
         pass
 
     @abstractmethod

--- a/tg_parser/storage/sqlalchemy/_metadata.py
+++ b/tg_parser/storage/sqlalchemy/_metadata.py
@@ -44,7 +44,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import REAL, TIMESTAMP, TSVECTOR, UUID
+from sqlalchemy.dialects.postgresql import JSONB, REAL, TIMESTAMP, TSVECTOR, UUID
 from sqlalchemy.types import CHAR
 
 INGESTION_METADATA = MetaData()
@@ -165,6 +165,8 @@ Table(
 )
 
 # digest_subscriptions — created via raw SQL in f6a1b2c3d4e5
+#                       + workspace_id + UNIQUE (owner_id, name) added
+#                         in f1a2b3c4d5e6 (Wave 1 step 3 / ENH-9 + BUG-022)
 Table(
     "digest_subscriptions",
     INGESTION_METADATA,
@@ -200,6 +202,7 @@ Table(
     Column("is_active", Boolean(), nullable=False, server_default=text("true")),
     Column("last_sent_at", TIMESTAMP(timezone=True), nullable=True),
     Column("last_digest_cursor", TIMESTAMP(timezone=True), nullable=True),
+    Column("workspace_id", UUID(as_uuid=True), nullable=True),
     Column(
         "created_at",
         TIMESTAMP(timezone=True),
@@ -219,15 +222,27 @@ Table(
         ondelete="CASCADE",
         name="digest_subscriptions_owner_id_fkey",
     ),
+    ForeignKeyConstraint(
+        ["workspace_id"],
+        ["workspaces.id"],
+        ondelete="SET NULL",
+        name="digest_subscriptions_workspace_id_fkey",
+    ),
     CheckConstraint(
         "array_length(channel_ids, 1) >= 1",
         name="digest_subscriptions_channel_ids_nonempty",
     ),
+    UniqueConstraint("owner_id", "name", name="uq_digest_subscriptions_owner_name"),
     Index("idx_digest_subscriptions_owner_active", "owner_id", "is_active"),
     Index(
         "idx_digest_subscriptions_active_cron",
         "is_active",
         postgresql_where=text("is_active = true"),
+    ),
+    Index(
+        "idx_digest_subscriptions_workspace_id",
+        "workspace_id",
+        postgresql_where=text("workspace_id IS NOT NULL"),
     ),
 )
 
@@ -299,6 +314,8 @@ Table(
 )
 
 # watch_interests — created via raw SQL in c8e9f0a1b2c3 (F11)
+#                  + workspace_id + UNIQUE (user_id, title) added in
+#                    f1a2b3c4d5e6 (Wave 1 step 3 / ENH-9 + BUG-022)
 Table(
     "watch_interests",
     INGESTION_METADATA,
@@ -336,6 +353,7 @@ Table(
     Column("embedding", Vector(1536), nullable=True),
     Column("last_checked_at", TIMESTAMP(timezone=True), nullable=True),
     Column("last_match_at", TIMESTAMP(timezone=True), nullable=True),
+    Column("workspace_id", UUID(as_uuid=True), nullable=True),
     Column(
         "created_at",
         TIMESTAMP(timezone=True),
@@ -355,6 +373,12 @@ Table(
         ondelete="CASCADE",
         name="watch_interests_user_id_fkey",
     ),
+    ForeignKeyConstraint(
+        ["workspace_id"],
+        ["workspaces.id"],
+        ondelete="SET NULL",
+        name="watch_interests_workspace_id_fkey",
+    ),
     CheckConstraint(
         "threshold >= 0.0 AND threshold <= 1.0",
         name="watch_interests_threshold_range",
@@ -367,11 +391,17 @@ Table(
         "notify_mode IN ('instant', 'batch', 'silent')",
         name="watch_interests_notify_mode_known",
     ),
+    UniqueConstraint("user_id", "title", name="uq_watch_interests_user_title"),
     Index("idx_watch_interests_user_id", "user_id"),
     Index(
         "idx_watch_interests_active",
         "is_active",
         postgresql_where=text("is_active = true"),
+    ),
+    Index(
+        "idx_watch_interests_workspace_id",
+        "workspace_id",
+        postgresql_where=text("workspace_id IS NOT NULL"),
     ),
 )
 
@@ -406,6 +436,36 @@ Table(
         name="uq_watch_matches_interest_source",
     ),
     Index("idx_watch_matches_interest_created", "interest_id", "created_at"),
+)
+
+# idempotency_keys — created via raw SQL in f1a2b3c4d5e6 (Wave 1 step 3
+#                    commit 1/4). Skeleton table for the HTTP middleware
+#                    wired in commit 4/4: every replay-able POST stores
+#                    `(key, request_hash, response_body)` here for the
+#                    24-hour TTL window. Cleanup task lives in the
+#                    scheduler tick (Q-OPEN-2 from sprint prompt).
+Table(
+    "idempotency_keys",
+    INGESTION_METADATA,
+    Column("key", Text(), nullable=False),
+    Column("user_id", UUID(as_uuid=True), nullable=False),
+    Column("request_hash", Text(), nullable=False),
+    Column("response_body", JSONB(), nullable=False),
+    Column(
+        "created_at",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("now()"),
+    ),
+    PrimaryKeyConstraint("key", name="idempotency_keys_pkey"),
+    ForeignKeyConstraint(
+        ["user_id"],
+        ["users.id"],
+        ondelete="CASCADE",
+        name="idempotency_keys_user_id_fkey",
+    ),
+    Index("idx_idempotency_keys_created_at", "created_at"),
+    Index("idx_idempotency_keys_user_id", "user_id"),
 )
 
 

--- a/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
+++ b/tg_parser/storage/sqlalchemy/digest_subscription_repo.py
@@ -14,7 +14,7 @@ from tg_parser.storage.ports import DigestSubscriptionRepo
 _SELECT_COLUMNS = (
     "id, owner_id, chat_id, name, channel_ids, cron_expression, timezone, "
     "format, language, is_active, last_sent_at, last_digest_cursor, "
-    "created_at, updated_at"
+    "workspace_id, created_at, updated_at"
 )
 
 
@@ -34,11 +34,12 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
                 INSERT INTO digest_subscriptions
                     (id, owner_id, chat_id, name, channel_ids, cron_expression,
                      timezone, format, language, is_active,
-                     last_sent_at, last_digest_cursor)
+                     last_sent_at, last_digest_cursor, workspace_id)
                 VALUES
                     (:id, :owner_id, :chat_id, :name, :channel_ids,
                      :cron_expression, :timezone, :format, :language,
-                     :is_active, :last_sent_at, :last_digest_cursor)
+                     :is_active, :last_sent_at, :last_digest_cursor,
+                     :workspace_id)
                 RETURNING {_SELECT_COLUMNS}
             """)
             params = {"id": provided_id}
@@ -47,11 +48,11 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
                 INSERT INTO digest_subscriptions
                     (owner_id, chat_id, name, channel_ids, cron_expression,
                      timezone, format, language, is_active,
-                     last_sent_at, last_digest_cursor)
+                     last_sent_at, last_digest_cursor, workspace_id)
                 VALUES
                     (:owner_id, :chat_id, :name, :channel_ids, :cron_expression,
                      :timezone, :format, :language, :is_active,
-                     :last_sent_at, :last_digest_cursor)
+                     :last_sent_at, :last_digest_cursor, :workspace_id)
                 RETURNING {_SELECT_COLUMNS}
             """)
             params = {}
@@ -68,6 +69,7 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
                 "is_active": sub.is_active,
                 "last_sent_at": sub.last_sent_at,
                 "last_digest_cursor": sub.last_digest_cursor,
+                "workspace_id": sub.workspace_id,
             }
         )
         result = await self.session.execute(query, params)
@@ -79,6 +81,17 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
         result = await self.session.execute(
             text(f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions WHERE id = :id"),
             {"id": subscription_id},
+        )
+        row = result.fetchone()
+        return self._row_to_model(row) if row else None
+
+    async def find_by_owner_and_name(self, owner_id: str, name: str) -> DigestSubscription | None:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM digest_subscriptions "
+                f"WHERE owner_id = :owner_id AND name = :name"
+            ),
+            {"owner_id": owner_id, "name": name},
         )
         row = result.fetchone()
         return self._row_to_model(row) if row else None
@@ -97,6 +110,8 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
         chat_id: int | None = None,
         name: str | None = None,
         channel_ids: list[str] | None = None,
+        workspace_id: str | None = None,
+        unset_workspace_id: bool = False,
     ) -> DigestSubscription | None:
         sets: list[str] = []
         params: dict[str, Any] = {"id": subscription_id}
@@ -131,6 +146,11 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
         if channel_ids is not None:
             sets.append("channel_ids = :channel_ids")
             params["channel_ids"] = list(channel_ids)
+        if unset_workspace_id:
+            sets.append("workspace_id = NULL")
+        elif workspace_id is not None:
+            sets.append("workspace_id = :workspace_id")
+            params["workspace_id"] = workspace_id
 
         if not sets:
             return await self.get(subscription_id)
@@ -184,12 +204,14 @@ class SADigestSubscriptionRepo(DigestSubscriptionRepo):
 
     @staticmethod
     def _row_to_model(row: Any) -> DigestSubscription:
+        workspace_id_raw = getattr(row, "workspace_id", None)
         return DigestSubscription(
             id=str(row.id),
             owner_id=str(row.owner_id),
             chat_id=int(row.chat_id),
             name=row.name,
             channel_ids=list(row.channel_ids or []),
+            workspace_id=str(workspace_id_raw) if workspace_id_raw is not None else None,
             cron_expression=row.cron_expression,
             timezone=row.timezone,
             format=DigestFormat(row.format),

--- a/tg_parser/storage/sqlalchemy/idempotency_key_repo.py
+++ b/tg_parser/storage/sqlalchemy/idempotency_key_repo.py
@@ -1,0 +1,102 @@
+"""SQLAlchemy implementation of IdempotencyKeyRepo (Wave 1 step 3 commit 4/4).
+
+Storage: PostgreSQL ``idempotency_keys`` (ingestion DB), created by migration
+``f1a2b3c4d5e6``. This repo is the persistence backend for the Stripe-style
+HTTP middleware in ``tg_parser/api/idempotency.py`` (opt-in per Q-OPEN-7 on
+``POST /api/v1/watchlists`` + ``POST /api/v1/digests``); ADR 0009 Option C
+hybrid.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tg_parser.domain.models import IdempotencyKey
+from tg_parser.storage.ports import IdempotencyKeyRepo
+
+
+class SAIdempotencyKeyRepo(IdempotencyKeyRepo):
+    """PostgreSQL-backed Idempotency-Key repository (ingestion DB).
+
+    Every method commits on its own — the table has no transactional
+    coupling with the endpoints it serves (a successful POST that
+    crashes before ``insert(...)`` simply replays as a cache miss on
+    retry, which is harmless given the service-layer natural-key
+    upsert collapses duplicates).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def find_by_key(self, *, key: str, user_id: str) -> IdempotencyKey | None:
+        result = await self.session.execute(
+            text(
+                "SELECT key, user_id, request_hash, response_body, created_at "
+                "FROM idempotency_keys "
+                "WHERE key = :key AND user_id = :user_id"
+            ),
+            {"key": key, "user_id": user_id},
+        )
+        row = result.fetchone()
+        if row is None:
+            return None
+        response_body = row.response_body
+        if isinstance(response_body, str):
+            response_body = json.loads(response_body)
+        return IdempotencyKey(
+            key=str(row.key),
+            user_id=str(row.user_id),
+            request_hash=str(row.request_hash),
+            response_body=dict(response_body or {}),
+            created_at=row.created_at,
+        )
+
+    async def insert(
+        self,
+        *,
+        key: str,
+        user_id: str,
+        request_hash: str,
+        response_body: dict[str, Any],
+    ) -> None:
+        """INSERT a fresh cache row.
+
+        Uses ``ON CONFLICT (key) DO NOTHING`` so a benign race between
+        two near-simultaneous first POSTs (same key, both miss the
+        ``find_by_key`` check) collapses to one row instead of an
+        :class:`IntegrityError`. The losing branch silently drops its
+        response — both clients receive a valid 2xx and a subsequent
+        replay will deterministically hit the surviving row.
+        """
+        await self.session.execute(
+            text(
+                "INSERT INTO idempotency_keys (key, user_id, request_hash, response_body) "
+                "VALUES (:key, :user_id, :request_hash, CAST(:response_body AS jsonb)) "
+                "ON CONFLICT (key) DO NOTHING"
+            ),
+            {
+                "key": key,
+                "user_id": user_id,
+                "request_hash": request_hash,
+                "response_body": json.dumps(response_body),
+            },
+        )
+        await self.session.commit()
+
+    async def delete_older_than(self, cutoff: datetime) -> int:
+        result = await self.session.execute(
+            text("DELETE FROM idempotency_keys WHERE created_at < :cutoff"),
+            {"cutoff": cutoff},
+        )
+        await self.session.commit()
+        return int(result.rowcount or 0)
+
+    async def count(self) -> int:
+        result = await self.session.execute(text("SELECT COUNT(*) FROM idempotency_keys"))
+        row = result.fetchone()
+        return int(row[0]) if row is not None else 0

--- a/tg_parser/storage/sqlalchemy/watch_interest_repo.py
+++ b/tg_parser/storage/sqlalchemy/watch_interest_repo.py
@@ -18,7 +18,7 @@ _SELECT_COLUMNS = (
     "keywords, exclude_keywords, channel_ids, "
     "threshold, notify_mode, is_active, "
     "embedding::text AS embedding_text, "
-    "last_checked_at, last_match_at, "
+    "last_checked_at, last_match_at, workspace_id, "
     "created_at, updated_at"
 )
 
@@ -39,13 +39,15 @@ class SAWatchInterestRepo(WatchInterestRepo):
                     (id, user_id, chat_id, title, description,
                      keywords, exclude_keywords, channel_ids,
                      threshold, notify_mode, is_active,
-                     embedding, last_checked_at, last_match_at)
+                     embedding, last_checked_at, last_match_at,
+                     workspace_id)
                 VALUES
                     (:id, :user_id, :chat_id, :title, :description,
                      :keywords, :exclude_keywords, :channel_ids,
                      :threshold, :notify_mode, :is_active,
                      CAST(:embedding AS vector),
-                     :last_checked_at, :last_match_at)
+                     :last_checked_at, :last_match_at,
+                     :workspace_id)
                 RETURNING {_SELECT_COLUMNS}
             """)
             params: dict[str, Any] = {"id": provided_id}
@@ -55,13 +57,15 @@ class SAWatchInterestRepo(WatchInterestRepo):
                     (user_id, chat_id, title, description,
                      keywords, exclude_keywords, channel_ids,
                      threshold, notify_mode, is_active,
-                     embedding, last_checked_at, last_match_at)
+                     embedding, last_checked_at, last_match_at,
+                     workspace_id)
                 VALUES
                     (:user_id, :chat_id, :title, :description,
                      :keywords, :exclude_keywords, :channel_ids,
                      :threshold, :notify_mode, :is_active,
                      CAST(:embedding AS vector),
-                     :last_checked_at, :last_match_at)
+                     :last_checked_at, :last_match_at,
+                     :workspace_id)
                 RETURNING {_SELECT_COLUMNS}
             """)
             params = {}
@@ -81,6 +85,7 @@ class SAWatchInterestRepo(WatchInterestRepo):
                 "embedding": embedding_param,
                 "last_checked_at": interest.last_checked_at,
                 "last_match_at": interest.last_match_at,
+                "workspace_id": interest.workspace_id,
             }
         )
 
@@ -95,6 +100,78 @@ class SAWatchInterestRepo(WatchInterestRepo):
             {"id": interest_id},
         )
         row = result.fetchone()
+        return self._row_to_model(row) if row else None
+
+    async def find_by_user_and_title(self, user_id: str, title: str) -> WatchInterest | None:
+        result = await self.session.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM watch_interests "
+                f"WHERE user_id = :user_id AND title = :title"
+            ),
+            {"user_id": user_id, "title": title},
+        )
+        row = result.fetchone()
+        return self._row_to_model(row) if row else None
+
+    async def update_subscribe_fields(
+        self,
+        interest_id: str,
+        *,
+        chat_id: int | None = None,
+        description: str | None = None,
+        keywords: list[str] | None = None,
+        exclude_keywords: list[str] | None = None,
+        channel_ids: list[str] | None = None,
+        threshold: float | None = None,
+        notify_mode: NotifyMode | None = None,
+        is_active: bool | None = None,
+        workspace_id: str | None = None,
+        unset_workspace_id: bool = False,
+    ) -> WatchInterest | None:
+        sets: list[str] = []
+        params: dict[str, Any] = {"id": interest_id}
+
+        if chat_id is not None:
+            sets.append("chat_id = :chat_id")
+            params["chat_id"] = chat_id
+        if description is not None:
+            sets.append("description = :description")
+            params["description"] = description
+        if keywords is not None:
+            sets.append("keywords = :keywords")
+            params["keywords"] = list(keywords)
+        if exclude_keywords is not None:
+            sets.append("exclude_keywords = :exclude_keywords")
+            params["exclude_keywords"] = list(exclude_keywords)
+        if channel_ids is not None:
+            sets.append("channel_ids = :channel_ids")
+            params["channel_ids"] = list(channel_ids)
+        if threshold is not None:
+            sets.append("threshold = :threshold")
+            params["threshold"] = float(threshold)
+        if notify_mode is not None:
+            sets.append("notify_mode = :notify_mode")
+            params["notify_mode"] = str(notify_mode.value)
+        if is_active is not None:
+            sets.append("is_active = :is_active")
+            params["is_active"] = is_active
+        if unset_workspace_id:
+            sets.append("workspace_id = NULL")
+        elif workspace_id is not None:
+            sets.append("workspace_id = :workspace_id")
+            params["workspace_id"] = workspace_id
+
+        if not sets:
+            return await self.get(interest_id)
+
+        sets.append("updated_at = NOW()")
+        sql = (
+            f"UPDATE watch_interests SET {', '.join(sets)} "
+            f"WHERE id = :id RETURNING {_SELECT_COLUMNS}"
+        )
+        result = await self.session.execute(text(sql), params)
+        row = result.fetchone()
+        await self.session.commit()
         return self._row_to_model(row) if row else None
 
     async def list_for_user(self, user_id: str) -> list[WatchInterest]:
@@ -171,6 +248,7 @@ class SAWatchInterestRepo(WatchInterestRepo):
     def _row_to_model(row: Any) -> WatchInterest:
         embedding_text = getattr(row, "embedding_text", None)
         embedding = _parse_pgvector_text(embedding_text) if embedding_text else None
+        workspace_id_raw = getattr(row, "workspace_id", None)
         return WatchInterest(
             id=str(row.id),
             user_id=str(row.user_id),
@@ -180,6 +258,7 @@ class SAWatchInterestRepo(WatchInterestRepo):
             keywords=list(row.keywords or []),
             exclude_keywords=list(row.exclude_keywords or []),
             channel_ids=list(row.channel_ids or []),
+            workspace_id=str(workspace_id_raw) if workspace_id_raw is not None else None,
             threshold=float(row.threshold),
             notify_mode=NotifyMode(row.notify_mode),
             is_active=bool(row.is_active),


### PR DESCRIPTION
## Summary

Wave 1 step 3 — **Surface Parity MVP** — closes the F11 Watchlist + F6 Digest HTTP API gap (audience A4 AI Agent Builder, primary; A6 Domain Curator, secondary via ENH-9). Single PR + 4 atomic commits per sprint prompt §8 PR shape.

| Commit | SHA | Scope |
|---|---|---|
| 1/4 | `56e65e2` | ENH-9 + BUG-022 service-layer foundation (Alembic migration + domain models + repo upsert + multi-surface signatures) |
| 2/4 | `6efb20b` | P-1 Watchlist HTTP API (5 endpoints under `/api/v1/watchlists`) |
| 3/4 | `0e450eb` | P-2 Digest HTTP API (4 endpoints under `/api/v1/digests`) |
| 4/4 | `5b828cf` | Idempotency-Key HTTP middleware + hourly cleanup tick + Prometheus metrics + docs + DONE marker stub + ADR 0009 `Draft → Accepted` |

## What lands

### P-1 Watchlist HTTP API (5 endpoints)
- `POST /api/v1/watchlists` — subscribe (idempotent upsert; `{watchlist_id, created, changed_fields}`)
- `GET /api/v1/watchlists` — list (offset/limit pagination)
- `GET /api/v1/watchlists/{id}` — single detail (workspace_id + workspace_name JOIN)
- `DELETE /api/v1/watchlists/{id}` — soft-delete (idempotent: second DELETE → 204)
- `GET /api/v1/watchlists/{id}/matches` — match history (`?since=ISO8601` + pagination)

### P-2 Digest HTTP API (4 endpoints)
- `POST /api/v1/digests` — subscribe (cron pre-validation, 422 `InvalidCron` on bad spec; row-not-written guard)
- `GET /api/v1/digests` — list
- `GET /api/v1/digests/{id}` — single detail
- `DELETE /api/v1/digests/{id}` — **HARD DELETE** (Q8 digest variant; second DELETE → 404, REST-strict per Q-OPEN-8; ASYMMETRIC vs watchlist 204+204)

### ENH-9 `workspace_id` (across all 4 surfaces)
- New nullable FK column on `watch_interests` + `digest_subscriptions` (ON DELETE SET NULL).
- `subscribe_*(... workspace_id=None)` on MCP / Bot / CLI / HTTP.
- Unknown / foreign → `WorkspaceNotFound` 404-like (existence never leaked).
- `workspace_id=None` default preserves bit-for-bit pre-ENH-9 behaviour.
- HTTP responses include `workspace_name` JOIN (Q-OPEN-3).

### BUG-022 idempotency closure (ADR 0009 Option C — Accepted)
- **Service-layer natural-key upsert** on `(user_id, title)` for watchlist + `(owner_id, name)` for digest.
- New `UNIQUE` constraints; race-condition guard via `IntegrityError` catch → retry as UPDATE.
- Soft-deleted rows resurrect on subscribe (`is_active` flips True, surfaced in `changed_fields`).
- **HTTP-layer Idempotency-Key middleware** (Stripe-style) on subscribe POST endpoints (opt-in per Q-OPEN-7).
  - Same key + same body → cached response.
  - Same key + different body → 422 `IdempotencyKeyMismatch`.
  - Only 2xx cached (R-2); canonical JSON hash (R-4); per-user scope.
- **Self-defensive migration** aborts with pointer to `docs/runbooks/wave1_step3_idempotency_dedupe.md` if pre-existing duplicates exist (R-3 `High → Low`).

### Cleanup + observability
- Hourly cron `0 * * * *` cleanup of stale idempotency keys (>24h).
- Prometheus metrics: `tg_idempotency_keys_hit_total{result=hit|miss|mismatch}`, `tg_idempotency_keys_table_size` (gauge).
- structlog binds: `idempotency_key`, `workspace_id`, `subscription_id` on relevant entry points.

### Docs + ADR
- `docs/USER_GUIDE.md`: new "HTTP API — Watchlist + Digest" section (auth, endpoints, Idempotency-Key, workspace_id, error shape, curl examples).
- `docs/MCP_AGENT_GUIDE.md`: 9 REST rows + HTTP↔MCP parity note.
- `CHANGELOG.md`: consolidated `[Unreleased]` entry.
- `docs/adr/0009-idempotency.md`: `Draft → Accepted (2026-05-22)`.
- `docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md`: DONE marker stub (post-watch sections marked TBD).
- `docs/runbooks/wave1_step3_idempotency_dedupe.md`: NEW admin runbook for pre-migration dedupe.

## Locked decisions (Q1–Q9 + Q-OPEN locks)

- **Q1 auth:** `X-API-Key` via existing `resolve_current_user` (no new auth surface).
- **Q4 base path:** `/api/v1/*` flat resource names.
- **Q5 versioning:** `/api/v1/*` (v2 reserved for future breaking shape change, e.g., ADR 0008 polymorphic target).
- **Q6 target:** `chat_id` only; polymorphic target deferred (Wave 1 step 4 + Wave 2A).
- **Q7 response:** Pydantic + envelope; flat `schemas.py` extend, not package split.
- **Q8 DELETE asymmetry:** watchlist soft (204+204), digest hard (204+404, REST-strict per parent Q-OPEN-8).
- **Q-OPEN-1:** `changed_fields` = Pydantic field names list.
- **Q-OPEN-3:** workspace_name JOIN in HTTP responses.
- **Q-OPEN-4:** `?since` only for matches filter; `until` / `min_score` deferred.
- **Q-OPEN-5:** self-defensive migration + new runbook.
- **Q-OPEN-7:** middleware opt-in per endpoint (watchlist + digest POST only); broadening = future PR.
- **Q-OPEN-8:** REST-strict DELETE (asymmetric per surface semantics).

## Anti-scope (hard, NOT in this PR)

- BUG-015 / ENH-1 / ENH-2 / O-3 → Wave 1 step 3.1 sprint (ADR 0007 ratification first).
- ADR 0008 polymorphic target (webhook / channel publish) → Wave 1 step 4 + Wave 2A.
- F4-B Sharing, Bot workspace UX, O-1 → Wave 2+.
- CLI gap A-1..A-13 → separate CLI parity sprint.
- M-15 docs hygiene, topicization, pipeline_service paths → orthogonal к subscribe_*; untouched.

## Tests

- **Default mode:** `2175 passed, 311 skipped, 0 failed` (was 2147/258 baseline → +28 passed [auth-gate tests] + +53 PG-skipped [new PG-gated functional]; ruff clean).
- **`TEST_POSTGRES=1` mode:** `2477 passed, 9 skipped, 0 failed` (was 2416/9 baseline → +61 new tests all green; the 9 remaining are pre-existing testcontainers-gated migration smokes).
- **0 regressions** on `test_f4*`, `test_f4b*`, `test_f6*`, `test_f11*`, `test_api_*`, `test_scheduler_service*`, `test_watchlist_service*`.

### New test files (~63 scenarios across 4 files)
- `tests/test_subscribe_idempotency.py` — 9 service-layer scenarios (BUG-022).
- `tests/test_watchlist_workspace_id.py` — 11 ENH-9 scenarios (workspace scoping × both subscribe paths).
- `tests/test_api_watchlists.py` — 23 P-1 HTTP scenarios.
- `tests/test_api_digests.py` — 23 P-2 HTTP scenarios.
- `tests/test_idempotency_key_middleware.py` — 12 middleware scenarios.
- `tests/test_idempotency_cleanup_job.py` — 3 cleanup tick scenarios.

## CI expected (5/5 green per sprint prompt §6 acceptance)

- Alembic upgrade smoke ×2 (default + testcontainers)
- Docker Build
- Lint Documentation
- Test Python 3.12

## Test plan для review (manual smoke после merge + deploy)

- [ ] `curl POST /api/v1/watchlists` с valid X-API-Key → 201 + `{watchlist_id, created: true, changed_fields: []}`
- [ ] Replay same body + `Idempotency-Key: foo` → cached response (`created: false`, no duplicate row)
- [ ] `curl POST /api/v1/watchlists` same key + different body → 422 `IdempotencyKeyMismatch`
- [ ] `curl POST /api/v1/digests` с invalid cron → 422 `InvalidCron` (no row written)
- [ ] `curl DELETE /api/v1/digests/{id}` → 204; replay → 404 (HARD DELETE)
- [ ] `workspace_id=<foreign>` → 404 `WorkspaceNotFound` (existence not leaked)
- [ ] Prometheus `tg_idempotency_keys_hit_total{result=hit}` increments on cached response.
- [ ] Hourly cleanup tick deletes >24h rows (visible in `docker logs tg_parser`).

## 24h post-deploy watch

Per sprint prompt §6:
- `tg_idempotency_keys_hit_total{result=mismatch}` — should be ~0 in normal traffic.
- `tg_watchlist_subscribe_total{result}` / `tg_digest_subscribe_total{result}` — emit на каждой subscribe.
- HTTP error rate `tg_api_requests_total{status=5xx}` on new endpoints — must be 0.
- Existing F11 / F6 metrics — must not regress.

After 24h GREEN → update `docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md` §2/§3/§6 with post-watch verdicts.

## Refs

- Sprint prompt: `docs/notes/START_PROMPT_SPRINT_WAVE1_STEP3_2026-05-21.md`
- ADR 0009 (Accepted): `docs/adr/0009-idempotency.md`
- ADR 0008 (Draft, partial use for Q6 chat_id-only): `docs/adr/0008-subscription-target-model.md`
- ADR 0007 (Draft, reference only — step 3.1 decision): `docs/adr/0007-mcp-scheduler-dispatch.md`
- DONE marker stub: `docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md`

Closes: BUG-022, ENH-9 (full surface roll-out), P-1, P-2.


Made with [Cursor](https://cursor.com)