### PR TITLE
fix(bug-028): digest cron PromptLoader None-string regression (hotfix)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,11 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - LLM_BASE_URL=${LLM_BASE_URL:-}
+      # Prompts (BUG-028 Layer D): explicit PROMPTS_DIR override pins the
+      # PromptLoader path inside the container, defense-in-depth for any
+      # call-site that bypasses Layers A/B/C. Default matches the
+      # `./prompts:/app/prompts:ro` bind mount above.
+      - PROMPTS_DIR=${PROMPTS_DIR:-/app/prompts}
       # Telegram
       - TELEGRAM_API_ID=${TELEGRAM_API_ID}
       - TELEGRAM_API_HASH=${TELEGRAM_API_HASH}
@@ -149,6 +154,8 @@ services:
       # Embedding (search_knowledge_base / ask_question)
       - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-openai}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-text-embedding-3-small}
+      # Prompts (BUG-028 Layer D): see tg_parser service for rationale.
+      - PROMPTS_DIR=${PROMPTS_DIR:-/app/prompts}
       # MCP
       - MCP_TRANSPORT=streamable-http
       - MCP_HOST=0.0.0.0
@@ -216,6 +223,14 @@ services:
       # Embedding (for search/RAG — uses OpenAI embeddings by default)
       - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-openai}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-text-embedding-3-small}
+      # Prompts (BUG-028 Layer D): explicit PROMPTS_DIR override pins the
+      # PromptLoader path inside the container for the daily digest cron
+      # (run_scheduled_digests_task → PromptLoader → load 'digest'/'processing').
+      # Defense-in-depth on top of Layers A/B/C; default matches the
+      # `./prompts:/app/prompts:ro` bind mount above. This was previously
+      # the prod hotfix workaround (applied 2026-05-23T09:49:15Z to
+      # tg_parser_bot ad-hoc) — now committed for all three services.
+      - PROMPTS_DIR=${PROMPTS_DIR:-/app/prompts}
       # Bot configuration
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - BOT_ALLOWED_USERS=${BOT_ALLOWED_USERS:-}

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -436,3 +436,88 @@ class TestRequiredStagesFailLoud:
 
         config = loader.load("resummarize")
         assert config["system"]["prompt"] == "Real resummarize prompt."
+
+
+class TestBug028LiteralNoneStringGuard:
+    """BUG-028 Layer B: defense-in-depth against literal ``"None"`` string.
+
+    Pre-hotfix, ``scheduler_service.py:560`` did
+    ``PromptLoader(prompts_dir=str(settings.prompts_dir))`` — when
+    ``settings.prompts_dir`` was ``None`` (the pre-Layer-C default), this
+    evaluated to ``PromptLoader(prompts_dir="None")`` because
+    ``str(None) == "None"``. ``Path("None")`` is a valid relative path
+    (PosixPath('None')), so the loader silently resolved
+    ``Path("None/<stage>.yaml")`` — surfaced in production as
+    ``YAML at None/digest.yaml did not provide a non-empty system.prompt``.
+
+    Layer A (call-site guard) plus Layer C (sensible default) already
+    prevent this for the production code path; Layer B is an explicit
+    in-class guard so any *future* call-site that accidentally passes
+    ``str(None)`` is rescued rather than silently degraded. This test
+    pins the Layer B contract.
+    """
+
+    def test_prompt_loader_falls_back_when_literal_None_string_passed(self):
+        """``PromptLoader(prompts_dir="None")`` MUST fall back to ``Path("prompts")``.
+
+        The fallback path is what makes the loader recover real YAML; the
+        critical anti-regression assertion is that ``prompts_dir`` is *not*
+        ``Path("None")`` after construction. Loading ``processing`` then
+        resolves real (non-empty) YAML content rather than the empty
+        config a non-existent ``None/processing.yaml`` would have yielded.
+        """
+        loader = PromptLoader(prompts_dir="None")
+
+        assert loader.prompts_dir == Path("prompts"), (
+            f"Layer B fallback regressed: prompts_dir={loader.prompts_dir!r} "
+            "(expected Path('prompts'))"
+        )
+        # Anti-regression: must NEVER silently resolve to literal 'None/...'.
+        assert loader.prompts_dir != Path("None")
+        assert str(loader.prompts_dir) != "None"
+
+        config = loader.load("processing")
+        assert isinstance(config, dict) and config, (
+            f"processing prompt resolved to empty: {config!r}"
+        )
+        assert config.get("system", {}).get("prompt", "").strip(), (
+            f"processing system.prompt is empty: {config!r}"
+        )
+
+    def test_prompt_loader_falls_back_when_pathified_None_string_passed(self):
+        """Same fallback must fire when caller pre-wraps the bad string in a Path.
+
+        ``PromptLoader(prompts_dir=Path("None"))`` is the second-order
+        artifact of an upstream ``Path(str(settings.prompts_dir))`` mistake.
+        The Layer B guard normalises both forms identically because it
+        compares ``str(self.prompts_dir) == "None"``.
+        """
+        loader = PromptLoader(prompts_dir=Path("None"))
+
+        assert loader.prompts_dir == Path("prompts"), (
+            f"Layer B fallback (Path form) regressed: {loader.prompts_dir!r}"
+        )
+
+        config = loader.load("processing")
+        assert config.get("system", {}).get("prompt", "").strip()
+
+    def test_prompt_loader_does_not_falsely_match_paths_containing_None(
+        self,
+        tmp_path: Path,
+    ):
+        """Layer B must only trigger on the *literal* string ``"None"``.
+
+        A directory whose name merely *contains* ``None`` (e.g.
+        ``/tmp/None-shaped-cache``) is a legitimate path and must be
+        accepted verbatim — otherwise the guard would erroneously rescue
+        a real, intentional configuration.
+        """
+        funny_dir = tmp_path / "NoneShapedCache"
+        funny_dir.mkdir()
+
+        loader = PromptLoader(prompts_dir=funny_dir)
+
+        assert loader.prompts_dir == funny_dir, (
+            "Layer B guard over-triggered: rewrote a legitimate directory "
+            f"name to {loader.prompts_dir!r}"
+        )

--- a/tests/test_scheduler_digest_prompt_loader.py
+++ b/tests/test_scheduler_digest_prompt_loader.py
@@ -1,0 +1,339 @@
+"""BUG-028 hotfix tests: digest cron PromptLoader None regression.
+
+Pins the contract that :func:`tg_parser.services.scheduler_service.run_scheduled_digests_task`
+(the APScheduler entry point that runs every active daily digest tick)
+constructs its :class:`tg_parser.processing.prompt_loader.PromptLoader`
+with a path that resolves to real YAML files even when
+``settings.prompts_dir`` is ``None`` or carries the post-Layer-C default
+``Path("prompts")``.
+
+Pre-fix call-site (``scheduler_service.py:560``)::
+
+    prompt_loader = PromptLoader(prompts_dir=str(settings.prompts_dir))
+
+evaluated to ``PromptLoader(prompts_dir="None")`` whenever the env var
+``PROMPTS_DIR`` was unset (because ``str(None) == "None"``). ``Path("None")``
+then silently became a valid relative path, and ``.load("digest")`` raised
+:class:`PromptLoaderError` with ``YAML at None/digest.yaml did not provide
+a non-empty system.prompt`` — surfaced in production on 2026-05-23T06:00:00Z
+during Wave 1 step 3 24h watch.
+
+Coverage map (mirrors hotfix layers documented in BUG_LOG.md § BUG-028):
+
+* :func:`test_settings_default_prompts_dir_is_path_prompts` — Layer C: a
+  hermetic ``Settings()`` (env scrubbed, ``.env`` bypassed) must expose
+  ``Path("prompts")`` as the default for :attr:`Settings.prompts_dir`.
+
+* :func:`test_digest_task_with_default_settings_loads_yaml_prompt` —
+  Layers A + C end-to-end: runs ``run_scheduled_digests_task`` with the
+  post-fix default settings, captures the live ``PromptLoader`` instance,
+  and asserts it resolves real non-empty YAML for the ``digest`` and
+  ``processing`` stages. The DB context is stubbed so ``sub_repo.get`` returns
+  ``None`` and the function short-circuits at ``not_found`` before any LLM
+  / bot work — but the ``PromptLoader`` construction at line 560 fires
+  unconditionally, which is exactly the call-site we need to exercise.
+
+* :func:`test_digest_task_with_explicit_none_prompts_dir_does_not_raise` —
+  Layer A guard isolation: forces ``settings.prompts_dir = None`` to
+  simulate the pre-Layer-C state and asserts that the guard converts
+  ``None`` to ``None`` (not the literal string ``"None"``) so the
+  downstream ``PromptLoader`` falls back to its own ``Path("prompts")``
+  default and still loads real YAML.
+
+Why this gap existed before BUG-028: ``tests/test_f6_scheduled_digests.py``
+exercises :class:`DigestService` directly with a manually-constructed
+``PromptLoader`` backed by the real ``prompts/`` directory; the production
+call-site at ``scheduler_service.py:560`` was never reached by any unit
+test, so the ``str(settings.prompts_dir)`` footgun stayed latent for
+~5 weeks after F6 landed (2026-04-19).
+"""
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_ingestion_and_processing_repos():
+    """Return an async-context factory yielding throwaway repo mocks.
+
+    Mirrors :func:`tests.test_scheduler_service._mock_ingestion_and_processing_repos`
+    but with no behaviour wired up — the test exits via ``not_found`` before
+    touching either repo, so AsyncMock defaults are sufficient.
+    """
+
+    @asynccontextmanager
+    async def _cm():
+        mock_state_repo = AsyncMock()
+        mock_processed_repo = AsyncMock()
+        mock_db = MagicMock()
+        mock_db.close = AsyncMock()
+        yield mock_state_repo, mock_processed_repo, mock_db
+
+    return _cm
+
+
+def _stub_digest_subscription_repo(*, sub_to_return):
+    """Return an async-context factory yielding a ``sub_repo`` mock.
+
+    ``sub_repo.get`` resolves to ``sub_to_return``; in BUG-028 tests we always
+    pass ``None`` so :func:`run_scheduled_digests_task` short-circuits at
+    ``not_found`` immediately after the ``PromptLoader`` construction.
+    """
+
+    @asynccontextmanager
+    async def _cm():
+        mock_sub_repo = AsyncMock()
+        mock_sub_repo.get.return_value = sub_to_return
+        mock_db = MagicMock()
+        mock_db.close = AsyncMock()
+        yield mock_sub_repo, mock_db
+
+    return _cm
+
+
+def _build_hermetic_settings():
+    """Construct a ``Settings`` instance fully isolated from local env / .env.
+
+    - ``_env_file=None`` bypasses the ``.env`` autoload so a developer's
+      personal ``PROMPTS_DIR`` override in ``.env`` cannot poison the test.
+    - ``PROMPTS_DIR`` env var must be scrubbed by the caller (via the
+      ``hermetic_prompts_env`` fixture).
+    """
+    from tg_parser.config.settings import Settings
+
+    return Settings(_env_file=None)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermetic_prompts_env(monkeypatch):
+    """Scrub ``PROMPTS_DIR`` so default-mode ``Settings()`` is deterministic.
+
+    The fixture only touches env — ``_env_file`` is handled per-test via
+    :func:`_build_hermetic_settings`. Yields the monkeypatch handle so
+    callers can layer additional patches on top.
+    """
+    monkeypatch.delenv("PROMPTS_DIR", raising=False)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Layer C — Settings default
+# ---------------------------------------------------------------------------
+
+
+def test_settings_default_prompts_dir_is_path_prompts(hermetic_prompts_env):
+    """Layer C: bare ``Settings()`` must expose ``Path("prompts")`` default.
+
+    Pre-fix default was ``None``, which combined with the ``str(...)`` cast
+    at the scheduler call-site to produce the literal ``"None"`` string.
+    Layer C removes the ambiguity by making the default explicit; the
+    ``Path | None`` typing is preserved so Layers A + B remain valid
+    defense-in-depth.
+    """
+    test_settings = _build_hermetic_settings()
+
+    assert test_settings.prompts_dir == Path("prompts"), (
+        "Layer C regressed: Settings.prompts_dir default is "
+        f"{test_settings.prompts_dir!r} (expected Path('prompts'))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer A + C end-to-end through digest_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_digest_task_with_default_settings_loads_yaml_prompt(
+    hermetic_prompts_env,
+):
+    """``run_scheduled_digests_task`` must NOT raise PromptLoaderError on default settings.
+
+    Exercises the *exact* production call-site that BUG-028 fires from
+    (scheduler_service.py:560) with the post-fix settings default. After
+    short-circuiting at ``not_found`` (PromptLoader is constructed BEFORE
+    the DB lookup), we inspect the captured loader and assert it resolves
+    real YAML for the two stages :class:`DigestService` actually consumes
+    (``digest`` and ``processing``).
+    """
+    monkeypatch = hermetic_prompts_env
+
+    test_settings = _build_hermetic_settings()
+    # Sanity: this test only makes sense once Layer C is in place. If this
+    # assertion fails the second integration assertion below would be
+    # vacuously testing the wrong code path.
+    assert test_settings.prompts_dir == Path("prompts")
+
+    monkeypatch.setattr("tg_parser.services.scheduler_service.settings", test_settings)
+
+    # Capture every PromptLoader instance constructed during the call so we
+    # can assert against the *production* object rather than rebuilding our
+    # own. spy_init must call the real __init__ to preserve all attributes.
+    from tg_parser.processing import prompt_loader as pl_module
+
+    real_init = pl_module.PromptLoader.__init__
+    captured_loaders: list[pl_module.PromptLoader] = []
+    captured_init_args: list[object] = []
+
+    def spy_init(self, prompts_dir=None):
+        captured_init_args.append(prompts_dir)
+        real_init(self, prompts_dir=prompts_dir)
+        captured_loaders.append(self)
+
+    monkeypatch.setattr(pl_module.PromptLoader, "__init__", spy_init)
+
+    # Function-local imports inside run_scheduled_digests_task pull names
+    # from their source modules each call — patch the source, not the
+    # scheduler module symbol table.
+    monkeypatch.setattr(
+        "tg_parser.services.db_context.ingestion_and_processing_repos",
+        _stub_ingestion_and_processing_repos(),
+    )
+    monkeypatch.setattr(
+        "tg_parser.services.db_context.digest_subscription_repo",
+        _stub_digest_subscription_repo(sub_to_return=None),
+    )
+
+    from tg_parser.services.scheduler_service import run_scheduled_digests_task
+
+    # not_found short-circuits BEFORE DigestService / LLM / bot are touched,
+    # which keeps the test hermetic. The PromptLoader line is BEFORE the DB
+    # lookup, so this still exercises the BUG-028 call-site.
+    result = await run_scheduled_digests_task("00000000-0000-0000-0000-000000000000")
+
+    assert result == {
+        "subscription_id": "00000000-0000-0000-0000-000000000000",
+        "status": "not_found",
+    }
+
+    # The not_found short-circuit path constructs exactly ONE PromptLoader
+    # (the one at scheduler_service.py:560 — the BUG-028 call-site).
+    # Asserting exact count catches spurious extra construction during
+    # cold-import of scheduler_service or db_context that would muddy
+    # which captured arg we are inspecting.
+    assert len(captured_loaders) == 1, (
+        f"Expected exactly 1 PromptLoader construction in not_found path, "
+        f"got {len(captured_loaders)} (init_args={captured_init_args!r})"
+    )
+
+    # Layer A + C: the call-site passes ``str(Path("prompts")) == "prompts"``
+    # — never the literal "None". This is the assertion that would have
+    # caught BUG-028 if it had existed. Pre-Layer-C alone: arg would be
+    # "None" (because str(None) == "None"). Pre-Layer-A with post-Layer-C:
+    # arg would still be "prompts" — but the dedicated Layer-A isolation
+    # test below covers the None-default scenario.
+    assert captured_init_args[0] == "prompts", (
+        f"Layer A/C regressed: PromptLoader received {captured_init_args[0]!r} (expected 'prompts')"
+    )
+
+    loader = captured_loaders[0]
+    assert loader.prompts_dir == Path("prompts")
+
+    # Real YAML resolution (not just "didn't raise"). digest_service loads
+    # both "digest" (for system / user templates) and "processing" (re-used
+    # in some delivery code paths). Both must yield non-empty system prompts.
+    digest_cfg = loader.load("digest")
+    assert isinstance(digest_cfg, dict) and digest_cfg, "digest.yaml resolved to empty"
+    digest_prompt = digest_cfg.get("system", {}).get("prompt", "")
+    assert isinstance(digest_prompt, str) and digest_prompt.strip(), (
+        f"digest.yaml system.prompt is empty: {digest_prompt!r}"
+    )
+
+    processing_cfg = loader.load("processing")
+    assert isinstance(processing_cfg, dict) and processing_cfg
+    processing_prompt = processing_cfg.get("system", {}).get("prompt", "")
+    assert isinstance(processing_prompt, str) and processing_prompt.strip(), (
+        f"processing.yaml system.prompt is empty: {processing_prompt!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer A guard isolation (forces the pre-Layer-C bug state)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_digest_task_with_explicit_none_prompts_dir_does_not_raise(
+    hermetic_prompts_env,
+):
+    """Layer A: even if ``settings.prompts_dir`` is the bare ``None`` value
+    the original F6 sprint shipped, the call-site must NOT regress to
+    ``str(None) == "None"`` semantics.
+
+    This is the regression test specifically pinned at the Layer A guard.
+    Without the guard, ``captured_init_args[0]`` would equal the string
+    ``"None"`` and the assertion below would fail; with the guard, it
+    must be the Python ``None`` value (and the PromptLoader's own
+    ``None``-handling kicks in to produce ``Path("prompts")``).
+    """
+    monkeypatch = hermetic_prompts_env
+
+    test_settings = _build_hermetic_settings()
+    # Force the original pre-Layer-C bug state — this is what production
+    # looked like before 2026-05-23.
+    test_settings.prompts_dir = None
+
+    monkeypatch.setattr("tg_parser.services.scheduler_service.settings", test_settings)
+
+    from tg_parser.processing import prompt_loader as pl_module
+
+    real_init = pl_module.PromptLoader.__init__
+    captured_loaders: list[pl_module.PromptLoader] = []
+    captured_init_args: list[object] = []
+
+    def spy_init(self, prompts_dir=None):
+        captured_init_args.append(prompts_dir)
+        real_init(self, prompts_dir=prompts_dir)
+        captured_loaders.append(self)
+
+    monkeypatch.setattr(pl_module.PromptLoader, "__init__", spy_init)
+
+    monkeypatch.setattr(
+        "tg_parser.services.db_context.ingestion_and_processing_repos",
+        _stub_ingestion_and_processing_repos(),
+    )
+    monkeypatch.setattr(
+        "tg_parser.services.db_context.digest_subscription_repo",
+        _stub_digest_subscription_repo(sub_to_return=None),
+    )
+
+    from tg_parser.services.scheduler_service import run_scheduled_digests_task
+
+    result = await run_scheduled_digests_task("00000000-0000-0000-0000-000000000000")
+
+    assert result["status"] == "not_found"
+    assert len(captured_loaders) == 1, (
+        f"Expected exactly 1 PromptLoader construction, got {len(captured_loaders)} "
+        f"(init_args={captured_init_args!r})"
+    )
+
+    # Crux of Layer A: guard converts ``None`` → ``None`` (NOT "None").
+    # Pre-fix code would have produced the string ``"None"`` here, which
+    # would in turn make ``loader.prompts_dir == Path("None")`` — and that
+    # is exactly the BUG-028 production failure mode.
+    assert captured_init_args[0] is None, (
+        f"Layer A guard broken: PromptLoader received {captured_init_args[0]!r} instead of None"
+    )
+
+    loader = captured_loaders[0]
+    # PromptLoader's own None-branch chooses Path("prompts").
+    assert loader.prompts_dir == Path("prompts")
+
+    # Belt-and-suspenders: real YAML still resolves. Pre-fix this raised
+    # PromptLoaderError with the "None/digest.yaml" message.
+    digest_cfg = loader.load("digest")
+    digest_prompt = digest_cfg.get("system", {}).get("prompt", "")
+    assert digest_prompt.strip(), (
+        f"digest.yaml resolved to empty under None-default fallback: {digest_prompt!r}"
+    )

--- a/tg_parser/config/settings.py
+++ b/tg_parser/config/settings.py
@@ -284,7 +284,15 @@ class Settings(BaseSettings):
     # Промпты (v1.1 Configurable Prompts)
     # ==========================================================================
 
-    prompts_dir: Path | None = None  # Кастомная директория промптов (default: ./prompts)
+    # Кастомная директория промптов (по умолчанию ./prompts).
+    #
+    # BUG-028 Layer C: default is Path("prompts") (not None) so downstream
+    # callers that do ``str(settings.prompts_dir)`` never see the literal
+    # Python string "None". The ``Path | None`` typing is preserved so
+    # call-sites can still pass ``None`` explicitly and so the Layer A
+    # (scheduler_service.py guard) / Layer B (PromptLoader fallback) layers
+    # remain valid defense-in-depth.
+    prompts_dir: Path | None = Path("prompts")
 
     # ==========================================================================
     # Output директория

--- a/tg_parser/processing/prompt_loader.py
+++ b/tg_parser/processing/prompt_loader.py
@@ -82,6 +82,20 @@ class PromptLoader:
             # Default: ./prompts в текущей рабочей директории
             self.prompts_dir = Path("prompts")
 
+        # BUG-028 Layer B: defense-in-depth against call-sites that
+        # accidentally pass ``str(None) == "None"`` (the literal Python
+        # repr of None) instead of a real path. Without this guard,
+        # ``Path("None")`` is a valid relative path that silently resolves
+        # to non-existent ``None/<stage>.yaml`` files, defeating the
+        # fail-loud contract for required stages.
+        if str(self.prompts_dir) == "None":
+            logger.warning(
+                "PromptLoader received literal 'None' string for prompts_dir; "
+                "falling back to default Path('prompts')",
+                received=prompts_dir,
+            )
+            self.prompts_dir = Path("prompts")
+
         self._cache: dict[str, dict[str, Any]] = {}
 
         logger.debug("PromptLoader initialized with prompts_dir=%s", self.prompts_dir)

--- a/tg_parser/services/scheduler_service.py
+++ b/tg_parser/services/scheduler_service.py
@@ -557,7 +557,9 @@ async def run_scheduled_digests_task(subscription_id: str) -> dict[str, Any]:
 
     logger.info("digest_task_triggered", subscription_id=subscription_id)
 
-    prompt_loader = PromptLoader(prompts_dir=str(settings.prompts_dir))
+    prompt_loader = PromptLoader(
+        prompts_dir=str(settings.prompts_dir) if settings.prompts_dir is not None else None,
+    )
 
     def _llm_factory():
         provider, api_key, model = resolve_llm_config("digest")


### PR DESCRIPTION
## Summary

Hotfix for **BUG-028** — daily digest cron task fails 100% of the time when `PROMPTS_DIR` env is unset because `PromptLoader(prompts_dir=str(settings.prompts_dir))` evaluates to `PromptLoader(prompts_dir="None")` (literal string) when `settings.prompts_dir is None`. `Path("None")` is a valid relative path, so `.load("digest")` raises `PromptLoaderError: YAML at None/digest.yaml did not provide a non-empty system.prompt`. Surfaced in production on **2026-05-23T06:00:00Z** during Wave 1 step 3 24h watch.

Refs:
- [`docs/notes/BUG_LOG.md` § BUG-028](../blob/fix/bug-028-digest-cron-prompt-loader/docs/notes/BUG_LOG.md) — root cause, evidence trace, Layer A/B/C/D recommendations.
- [`docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md` § 4a Open Items #5](../blob/fix/bug-028-digest-cron-prompt-loader/docs/notes/REVIEW_2026-05-21_WAVE1_STEP3_DONE.md) — open item carry-over from Wave 1 step 3 closure.

**Prod workaround status:** active since `2026-05-23T09:49:15Z` — env `PROMPTS_DIR=/app/prompts` set ad-hoc on `tg_parser_bot` container (backup at `~/TG_parser/docker-compose.yml.bak-bug028-20260523-114830` on VPS). **Workaround stays in place until this PR is merged + deployed**; only then is it safe to remove (Layer D commit committed to repo makes the override deterministic, so removing the ad-hoc env is purely cleanup).

## Coverage — Layers delivered

| Layer | Status | Location |
|---|---|---|
| **A** — call-site guard | ✅ included | `tg_parser/services/scheduler_service.py:560` — `PromptLoader(prompts_dir=str(settings.prompts_dir) if settings.prompts_dir is not None else None)` |
| **B** — in-class fallback | ✅ included | `tg_parser/processing/prompt_loader.py:__init__` — detects literal `"None"` string and rewrites to `Path("prompts")` with a WARNING log |
| **C** — sensible default | ✅ included | `tg_parser/config/settings.py` — `prompts_dir: Path \| None = Path("prompts")` (typing preserved as `Path \| None` so Layers A + B remain defense-in-depth) |
| **D** — compose env propagation | ✅ included | `docker-compose.yml` — `PROMPTS_DIR=${PROMPTS_DIR:-/app/prompts}` added to all three pipeline services (`tg_parser`, `mcp`, `tg_bot`) |

All four layers are intentionally redundant — any one of A/B/C alone would close the production failure mode, but defense-in-depth keeps the system robust against future call-site mistakes.

## Test plan

New tests (6 total):

- **`tests/test_scheduler_digest_prompt_loader.py`** (new file, 3 tests):
  - `test_settings_default_prompts_dir_is_path_prompts` — Layer C: hermetic `Settings()` (env scrubbed + `_env_file=None`) must expose `Path("prompts")` default.
  - `test_digest_task_with_default_settings_loads_yaml_prompt` — Layers A + C end-to-end: runs `run_scheduled_digests_task` with stubbed DB context, captures the `PromptLoader` instance, asserts real non-empty YAML resolves for both `digest` and `processing` stages.
  - `test_digest_task_with_explicit_none_prompts_dir_does_not_raise` — Layer A isolation: forces `settings.prompts_dir = None` (pre-Layer-C bug state), asserts the guard converts `None` → `None` (not the literal `"None"`).

- **`tests/test_prompt_loader.py`** (extended with `TestBug028LiteralNoneStringGuard` class, 3 tests):
  - `test_prompt_loader_falls_back_when_literal_None_string_passed` — Layer B: `PromptLoader(prompts_dir="None")` must fall back to `Path("prompts")` and load real YAML.
  - `test_prompt_loader_falls_back_when_pathified_None_string_passed` — `Path("None")` form normalises identically.
  - `test_prompt_loader_does_not_falsely_match_paths_containing_None` — negative: `/tmp/NoneShapedCache` is a legitimate name and must be passed through unchanged (no over-trigger).

All new tests are hermetic — `monkeypatch.delenv("PROMPTS_DIR", raising=False)` + `Settings(_env_file=None)` so local developer `.env` overrides cannot poison results.

### Gates (run pre-commit, then re-run after self-review)

- `.venv/bin/pytest -q` — **2201 passed / 313 skipped / 0 failed** (+6 over baseline 2195).
- `TEST_POSTGRES=1 .venv/bin/pytest -q` — **2505 passed / 9 skipped / 0 failed** (+6 over baseline 2499).
- `ruff format --check . && ruff check .` — clean.

## Risk note

**Low.** Layer A is a 2-LOC idiomatic None-guard. Layer C makes the default explicit and matches the actual repo layout (`./prompts/` is committed). Layer B is a defensive in-class fallback that only triggers on the literal Python repr of `None`. Layer D is a compose-only env addition that matches the existing `./prompts:/app/prompts:ro` bind mount on every service. No public API surface changes; `Path | None` typing preserved on `Settings.prompts_dir`.

Pre-existing UP038 lint in `scheduler_service.py` (out-of-scope per start-prompt § 4) intentionally NOT fixed in this PR.

## Post-merge ops

1. Deploy: `git pull` on VPS → rebuild → restart at minimum `tg_bot` (recommended: `tg_bot` + `tg_parser` + `mcp` for full Layer D coverage).
2. After hotfix is live: optionally remove `~/TG_parser/docker-compose.yml.bak-bug028-20260523-114830` on VPS.
3. Smoke: `docker logs tg_parser_bot` should show `PromptLoader initialized with prompts_dir=PosixPath('/app/prompts')` and no `PromptLoaderError` on the next cron tick (`2026-05-24T06:00:00Z` / 09:00 MSK).
4. Update `BUG_LOG.md` § BUG-028 → status `resolved` with commit SHAs + this PR URL.

## Labels

`bug-fix`, `hotfix`, `bug-028`

Made with [Cursor](https://cursor.com)