### PR TITLE
fix(scheduler): synchronously remove APScheduler job on unsubscribe (BUG-035)

### DIFF
--- a/docs/notes/PR_BODY_BUG_035.md
+++ b/docs/notes/PR_BODY_BUG_035.md
@@ -1,0 +1,184 @@
+## Summary
+
+Closes BUG-035. Hardens `BackgroundScheduler.remove_task` to always attempt `AsyncIOScheduler.remove_job` (not only when the in-memory `_tasks` dict tracks the id), specifically catches `apscheduler.jobstores.base.JobLookupError` for the race with the reconcile loop, and emits a structured `scheduler_job_removed` event tagged with a `reason` so operators can attribute every scheduler-state mutation back to its origin (`mcp_unsubscribe_digest` / `bot_unsubscribe_digest` / `reconcile` / `*_subscribe_digest_reregister`). The MCP and bot `unsubscribe_digest` tools forward the new `reason` kwarg. No behavioural change for the reconcile loop or for the existing tick-time DB re-check inside `run_scheduled_digests_task` — both remain in place as defense-in-depth.
+
+## Root cause (post-investigation; replaces handoff hypothesis)
+
+The handoff hypothesis was that `unsubscribe_digest` simply did not call `scheduler.remove_job`. Empirically, both surfaces (MCP `tg_parser/mcp_server.py::unsubscribe_digest` and bot `tg_parser/bot/tools.py::_exec_unsubscribe_digest`) **have** invoked `unregister_digest_subscription(sub_id)` synchronously after the DB delete since F6's introduction (PR #11, commit `410452a`, 2026-04-19). The orphan-tick delivery observed during the Test C cleanup on 2026-05-24 ~21:00Z must have come from a different mechanism — most likely the cross-process gap inherent to the deployment: MCP and bot run as **separate Docker containers** (`docker-compose.yml` lines 168 + 243), each with its own `BackgroundScheduler` singleton. An `unregister_digest_subscription` call inside the MCP container only mutates the MCP-process scheduler (which never had the job — only the bot does). The bot's singleton retains the job until its 60-second `_reconcile_loop` next ticks.
+
+Two safeguards already mitigated this in practice:
+
+1. **Tick-time DB re-check** — `run_scheduled_digests_task` (in the bot process) opens a fresh `digest_subscription_repo()` context at the start of every cron tick and bails with `status="not_found"` if `sub_repo.get(...)` returns `None`. Any tick that fires after the DB delete commits short-circuits before delivery.
+2. **Reconcile loop** — `reconcile_digest_subscriptions()` diffs `desired` (active rows in DB) against `registered` (jobs in the in-memory `_tasks` dict) and unregisters orphans every `digest_refresh_interval` (default 60s).
+
+The structural gap closed by this PR is narrower and more operational:
+
+* The pre-fix `BackgroundScheduler.remove_task` returned `False` immediately when `task_id not in self._tasks` — it **never attempted** `AsyncIOScheduler.remove_job` in that branch. So in any deployment where the bookkeeping dict has diverged from the APScheduler job store (cross-process replicas, future shared `JobStore` backends, an aborted reconcile mid-tick), `unregister_digest_subscription` would be a silent no-op even when the underlying scheduler did still have the job.
+* The pre-fix path also swallowed a bare `Exception` from `scheduler.remove_job` with a `logger.debug`, which masked schema/network errors that should fail loud.
+* The pre-fix path emitted a positional `logger.info("Removed task %s", task_id)` line with no `reason` tag — operators cannot tell from logs whether a removal came from an MCP unsubscribe, a bot tool unsubscribe, a reconcile-loop sweep, or a subscribe-then-replace cycle.
+
+This PR makes `remove_task` genuinely idempotent across all those dimensions, specifically handles `JobLookupError` (apscheduler's documented "missing-job" signal), and threads a `reason` tag through every scheduler-mutation call site.
+
+## Scope decision (digest-only)
+
+`unsubscribe_watchlist` is **not** symmetric to `unsubscribe_digest`. The F11 matcher does not own a per-interest APScheduler job — it runs piggy-back inside the incremental pipeline tick and reads `WatchInterestRepoPort.list_active_for_channel(channel_id)` at the start of every tick, which filters on `is_active = TRUE`. The `unsubscribe_watchlist` tool soft-deletes the interest (`is_active=False`), so it immediately drops out of the matcher's source set — no in-memory scheduler state to invalidate, no orphan-tick window to close.
+
+This invariant is locked in by `tests/test_scheduler_invalidation_on_unsubscribe.py::TestWatchlistInvalidationByConstruction`. If a future change introduces APScheduler-driven scheduling for watchlists, those guards will fail and force a symmetric fix to be added inside this same test file.
+
+## Before / after
+
+### `tg_parser/services/background_scheduler.py::BackgroundScheduler.remove_task`
+
+Before:
+
+```python
+def remove_task(self, task_id: str) -> bool:
+    if task_id not in self._tasks:
+        return False  # <-- never attempts scheduler.remove_job
+
+    try:
+        self._scheduler.remove_job(task_id)
+    except Exception as e:
+        logger.debug("Job %s not found in scheduler: %s", task_id, e)
+
+    del self._tasks[task_id]
+    logger.info("Removed task %s", task_id)
+    return True
+```
+
+After:
+
+```python
+def remove_task(self, task_id: str, *, reason: str | None = None) -> bool:
+    had_tracked = task_id in self._tasks
+    had_scheduled = False
+    try:
+        self._scheduler.remove_job(task_id)
+        had_scheduled = True
+    except JobLookupError:
+        pass  # idempotent: reconcile / sibling already removed it
+    self._tasks.pop(task_id, None)
+    if had_tracked or had_scheduled:
+        logger.info(
+            "scheduler_job_removed",
+            task_id=task_id,
+            reason=reason or "unspecified",
+            from_memory=had_tracked,
+            from_scheduler=had_scheduled,
+        )
+        return True
+    logger.debug(
+        "scheduler_job_remove_noop",
+        task_id=task_id,
+        reason=reason or "unspecified",
+    )
+    return False
+```
+
+### `tg_parser/services/background_scheduler.py::unregister_digest_subscription`
+
+```python
+def unregister_digest_subscription(
+    subscription_id: str,
+    scheduler: BackgroundScheduler | None = None,
+    *,
+    reason: str = "unsubscribe",
+) -> bool:
+    sched = scheduler or get_scheduler()
+    return sched.remove_task(_digest_job_id(subscription_id), reason=reason)
+```
+
+### MCP + bot call sites
+
+```python
+# tg_parser/mcp_server.py::unsubscribe_digest
+unregister_digest_subscription(sub_id, reason="mcp_unsubscribe_digest")
+
+# tg_parser/bot/tools.py::_exec_unsubscribe_digest
+unregister_digest_subscription(sub_id, reason="bot_unsubscribe_digest")
+
+# tg_parser/services/scheduler_service.py::reconcile_digest_subscriptions
+unregister_digest_subscription(sub_id, reason="reconcile")
+```
+
+## Test plan
+
+New regression file `tests/test_scheduler_invalidation_on_unsubscribe.py` — **19 tests**, organised into 5 layers:
+
+* **Layer A — `BackgroundScheduler.remove_task` hardening (10 tests):** cross-process `_tasks`-dict-divergence, in-memory-only and scheduler-only paths, idempotent double-call, `JobLookupError` swallowed, other exceptions propagated, structured `scheduler_job_removed` event includes `reason`, `unregister_digest_subscription` forwards `reason` (default `"unsubscribe"`, idempotent on second call).
+* **Layer B — end-to-end MCP / bot unsubscribe contract (3 tests):** MCP `unsubscribe_digest` removes the in-process scheduler job atomically (verified via direct logger introspection: `scheduler_job_removed` event with `reason="mcp_unsubscribe_digest"` and the matching `task_id`); same shape for bot `_exec_unsubscribe_digest` (`reason="bot_unsubscribe_digest"`); MCP unsubscribe twice returns `success=False` "not found" the second time.
+* **Layer C — anti-regression for existing safeguards (3 tests):** `run_scheduled_digests_task` returns `status="not_found"` when the DB row is gone; full `subscribe → register job → MCP unsubscribe → fire tick → assert AsyncMock(Bot).send_message.await_count == 0` end-to-end (no delivery); reconcile loop removes orphan jobs after an external (psql-style) DB delete.
+* **Layer D — watchlist scope decision (2 tests):** soft-deleted interest is excluded from `WatchInterestRepoPort.list_active_for_channel`; `WatchlistService.check_interests` produces zero matches when the only matching interest has been soft-deleted (proves the digest-only scope decision).
+* **Layer E — Prometheus assertion (1 test):** snapshot `tg_digest_channel_publish_total` for every label, run the `subscribe → unsubscribe → manual tick` sequence with a mocked Bot, snapshot again — counter MUST be unchanged.
+
+### Self-review-and-rerun loop (operator-mandated)
+
+* [x] Initial green run on the new file (`TEST_POSTGRES=1`): **19 passed, 0 failed**.
+* [x] Stashed the production fix (`git stash push -- tg_parser/bot/tools.py tg_parser/mcp_server.py tg_parser/services/background_scheduler.py tg_parser/services/scheduler_service.py`) and reran on `main@66e8297` shape: **8 failed, 11 passed**:
+  * 6 unit-level hardening tests (`test_remove_task_removes_apscheduler_job_when_dict_empty`, `test_remove_task_swallows_job_lookup_error_from_apscheduler`, `test_remove_task_propagates_unexpected_exceptions`, `test_remove_task_emits_structured_reason_in_log`, `test_unregister_passes_reason_to_remove_task`, `test_unregister_default_reason_is_unsubscribe`);
+  * 2 end-to-end telemetry assertions (MCP + bot atomically-remove tests — pre-fix emits positional `("Removed task %s", task_id)` instead of the structured `scheduler_job_removed` event, captured cleanly with `Got captured calls: [(('Removed task %s', ...), {})]`).
+  * The 11 tests that still pass on pre-fix code prove that the existing safeguards (tick-time DB re-check + reconcile loop + soft-delete-by-construction for watchlist) were already working — this PR is **strictly additive**, closing a narrower telemetry + cross-process invalidation gap rather than the broader "no removal happens" gap the handoff originally hypothesised.
+* [x] Self-review identified that the original integration tests would pass pre-fix because the basic call was already in place; strengthened the MCP / bot end-to-end tests to **also** assert on the new structured `scheduler_job_removed` event with the right `reason` tag, captured via direct `logger.info` introspection (more deterministic than `caplog` under pytest-asyncio + structlog stdlib routing).
+* [x] Restored fix (`git stash pop`) and reran: **19/19 passed** on the new file.
+
+### Full affected-suite rerun
+
+Normal mode:
+
+```
+.venv/bin/pytest tests/test_scheduler_invalidation_on_unsubscribe.py \
+    tests/test_bot_chat_target_resolution.py tests/test_bot_channel_name_parser.py \
+    tests/test_bot_confirm_flow.py tests/test_f4b_deferred_surface_guard.py \
+    tests/test_f11_bot_tools.py tests/test_subscribe_idempotency.py \
+    tests/test_f6_scheduled_digests.py
+=> 336 passed, 30 skipped
+```
+
+**Mandatory `TEST_POSTGRES=1` rerun** (per `docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`):
+
+```
+TEST_POSTGRES=1 .venv/bin/pytest \
+    tests/test_scheduler_invalidation_on_unsubscribe.py tests/test_f6_scheduled_digests.py \
+    tests/test_f11_mcp_tools.py tests/test_subscribe_idempotency.py \
+    tests/test_api_digests.py tests/test_bot_chat_target_resolution.py \
+    tests/test_bot_channel_name_parser.py tests/test_bot_confirm_flow.py \
+    tests/test_f4b_deferred_surface_guard.py tests/test_f11_bot_tools.py
+=> 407 passed, 1 skipped, 0 failed
+```
+
+The single skip is the pre-existing `test_concurrent_two_confirms_race_documented` integration-harness skip (tracked as TD-confirm-flow-concurrency-integration) — unrelated to this PR.
+
+### `ruff` results
+
+```
+ruff check tg_parser/services/background_scheduler.py tg_parser/services/scheduler_service.py \
+           tg_parser/mcp_server.py tg_parser/bot/tools.py \
+           tests/test_scheduler_invalidation_on_unsubscribe.py
+=> All checks passed!
+
+ruff format --check (same five files)
+=> 5 files already formatted
+```
+
+### Reconcile-loop invariant (defense-in-depth)
+
+`reconcile_digest_subscriptions()` continues to handle two cases this PR does not address synchronously:
+
+1. **External DB deletes** (psql, alembic migrations) that bypass both MCP and bot tools — reconcile catches the orphan within ≤ `digest_refresh_interval`.
+2. **Cross-process MCP-side deletes** — the bot's reconcile loop still picks up the deletion within ≤ `digest_refresh_interval`. The tick-time DB re-check (`run_scheduled_digests_task` → `sub_repo.get(...) is None` → `status="not_found"`) prevents any stale delivery during that window.
+
+Both are explicitly asserted by `TestReconcileLoopOrphanCleanup::test_reconcile_loop_removes_orphan_job_after_external_db_delete` and `TestTickTimeSafeguard::test_run_scheduled_digests_task_returns_not_found_after_db_delete` so accidental regressions in either path are caught at PR review time.
+
+## References
+
+- [`docs/notes/BUG_LOG.md` § BUG-035](docs/notes/BUG_LOG.md)
+- [`docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md` § 3.1](docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md)
+- [`docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md`](docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md) (Test C cleanup empirical trace)
+- [`docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`](docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md) (`TEST_POSTGRES=1` rerun mandate)
+- Recent merge precedent: `e50449b` (BUG-033 PR #108), `6ebad33` (BUG-034 PR #109), `66e8297` (BUG-031+032 PR #111)
+
+## Operator action required
+
+- **DO NOT MERGE** without sign-off (per `AGENTS.md` + handoff anti-patterns).
+- Optional follow-up (not in scope): consider lowering `digest_refresh_interval` from 60s to 15-30s in production to shrink the cross-process convergence window further. Pure operational tuning — no code change required.
+- Optional follow-up (not in scope): the empirical orphan delivery observed on 2026-05-24 ~21:00Z remains unexplained at the code level (the tick-time DB re-check should have caught it). The most likely culprit is a sub-second race between the DB delete commit and the cron-tick coroutine completing its `sub_repo.get(...)` lookup, but no production trace correlates that hypothesis with certainty. If the pattern recurs after this PR ships, a separate spike to add `SELECT FOR UPDATE` on the tick-time fetch (or a `BEGIN ISOLATION LEVEL REPEATABLE READ` envelope around delete) may be warranted.

--- a/tests/test_scheduler_invalidation_on_unsubscribe.py
+++ b/tests/test_scheduler_invalidation_on_unsubscribe.py
@@ -1,0 +1,863 @@
+"""BUG-035 regression suite — synchronous scheduler invalidation on unsubscribe.
+
+Background
+==========
+
+Empirical observation (Wave 1 step 4 VPS watch session, 2026-05-24 ~21:00 UTC):
+
+    operator → MCP unsubscribe_digest(...) at ~20:58Z (DB row hard-deleted) →
+    APScheduler in-memory job still armed inside the bot process →
+    21:00 cron tick fired → one stray digest delivered
+
+The handoff (`docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md`
+§ 3.1, lines 122-133) prescribed a synchronous ``scheduler.remove_job`` call
+inside ``unsubscribe_digest`` so the very next cron tick is bounded to a no-op
+instead of relying solely on the 60-second reconcile loop.
+
+This file covers four layers:
+
+A. **Unit-level scheduler hardening** — :meth:`BackgroundScheduler.remove_task`
+   must now always attempt ``scheduler.remove_job`` (even when the in-memory
+   ``_tasks`` dict has gone stale), specifically catch
+   :class:`apscheduler.jobstores.base.JobLookupError` for the "already gone"
+   race with the reconcile loop, and emit a structured ``scheduler_job_removed``
+   log event with a ``reason`` tag for telemetry. Other exceptions still
+   propagate so schema/network issues fail loud.
+
+B. **End-to-end MCP / bot unsubscribe contract** — both the MCP tool
+   :func:`tg_parser.mcp_server.unsubscribe_digest` and the bot tool
+   :func:`tg_parser.bot.tools._exec_unsubscribe_digest` must remove the
+   APScheduler job *synchronously* before returning success to the caller.
+
+C. **Anti-regression for existing safeguards** — :func:`run_scheduled_digests_task`
+   already re-reads the subscription from the DB at tick time and bails with
+   ``status="not_found"`` if the row is gone (the immediate cross-process
+   safeguard); :func:`reconcile_digest_subscriptions` already detects and
+   removes orphan scheduler jobs whose DB row was deleted out-of-band. Both
+   must keep working alongside the new synchronous hook so cross-process
+   MCP↔bot deployments and external (psql) deletes stay self-healing.
+
+D. **Watchlist scope decision** — :func:`unsubscribe_watchlist` is *not*
+   symmetric to ``unsubscribe_digest`` because the F11 matcher does not own a
+   per-interest APScheduler job. Instead it queries
+   :meth:`WatchInterestRepoPort.list_active_for_channel` at the start of every
+   pipeline tick, which already filters on ``is_active = TRUE``. A
+   soft-deleted interest therefore drops out of consideration on the very
+   next tick — invalidation is by construction. Locked in here by a regression
+   test so any future change that adds APScheduler-driven scheduling to
+   watchlists will trip this guard and force a symmetric fix.
+
+References
+----------
+- ``docs/notes/BUG_LOG.md`` § BUG-035
+- ``docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md`` § 3.1
+- ``docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md`` (Test C cleanup
+  evidence)
+- ``docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`` — ``TEST_POSTGRES=1`` rerun
+  is now standard for every PR; the Postgres-gated tests below MUST exit
+  green under that env.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from apscheduler.jobstores.base import JobLookupError
+
+from tg_parser.domain.models import (
+    DigestFormat,
+    DigestSubscription,
+    NotifyMode,
+    ProcessedDocument,
+    WatchInterest,
+)
+from tg_parser.services.background_scheduler import (
+    BackgroundScheduler,
+    _digest_job_id,
+    register_digest_subscription,
+    unregister_digest_subscription,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subscription(
+    *,
+    sub_id: str | None = None,
+    owner_id: str = "00000000-0000-0000-0000-0000000000bb",
+    chat_id: int = 999_001,
+    name: str | None = None,
+    channel_ids: list[str] | None = None,
+    cron_expression: str = "0 9 * * *",
+    timezone: str = "UTC",
+    is_active: bool = True,
+) -> DigestSubscription:
+    return DigestSubscription(
+        id=sub_id if sub_id is not None else str(uuid.uuid4()),
+        owner_id=owner_id,
+        chat_id=chat_id,
+        name=name or f"bug035-sub-{uuid.uuid4().hex[:8]}",
+        channel_ids=channel_ids or ["bug035_test_channel"],
+        cron_expression=cron_expression,
+        timezone=timezone,
+        format=DigestFormat.SUMMARY,
+        language="ru",
+        is_active=is_active,
+    )
+
+
+def _make_current_user(user_id: str, *, name: str = "bug035-tester", role: str = "admin"):
+    from tg_parser.auth.models import CurrentUser
+
+    return CurrentUser(
+        id=user_id,
+        name=name,
+        role=role,
+        allowed_channel_ids=None if role == "admin" else set(),
+        max_channels=999,
+    )
+
+
+def _make_interest(
+    *,
+    interest_id: str | None = None,
+    user_id: str = "user-bug035",
+    keywords: list[str] | None = None,
+    channel_ids: list[str] | None = None,
+    is_active: bool = True,
+) -> WatchInterest:
+    return WatchInterest(
+        id=interest_id or f"int-bug035-{uuid.uuid4().hex[:8]}",
+        user_id=user_id,
+        chat_id=42,
+        title="BUG-035 watchlist scope guard",
+        description="Symmetric coverage probe — soft-delete must drop from matcher.",
+        keywords=list(keywords or ["bug035_keyword"]),
+        exclude_keywords=[],
+        channel_ids=list(channel_ids or ["bug035_test_channel"]),
+        threshold=0.5,
+        notify_mode=NotifyMode.INSTANT,
+        is_active=is_active,
+        embedding=None,
+    )
+
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES"),
+    reason="PostgreSQL tests disabled (set TEST_POSTGRES=1)",
+)
+
+
+# ===========================================================================
+# Layer A — unit-level BackgroundScheduler.remove_task hardening
+# ===========================================================================
+
+
+class TestRemoveTaskHardening:
+    """Cover the new ``remove_task`` contract introduced by the BUG-035 fix."""
+
+    def test_remove_task_returns_false_when_nothing_to_remove(self):
+        """No in-memory entry, no scheduler job → no-op + False."""
+        sched = BackgroundScheduler()
+        assert sched.remove_task("digest:never-existed") is False
+
+    def test_remove_task_removes_apscheduler_job_when_dict_empty(self):
+        """Cross-process simulation: another path seeded the APScheduler
+        directly; this scheduler's ``_tasks`` dict was never populated.
+
+        Pre-fix ``remove_task`` returned ``False`` immediately when
+        ``task_id not in self._tasks``, leaving the APScheduler job armed.
+        The hardened version must always attempt ``scheduler.remove_job``
+        so a divergence between the in-memory bookkeeping dict and the
+        scheduler's job store cannot cause an orphan tick.
+        """
+        sched = BackgroundScheduler()
+        sub_id = "11111111-1111-1111-1111-111111111111"
+        job_id = _digest_job_id(sub_id)
+
+        sched._scheduler.add_job(
+            func=lambda: None,
+            trigger="cron",
+            hour=0,
+            id=job_id,
+            replace_existing=True,
+        )
+        assert sched._scheduler.get_job(job_id) is not None
+        assert job_id not in sched._tasks
+
+        assert sched.remove_task(job_id, reason="cross_process_probe") is True
+        assert sched._scheduler.get_job(job_id) is None
+
+    def test_remove_task_removes_when_dict_only(self):
+        """In-memory entry exists but scheduler doesn't have the job (e.g.
+        scheduler was restarted) → ``remove_task`` still cleans the dict
+        and reports True so the caller knows it did *something*."""
+        sched = BackgroundScheduler()
+        job_id = "digest:dict-only-1234"
+        sched._tasks[job_id] = lambda: None
+        assert sched._scheduler.get_job(job_id) is None
+
+        assert sched.remove_task(job_id) is True
+        assert job_id not in sched._tasks
+
+    def test_remove_task_idempotent_double_call(self):
+        sched = BackgroundScheduler()
+        sub = _make_subscription(sub_id="22222222-2222-2222-2222-222222222222")
+        register_digest_subscription(sub, sched)
+        assert sched.remove_task(_digest_job_id(sub.id)) is True
+        assert sched.remove_task(_digest_job_id(sub.id)) is False
+
+    def test_remove_task_swallows_job_lookup_error_from_apscheduler(self):
+        """The library raises ``JobLookupError`` if the job is gone before
+        we ask for it (race with reconcile / sibling process). We must
+        treat that as the idempotent path — no exception bubbles up."""
+        sched = BackgroundScheduler()
+        sched._scheduler = MagicMock()
+        sched._scheduler.remove_job = MagicMock(side_effect=JobLookupError("missing"))
+
+        result = sched.remove_task("digest:gone-already", reason="race_with_reconcile")
+        assert result is False
+        sched._scheduler.remove_job.assert_called_once_with("digest:gone-already")
+
+    def test_remove_task_propagates_unexpected_exceptions(self):
+        """Schema mismatch / network errors must fail loud, not be
+        silently swallowed (operator-mandated invariant per handoff)."""
+        sched = BackgroundScheduler()
+        sched._scheduler = MagicMock()
+        sched._scheduler.remove_job = MagicMock(side_effect=RuntimeError("db gone"))
+
+        with pytest.raises(RuntimeError, match="db gone"):
+            sched.remove_task("digest:explode")
+
+    def test_remove_task_emits_structured_reason_in_log(self, caplog):
+        """Operator visibility: ``reason`` is forwarded to the log event."""
+        sched = BackgroundScheduler()
+        sub = _make_subscription(sub_id="33333333-3333-3333-3333-333333333333")
+        register_digest_subscription(sub, sched)
+
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            sched.remove_task(_digest_job_id(sub.id), reason="mcp_unsubscribe_digest")
+
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "scheduler_job_removed" in joined
+        assert "mcp_unsubscribe_digest" in joined
+
+
+class TestUnregisterDigestSubscription:
+    """Cover the public helper used by both MCP and bot tools."""
+
+    def test_unregister_passes_reason_to_remove_task(self):
+        sched = BackgroundScheduler()
+        sub = _make_subscription(sub_id="44444444-4444-4444-4444-444444444444")
+        register_digest_subscription(sub, sched)
+
+        # Capture by patching the bound method on this scheduler instance.
+        with patch.object(sched, "remove_task", wraps=sched.remove_task) as spy:
+            unregister_digest_subscription(sub.id, sched, reason="bot_unsubscribe_digest")
+            spy.assert_called_once_with(_digest_job_id(sub.id), reason="bot_unsubscribe_digest")
+
+    def test_unregister_idempotent_returns_false_on_second_call(self):
+        sched = BackgroundScheduler()
+        sub = _make_subscription(sub_id="55555555-5555-5555-5555-555555555555")
+        register_digest_subscription(sub, sched)
+        assert unregister_digest_subscription(sub.id, sched) is True
+        assert unregister_digest_subscription(sub.id, sched) is False
+
+    def test_unregister_default_reason_is_unsubscribe(self):
+        """Backward-compatible: existing callers without ``reason=`` still
+        get a sensible tag in the log."""
+        sched = BackgroundScheduler()
+        sub = _make_subscription(sub_id="66666666-6666-6666-6666-666666666666")
+        register_digest_subscription(sub, sched)
+        with patch.object(sched, "remove_task", wraps=sched.remove_task) as spy:
+            unregister_digest_subscription(sub.id, sched)
+            spy.assert_called_once_with(_digest_job_id(sub.id), reason="unsubscribe")
+
+
+# ===========================================================================
+# Layer B — end-to-end MCP / bot unsubscribe contract
+# ===========================================================================
+
+
+@pg_only
+class TestMcpUnsubscribeDigestSynchronous:
+    """The MCP tool must invalidate the in-process scheduler job before
+    returning success — no reliance on the reconcile loop in the same
+    process."""
+
+    async def test_mcp_unsubscribe_digest_removes_scheduler_job_atomically(self, _digest_db):
+        from tg_parser.mcp_server import unsubscribe_digest
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            get_scheduler,
+        )
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("alice_bug035_mcp")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_001)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        # NOTE: Do NOT call ``scheduler.start()`` in tests — AsyncIOScheduler
+        # binds to the running event loop on start, but pytest-asyncio
+        # creates a fresh loop per test, so the second test would crash
+        # with "Event loop is closed" on the next ``add_job``. APScheduler
+        # registers jobs into ``_pending_jobs`` while in ``STATE_STOPPED``
+        # so the invariants we want to check (presence/absence in the
+        # job store + in-memory ``_tasks`` dict) work without ``start()``.
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+
+        # Capture the structured ``scheduler_job_removed`` event directly
+        # via the module's structlog binding rather than ``caplog`` —
+        # pytest-asyncio + structlog stdlib routing has a known
+        # test-order-dependent caplog issue that swallows records when
+        # ``test_db`` is the first session-scoped DB-dependent fixture
+        # acquired inside a caplog context.  Direct logger patching is
+        # both more deterministic and more explicit about the contract
+        # under test: the new ``reason`` kwarg must reach the log site.
+        # Wrap the structlog binding so we can introspect both the event
+        # name and the kwargs. Pre-fix code emits a positional
+        # ``logger.info("Removed task %s", task_id)`` call which is
+        # captured here as ``(args=("Removed task %s", "digest:..."),
+        # kwargs={})`` — no ``scheduler_job_removed`` event, no
+        # ``reason`` kwarg, so the contract assertions below trip
+        # cleanly without a TypeError.
+        captured: list[tuple[tuple, dict]] = []
+        from tg_parser.services import background_scheduler as bs_module
+
+        original_info = bs_module.logger.info
+
+        def _capture_info(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original_info(*args, **kwargs)
+
+        try:
+            assert sub.id in get_registered_digest_subscription_ids()
+
+            current_user = _make_current_user(owner.id, name=owner.name)
+            with (
+                patch.object(bs_module.logger, "info", side_effect=_capture_info),
+                patch(
+                    "tg_parser.mcp_server.resolve_mcp_user",
+                    AsyncMock(return_value=current_user),
+                ),
+            ):
+                result = await unsubscribe_digest(subscription_id=sub.id)
+
+            assert result.success is True
+            assert sub.id not in get_registered_digest_subscription_ids(), (
+                "MCP unsubscribe_digest must invalidate the in-process scheduler "
+                "job synchronously; the reconcile loop is defense-in-depth only."
+            )
+
+            removed_events = [
+                kwargs
+                for args, kwargs in captured
+                if len(args) >= 1 and args[0] == "scheduler_job_removed"
+            ]
+            assert len(removed_events) >= 1, (
+                "Post-fix MCP unsubscribe_digest must emit the structured "
+                "'scheduler_job_removed' event so operators can correlate "
+                "the scheduler invalidation with the originating MCP call. "
+                f"Got captured calls: {captured!r}"
+            )
+            assert removed_events[-1].get("reason") == "mcp_unsubscribe_digest", (
+                "Post-fix MCP unsubscribe_digest must pass reason="
+                "'mcp_unsubscribe_digest' through to remove_task so Grafana / "
+                "Loki dashboards can distinguish MCP-driven invalidations "
+                "from bot-tool / reconcile-loop / API-route invalidations. "
+                f"Got: {removed_events[-1]!r}"
+            )
+            assert removed_events[-1].get("task_id") == _digest_job_id(sub.id)
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+    async def test_mcp_unsubscribe_digest_is_idempotent(self, _digest_db):
+        """Second unsubscribe must not raise (handles race with reconcile
+        loop / parallel operator clicks)."""
+        from tg_parser.mcp_server import unsubscribe_digest
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("alice_bug035_idem")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_002)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        from tg_parser.services.background_scheduler import get_scheduler
+
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+        try:
+            current_user = _make_current_user(owner.id, name=owner.name)
+            with patch(
+                "tg_parser.mcp_server.resolve_mcp_user",
+                AsyncMock(return_value=current_user),
+            ):
+                first = await unsubscribe_digest(subscription_id=sub.id)
+                second = await unsubscribe_digest(subscription_id=sub.id)
+
+            assert first.success is True
+            assert second.success is False
+            assert "not found" in second.message.lower()
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+
+@pg_only
+class TestBotUnsubscribeDigestSynchronous:
+    """Same contract for the bot-tool path — this is the one that actually
+    runs inside the bot process where the digest jobs live."""
+
+    async def test_bot_unsubscribe_digest_removes_scheduler_job_atomically(self, _digest_db):
+        from tg_parser.bot.tools import _exec_unsubscribe_digest
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            get_scheduler,
+        )
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("bob_bug035_bot")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_003)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+
+        captured: list[tuple[tuple, dict]] = []
+        from tg_parser.services import background_scheduler as bs_module
+
+        original_info = bs_module.logger.info
+
+        def _capture_info(*args, **kwargs):
+            captured.append((args, kwargs))
+            return original_info(*args, **kwargs)
+
+        try:
+            assert sub.id in get_registered_digest_subscription_ids()
+
+            with patch.object(bs_module.logger, "info", side_effect=_capture_info):
+                result = await _exec_unsubscribe_digest(
+                    {"subscription_id": sub.id},
+                    current_user=_make_current_user(owner.id, name=owner.name),
+                )
+            assert result.get("deleted") is True
+            assert sub.id not in get_registered_digest_subscription_ids(), (
+                "Bot _exec_unsubscribe_digest must invalidate the in-process "
+                "scheduler job synchronously."
+            )
+
+            removed_events = [
+                kwargs
+                for args, kwargs in captured
+                if len(args) >= 1 and args[0] == "scheduler_job_removed"
+            ]
+            assert len(removed_events) >= 1, (
+                "Post-fix bot _exec_unsubscribe_digest must emit the "
+                "structured 'scheduler_job_removed' event. "
+                f"Got captured calls: {captured!r}"
+            )
+            assert removed_events[-1].get("reason") == "bot_unsubscribe_digest", (
+                "Post-fix bot _exec_unsubscribe_digest must pass reason="
+                "'bot_unsubscribe_digest' so the structured log distinguishes "
+                "this call site from the MCP path. Pre-fix code did not pass "
+                "any reason tag — this assertion enforces the new contract. "
+                f"Got: {removed_events[-1]!r}"
+            )
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+
+# ===========================================================================
+# Layer C — anti-regression for the existing safeguards
+# ===========================================================================
+
+
+@pg_only
+class TestTickTimeSafeguard:
+    """``run_scheduled_digests_task`` re-reads the subscription from the
+    DB before delivering; this guards against the cross-process gap where
+    the bot's APScheduler still has a job for an MCP-deleted subscription
+    and against the sub-tick race where the cron tick fires moments after
+    a DB delete commits.
+
+    A regression in this guard would re-open the BUG-035 attack surface
+    even with the new synchronous ``remove_job`` call in place, so we
+    lock it in here.
+    """
+
+    async def test_run_scheduled_digests_task_returns_not_found_after_db_delete(self, _digest_db):
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.services.scheduler_service import run_scheduled_digests_task
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("carol_bug035_tick")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_004)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+            await repo.delete(sub.id)
+
+        result = await run_scheduled_digests_task(sub.id)
+        assert result["status"] == "not_found", (
+            "tick-time DB re-check must short-circuit when the row is gone; "
+            "without this, a cron tick that fires before the bot's reconcile "
+            "loop catches the MCP-side delete would still deliver a stale "
+            "digest (the exact BUG-035 symptom)."
+        )
+
+    async def test_no_send_message_after_unsubscribe_and_tick(self, _digest_db):
+        """End-to-end proof: subscribe → register job → unsubscribe via MCP
+        → manually fire the tick (simulating the cron firing in the gap
+        between DB delete commit and reconcile-loop cleanup) → assert
+        ``bot.send_message`` was NEVER awaited.
+
+        Uses an ``AsyncMock`` Bot so any accidental delivery shows up as
+        ``await_count > 0``."""
+        from tg_parser.mcp_server import unsubscribe_digest
+        from tg_parser.services.background_scheduler import get_scheduler
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.services.scheduler_service import run_scheduled_digests_task
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("dora_bug035_nosend")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_005)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+
+        mock_bot = AsyncMock()
+        mock_bot.send_message = AsyncMock()
+        mock_bot.send_document = AsyncMock()
+
+        try:
+            current_user = _make_current_user(owner.id, name=owner.name)
+            with patch(
+                "tg_parser.mcp_server.resolve_mcp_user",
+                AsyncMock(return_value=current_user),
+            ):
+                ack = await unsubscribe_digest(subscription_id=sub.id)
+            assert ack.success is True
+
+            with patch(
+                "tg_parser.bot.runtime.get_bot",
+                return_value=mock_bot,
+            ):
+                result = await run_scheduled_digests_task(sub.id)
+
+            assert result["status"] == "not_found"
+            assert mock_bot.send_message.await_count == 0, (
+                "No delivery may happen after unsubscribe — explicit "
+                "await_count==0 check (rather than 'no side effects')."
+            )
+            assert mock_bot.send_document.await_count == 0
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+
+@pg_only
+class TestReconcileLoopOrphanCleanup:
+    """Even if the synchronous hook regressed or an operator hard-deletes a
+    DB row out-of-band (via ``psql``), the reconcile loop must still
+    detect and remove the orphan APScheduler job. This was working
+    before BUG-035 — guard against accidentally regressing it while
+    adding the synchronous fix."""
+
+    async def test_reconcile_loop_removes_orphan_job_after_external_db_delete(self, _digest_db):
+        from tg_parser.services.background_scheduler import (
+            get_registered_digest_subscription_ids,
+            get_scheduler,
+        )
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("erin_bug035_reconcile")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_006)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+        assert sub.id in get_registered_digest_subscription_ids()
+
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.delete(sub.id)
+
+        try:
+            stats = await reconcile_digest_subscriptions()
+            assert sub.id in stats["removed"]
+            assert sub.id not in get_registered_digest_subscription_ids()
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+
+# ===========================================================================
+# Layer D — watchlist scope decision (no symmetric bug by construction)
+# ===========================================================================
+
+
+class TestWatchlistInvalidationByConstruction:
+    """The F11 watchlist matcher does not own a per-interest APScheduler
+    job; it queries ``WatchInterestRepo.list_active_for_channel`` at the
+    start of every pipeline tick, which filters on ``is_active = TRUE``.
+    Therefore soft-delete (the action that ``unsubscribe_watchlist``
+    performs) immediately removes the interest from consideration — no
+    in-memory scheduler state to invalidate, no orphan-tick window to
+    close.
+
+    These tests lock that invariant in place: any future change that
+    introduces per-interest APScheduler scheduling for watchlists would
+    fail these guards, forcing a symmetric fix to be added in this file.
+    """
+
+    def setup_method(self):
+        sys.path.insert(0, str(PROJECT_ROOT / "tests"))
+
+    async def test_soft_deleted_interest_is_excluded_from_active_query(self):
+        """Direct repo invariant: ``list_active_for_channel`` must not
+        return a soft-deleted (``is_active=False``) interest."""
+        from test_watchlist_service import _FakeInterestRepo  # type: ignore[import-not-found]
+
+        ir = _FakeInterestRepo()
+        await ir.create(
+            _make_interest(
+                interest_id="int-watchlist-active",
+                channel_ids=["bug035_test_channel"],
+                is_active=True,
+            )
+        )
+        await ir.create(
+            _make_interest(
+                interest_id="int-watchlist-paused",
+                channel_ids=["bug035_test_channel"],
+            )
+        )
+
+        before = await ir.list_active_for_channel("bug035_test_channel")
+        assert {i.id for i in before} == {"int-watchlist-active", "int-watchlist-paused"}
+
+        soft_deleted = await ir.soft_delete("int-watchlist-paused")
+        assert soft_deleted is True
+
+        after = await ir.list_active_for_channel("bug035_test_channel")
+        assert {i.id for i in after} == {"int-watchlist-active"}
+
+    async def test_check_interests_skips_soft_deleted_interest(self):
+        """End-to-end matcher invariant: even when a soft-deleted interest
+        would have matched a document on keywords + threshold, the
+        matcher must skip it because its source query is gated on
+        ``is_active = TRUE``. This is the watchlist-symmetric guarantee
+        that the BUG-035 fix relies on for the watchlist scope decision."""
+        from test_watchlist_service import (  # type: ignore[import-not-found]
+            _FakeEmbeddingRepo,
+            _FakeInterestRepo,
+            _FakeMatchRepo,
+            _FakeProcessedDocRepo,
+        )
+
+        from tg_parser.services.watchlist_service import WatchlistService
+
+        doc = ProcessedDocument(
+            id="doc:tg:bug035_test_channel:post:1",
+            source_ref="tg:bug035_test_channel:post:1",
+            source_message_id="1",
+            channel_id="bug035_test_channel",
+            processed_at=datetime(2026, 5, 24, 21, 0, tzinfo=UTC),
+            text_clean="bug035_keyword appears in this document body",
+            summary="bug035_keyword summary",
+            topics=[],
+            entities=[],
+        )
+
+        ir = _FakeInterestRepo()
+        await ir.create(
+            _make_interest(
+                interest_id="int-watch-soft-deleted",
+                channel_ids=["bug035_test_channel"],
+                keywords=["bug035_keyword"],
+            )
+        )
+        await ir.soft_delete("int-watch-soft-deleted")
+
+        mr = _FakeMatchRepo()
+        service = WatchlistService(
+            interest_repo=ir,
+            match_repo=mr,
+            processed_doc_repo=_FakeProcessedDocRepo([doc]),
+            embedding_repo=_FakeEmbeddingRepo(),
+            embedding_client=None,
+        )
+
+        inserted = await service.check_interests(
+            channel_id="bug035_test_channel",
+            new_doc_refs=[doc.source_ref],
+            bot=None,
+        )
+
+        assert inserted == [], (
+            "A soft-deleted watchlist interest must NEVER produce a match "
+            "on a subsequent pipeline tick. If this fails, the watchlist "
+            "scope decision in the BUG-035 PR (digest-only) is invalidated "
+            "and a symmetric scheduler-invalidation fix is required."
+        )
+        assert mr.upsert_calls == 0
+
+
+# ===========================================================================
+# Layer E — Prometheus assertion (per handoff requirement)
+# ===========================================================================
+
+
+@pg_only
+class TestPrometheusPublishCounterNotIncrementedAfterUnsubscribe:
+    """Per handoff: ``tg_digest_channel_publish_total`` MUST NOT increment
+    after unsubscribe. The counter is incremented by
+    ``record_digest_channel_publish`` inside the deliver path; if the
+    tick-time DB re-check correctly bails with ``not_found``, the
+    counter stays untouched.
+
+    Uses ``CollectorRegistry`` value sampling rather than asserting on
+    Prometheus internals."""
+
+    async def test_channel_publish_counter_unchanged_after_unsubscribe_then_tick(self, _digest_db):
+        from tg_parser.api.metrics import DIGEST_CHANNEL_PUBLISH
+        from tg_parser.mcp_server import unsubscribe_digest
+        from tg_parser.services.background_scheduler import get_scheduler
+        from tg_parser.services.db_context import digest_subscription_repo
+        from tg_parser.services.scheduler_service import run_scheduled_digests_task
+        from tg_parser.storage.sqlalchemy.user_repo import SAUserRepo
+
+        session = _digest_db.ingestion_state_session()
+        try:
+            user_repo = SAUserRepo(session)
+            owner = await user_repo.create_user("frank_bug035_metric")
+        finally:
+            await session.close()
+
+        sub = _make_subscription(owner_id=owner.id, chat_id=987_007)
+        async with digest_subscription_repo() as (repo, _db):
+            await repo.create(sub)
+
+        scheduler = get_scheduler()
+        register_digest_subscription(sub, scheduler)
+
+        def _snapshot() -> dict[str, float]:
+            out: dict[str, float] = {}
+            for metric in DIGEST_CHANNEL_PUBLISH.collect():
+                for sample in metric.samples:
+                    out[sample.labels.get("result", "")] = (
+                        out.get(sample.labels.get("result", ""), 0.0) + sample.value
+                    )
+            return out
+
+        before = _snapshot()
+        mock_bot = AsyncMock()
+        mock_bot.send_message = AsyncMock()
+        mock_bot.send_document = AsyncMock()
+
+        try:
+            current_user = _make_current_user(owner.id, name=owner.name)
+            with patch(
+                "tg_parser.mcp_server.resolve_mcp_user",
+                AsyncMock(return_value=current_user),
+            ):
+                ack = await unsubscribe_digest(subscription_id=sub.id)
+            assert ack.success is True
+
+            with patch(
+                "tg_parser.bot.runtime.get_bot",
+                return_value=mock_bot,
+            ):
+                result = await run_scheduled_digests_task(sub.id)
+            assert result["status"] == "not_found"
+
+            after = _snapshot()
+            assert after == before, (
+                f"Prometheus tg_digest_channel_publish_total leaked an "
+                f"increment after unsubscribe + tick. Before={before} "
+                f"After={after}. This signals an orphan delivery slipped "
+                f"past the tick-time DB re-check."
+            )
+        finally:
+            unregister_digest_subscription(sub.id, scheduler)
+
+
+# ===========================================================================
+# Postgres test fixtures (shared with the existing F6 suite)
+# ===========================================================================
+
+
+@pytest.fixture
+async def _digest_db(test_db):
+    """Truncate digest + user tables for a clean per-test slate.
+
+    Mirrors the helper fixture in ``tests/test_f6_scheduled_digests.py`` so
+    the new test classes are self-contained — they do not import from the
+    F6 module to avoid coupling regression to that suite's evolution.
+    """
+    session = test_db.ingestion_state_session()
+    try:
+        from sqlalchemy import text
+
+        await session.execute(text("DELETE FROM digest_subscriptions"))
+        await session.execute(text("DELETE FROM user_auth_mappings"))
+        await session.execute(text("UPDATE sources SET owner_id = NULL"))
+        await session.execute(text("DELETE FROM users"))
+        await session.commit()
+    finally:
+        await session.close()
+    return test_db

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -2690,7 +2690,7 @@ async def _exec_subscribe_digest(
 
     created_sub = result.subscription
     try:
-        unregister_digest_subscription(created_sub.id)
+        unregister_digest_subscription(created_sub.id, reason="bot_subscribe_digest_reregister")
     except Exception:
         logger.debug("subscribe_digest_unregister_pre_register_failed", exc_info=True)
     try:
@@ -2795,7 +2795,14 @@ async def _exec_unsubscribe_digest(
         deleted = await repo.delete(sub_id)
 
     if deleted:
-        unregister_digest_subscription(sub_id)
+        # BUG-035: synchronously invalidate the in-process scheduler job
+        # **after** the DB delete commits. In the bot process (which is
+        # the one that actually runs digest delivery jobs) this prevents
+        # the next cron tick from ever firing for a deleted subscription.
+        # ``unregister_digest_subscription`` is idempotent — if the
+        # reconcile loop already removed the job it silently logs at
+        # debug and returns False.
+        unregister_digest_subscription(sub_id, reason="bot_unsubscribe_digest")
         return {"subscription_id": sub_id, "deleted": True}
     return {"subscription_id": sub_id, "deleted": False, "error": "delete failed"}
 

--- a/tg_parser/mcp_server.py
+++ b/tg_parser/mcp_server.py
@@ -2710,7 +2710,9 @@ async def subscribe_digest(
     # validation fails we surface the error and roll the row back to
     # the pre-subscribe state where possible.
     try:
-        unregister_digest_subscription(result.subscription.id)
+        unregister_digest_subscription(
+            result.subscription.id, reason="mcp_subscribe_digest_reregister"
+        )
     except Exception:
         logger.debug("mcp_subscribe_digest_unregister_pre_register_failed", exc_info=True)
     try:
@@ -2816,7 +2818,19 @@ async def unsubscribe_digest(
         deleted = await repo.delete(sub_id)
 
     if deleted:
-        unregister_digest_subscription(sub_id)
+        # BUG-035: synchronously invalidate the in-process scheduler job
+        # **after** the DB delete commits so the very next cron tick that
+        # fires inside *this* process becomes a no-op (idempotent: if the
+        # reconcile loop already removed the job it logs at debug and
+        # returns False; if APScheduler raises ``JobLookupError`` it is
+        # swallowed inside ``remove_task``).  In a cross-process
+        # MCP↔bot deployment the bot's scheduler still has the job until
+        # its reconcile loop next ticks (≤ ``digest_refresh_interval``
+        # seconds) — that gap is closed by the existing tick-time DB
+        # re-check in ``run_scheduled_digests_task`` which bails with
+        # ``status="not_found"`` for any tick that fires after the row
+        # is gone (anti-regression covered by the new test suite).
+        unregister_digest_subscription(sub_id, reason="mcp_unsubscribe_digest")
         return UnsubscribeDigestResult(
             success=True,
             subscription_id=sub_id,

--- a/tg_parser/services/background_scheduler.py
+++ b/tg_parser/services/background_scheduler.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import structlog
+from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
@@ -170,27 +171,65 @@ class BackgroundScheduler:
         )
         return job
 
-    def remove_task(self, task_id: str) -> bool:
-        """
-        Remove a task.
+    def remove_task(self, task_id: str, *, reason: str | None = None) -> bool:
+        """Remove a task synchronously from APScheduler **and** the local
+        bookkeeping dict.
+
+        BUG-035 hardening: we now always attempt
+        :meth:`AsyncIOScheduler.remove_job` even when ``task_id`` is missing
+        from ``self._tasks``.  The two pieces of state can legitimately
+        diverge — for example after a reconciliation loop tick removed the
+        job but the caller still holds a stale id, or in a multi-process
+        deployment where the in-memory dict tracks only registrations made
+        in *this* process while the APScheduler instance may have been
+        seeded from another path.  Always trying ``remove_job`` makes the
+        helper genuinely idempotent.
 
         Args:
-            task_id: Task identifier
+            task_id: Task identifier.
+            reason: Optional short tag (e.g. ``"unsubscribe"`` /
+                ``"reconcile"``) included in the structured log event so
+                operators can correlate scheduler-state mutations with
+                their trigger.
 
         Returns:
-            True if task was removed, False if not found
+            ``True`` if the job was present in either the in-memory
+            ``_tasks`` dict or the APScheduler job store (i.e. *something*
+            was actually removed); ``False`` if the call was a complete
+            no-op (job not tracked anywhere — race with reconcile, double
+            unsubscribe, or unknown id).
         """
-        if task_id not in self._tasks:
-            return False
-
+        had_tracked = task_id in self._tasks
+        had_scheduled = False
         try:
             self._scheduler.remove_job(task_id)
-        except Exception as e:
-            logger.debug("Job %s not found in scheduler: %s", task_id, e)
+            had_scheduled = True
+        except JobLookupError:
+            # APScheduler-native "job missing" — idempotent path; the
+            # reconcile loop or a sibling tool may have removed it
+            # already.  This is the expected branch in cross-process
+            # MCP↔bot deployments where the in-memory ``_tasks`` dict
+            # in the MCP process never held the job to begin with.
+            pass
 
-        del self._tasks[task_id]
-        logger.info("Removed task %s", task_id)
-        return True
+        self._tasks.pop(task_id, None)
+
+        if had_tracked or had_scheduled:
+            logger.info(
+                "scheduler_job_removed",
+                task_id=task_id,
+                reason=reason or "unspecified",
+                from_memory=had_tracked,
+                from_scheduler=had_scheduled,
+            )
+            return True
+
+        logger.debug(
+            "scheduler_job_remove_noop",
+            task_id=task_id,
+            reason=reason or "unspecified",
+        )
+        return False
 
     def get_tasks(self) -> list[dict[str, Any]]:
         """
@@ -447,10 +486,20 @@ def register_digest_subscription(
 def unregister_digest_subscription(
     subscription_id: str,
     scheduler: BackgroundScheduler | None = None,
+    *,
+    reason: str = "unsubscribe",
 ) -> bool:
-    """Remove the cron job for ``subscription_id`` if present. Idempotent."""
+    """Remove the cron job for ``subscription_id`` if present. Idempotent.
+
+    BUG-035 fix: ``reason`` is forwarded to :meth:`BackgroundScheduler.remove_task`
+    so operators can distinguish call sites in the structured
+    ``scheduler_job_removed`` log event (``mcp_unsubscribe_digest`` vs
+    ``bot_unsubscribe_digest`` vs ``reconcile`` vs ``api_*``).  Defaults to
+    the generic ``"unsubscribe"`` tag for backward-compatible call sites
+    that do not yet pass a reason.
+    """
     sched = scheduler or get_scheduler()
-    return sched.remove_task(_digest_job_id(subscription_id))
+    return sched.remove_task(_digest_job_id(subscription_id), reason=reason)
 
 
 def reschedule_digest_subscription(

--- a/tg_parser/services/scheduler_service.py
+++ b/tg_parser/services/scheduler_service.py
@@ -756,7 +756,7 @@ async def reconcile_digest_subscriptions() -> dict[str, Any]:
             failed.append(sub.id)
 
     for sub_id in registered_ids - desired_ids:
-        if unregister_digest_subscription(sub_id):
+        if unregister_digest_subscription(sub_id, reason="reconcile"):
             removed.append(sub_id)
 
     if added or removed or failed:


### PR DESCRIPTION
## Summary

Closes BUG-035. Hardens `BackgroundScheduler.remove_task` to always attempt `AsyncIOScheduler.remove_job` (not only when the in-memory `_tasks` dict tracks the id), specifically catches `apscheduler.jobstores.base.JobLookupError` for the race with the reconcile loop, and emits a structured `scheduler_job_removed` event tagged with a `reason` so operators can attribute every scheduler-state mutation back to its origin (`mcp_unsubscribe_digest` / `bot_unsubscribe_digest` / `reconcile` / `*_subscribe_digest_reregister`). The MCP and bot `unsubscribe_digest` tools forward the new `reason` kwarg. No behavioural change for the reconcile loop or for the existing tick-time DB re-check inside `run_scheduled_digests_task` — both remain in place as defense-in-depth.

## Root cause (post-investigation; replaces handoff hypothesis)

The handoff hypothesis was that `unsubscribe_digest` simply did not call `scheduler.remove_job`. Empirically, both surfaces (MCP `tg_parser/mcp_server.py::unsubscribe_digest` and bot `tg_parser/bot/tools.py::_exec_unsubscribe_digest`) **have** invoked `unregister_digest_subscription(sub_id)` synchronously after the DB delete since F6's introduction (PR #11, commit `410452a`, 2026-04-19). The orphan-tick delivery observed during the Test C cleanup on 2026-05-24 ~21:00Z must have come from a different mechanism — most likely the cross-process gap inherent to the deployment: MCP and bot run as **separate Docker containers** (`docker-compose.yml` lines 168 + 243), each with its own `BackgroundScheduler` singleton. An `unregister_digest_subscription` call inside the MCP container only mutates the MCP-process scheduler (which never had the job — only the bot does). The bot's singleton retains the job until its 60-second `_reconcile_loop` next ticks.

Two safeguards already mitigated this in practice:

1. **Tick-time DB re-check** — `run_scheduled_digests_task` (in the bot process) opens a fresh `digest_subscription_repo()` context at the start of every cron tick and bails with `status="not_found"` if `sub_repo.get(...)` returns `None`. Any tick that fires after the DB delete commits short-circuits before delivery.
2. **Reconcile loop** — `reconcile_digest_subscriptions()` diffs `desired` (active rows in DB) against `registered` (jobs in the in-memory `_tasks` dict) and unregisters orphans every `digest_refresh_interval` (default 60s).

The structural gap closed by this PR is narrower and more operational:

* The pre-fix `BackgroundScheduler.remove_task` returned `False` immediately when `task_id not in self._tasks` — it **never attempted** `AsyncIOScheduler.remove_job` in that branch. So in any deployment where the bookkeeping dict has diverged from the APScheduler job store (cross-process replicas, future shared `JobStore` backends, an aborted reconcile mid-tick), `unregister_digest_subscription` would be a silent no-op even when the underlying scheduler did still have the job.
* The pre-fix path also swallowed a bare `Exception` from `scheduler.remove_job` with a `logger.debug`, which masked schema/network errors that should fail loud.
* The pre-fix path emitted a positional `logger.info("Removed task %s", task_id)` line with no `reason` tag — operators cannot tell from logs whether a removal came from an MCP unsubscribe, a bot tool unsubscribe, a reconcile-loop sweep, or a subscribe-then-replace cycle.

This PR makes `remove_task` genuinely idempotent across all those dimensions, specifically handles `JobLookupError` (apscheduler's documented "missing-job" signal), and threads a `reason` tag through every scheduler-mutation call site.

## Scope decision (digest-only)

`unsubscribe_watchlist` is **not** symmetric to `unsubscribe_digest`. The F11 matcher does not own a per-interest APScheduler job — it runs piggy-back inside the incremental pipeline tick and reads `WatchInterestRepoPort.list_active_for_channel(channel_id)` at the start of every tick, which filters on `is_active = TRUE`. The `unsubscribe_watchlist` tool soft-deletes the interest (`is_active=False`), so it immediately drops out of the matcher's source set — no in-memory scheduler state to invalidate, no orphan-tick window to close.

This invariant is locked in by `tests/test_scheduler_invalidation_on_unsubscribe.py::TestWatchlistInvalidationByConstruction`. If a future change introduces APScheduler-driven scheduling for watchlists, those guards will fail and force a symmetric fix to be added inside this same test file.

## Before / after

### `tg_parser/services/background_scheduler.py::BackgroundScheduler.remove_task`

Before:

```python
def remove_task(self, task_id: str) -> bool:
    if task_id not in self._tasks:
        return False  # <-- never attempts scheduler.remove_job

    try:
        self._scheduler.remove_job(task_id)
    except Exception as e:
        logger.debug("Job %s not found in scheduler: %s", task_id, e)

    del self._tasks[task_id]
    logger.info("Removed task %s", task_id)
    return True
```

After:

```python
def remove_task(self, task_id: str, *, reason: str | None = None) -> bool:
    had_tracked = task_id in self._tasks
    had_scheduled = False
    try:
        self._scheduler.remove_job(task_id)
        had_scheduled = True
    except JobLookupError:
        pass  # idempotent: reconcile / sibling already removed it
    self._tasks.pop(task_id, None)
    if had_tracked or had_scheduled:
        logger.info(
            "scheduler_job_removed",
            task_id=task_id,
            reason=reason or "unspecified",
            from_memory=had_tracked,
            from_scheduler=had_scheduled,
        )
        return True
    logger.debug(
        "scheduler_job_remove_noop",
        task_id=task_id,
        reason=reason or "unspecified",
    )
    return False
```

### `tg_parser/services/background_scheduler.py::unregister_digest_subscription`

```python
def unregister_digest_subscription(
    subscription_id: str,
    scheduler: BackgroundScheduler | None = None,
    *,
    reason: str = "unsubscribe",
) -> bool:
    sched = scheduler or get_scheduler()
    return sched.remove_task(_digest_job_id(subscription_id), reason=reason)
```

### MCP + bot call sites

```python
# tg_parser/mcp_server.py::unsubscribe_digest
unregister_digest_subscription(sub_id, reason="mcp_unsubscribe_digest")

# tg_parser/bot/tools.py::_exec_unsubscribe_digest
unregister_digest_subscription(sub_id, reason="bot_unsubscribe_digest")

# tg_parser/services/scheduler_service.py::reconcile_digest_subscriptions
unregister_digest_subscription(sub_id, reason="reconcile")
```

## Test plan

New regression file `tests/test_scheduler_invalidation_on_unsubscribe.py` — **19 tests**, organised into 5 layers:

* **Layer A — `BackgroundScheduler.remove_task` hardening (10 tests):** cross-process `_tasks`-dict-divergence, in-memory-only and scheduler-only paths, idempotent double-call, `JobLookupError` swallowed, other exceptions propagated, structured `scheduler_job_removed` event includes `reason`, `unregister_digest_subscription` forwards `reason` (default `"unsubscribe"`, idempotent on second call).
* **Layer B — end-to-end MCP / bot unsubscribe contract (3 tests):** MCP `unsubscribe_digest` removes the in-process scheduler job atomically (verified via direct logger introspection: `scheduler_job_removed` event with `reason="mcp_unsubscribe_digest"` and the matching `task_id`); same shape for bot `_exec_unsubscribe_digest` (`reason="bot_unsubscribe_digest"`); MCP unsubscribe twice returns `success=False` "not found" the second time.
* **Layer C — anti-regression for existing safeguards (3 tests):** `run_scheduled_digests_task` returns `status="not_found"` when the DB row is gone; full `subscribe → register job → MCP unsubscribe → fire tick → assert AsyncMock(Bot).send_message.await_count == 0` end-to-end (no delivery); reconcile loop removes orphan jobs after an external (psql-style) DB delete.
* **Layer D — watchlist scope decision (2 tests):** soft-deleted interest is excluded from `WatchInterestRepoPort.list_active_for_channel`; `WatchlistService.check_interests` produces zero matches when the only matching interest has been soft-deleted (proves the digest-only scope decision).
* **Layer E — Prometheus assertion (1 test):** snapshot `tg_digest_channel_publish_total` for every label, run the `subscribe → unsubscribe → manual tick` sequence with a mocked Bot, snapshot again — counter MUST be unchanged.

### Self-review-and-rerun loop (operator-mandated)

* [x] Initial green run on the new file (`TEST_POSTGRES=1`): **19 passed, 0 failed**.
* [x] Stashed the production fix (`git stash push -- tg_parser/bot/tools.py tg_parser/mcp_server.py tg_parser/services/background_scheduler.py tg_parser/services/scheduler_service.py`) and reran on `main@66e8297` shape: **8 failed, 11 passed**:
  * 6 unit-level hardening tests (`test_remove_task_removes_apscheduler_job_when_dict_empty`, `test_remove_task_swallows_job_lookup_error_from_apscheduler`, `test_remove_task_propagates_unexpected_exceptions`, `test_remove_task_emits_structured_reason_in_log`, `test_unregister_passes_reason_to_remove_task`, `test_unregister_default_reason_is_unsubscribe`);
  * 2 end-to-end telemetry assertions (MCP + bot atomically-remove tests — pre-fix emits positional `("Removed task %s", task_id)` instead of the structured `scheduler_job_removed` event, captured cleanly with `Got captured calls: [(('Removed task %s', ...), {})]`).
  * The 11 tests that still pass on pre-fix code prove that the existing safeguards (tick-time DB re-check + reconcile loop + soft-delete-by-construction for watchlist) were already working — this PR is **strictly additive**, closing a narrower telemetry + cross-process invalidation gap rather than the broader "no removal happens" gap the handoff originally hypothesised.
* [x] Self-review identified that the original integration tests would pass pre-fix because the basic call was already in place; strengthened the MCP / bot end-to-end tests to **also** assert on the new structured `scheduler_job_removed` event with the right `reason` tag, captured via direct `logger.info` introspection (more deterministic than `caplog` under pytest-asyncio + structlog stdlib routing).
* [x] Restored fix (`git stash pop`) and reran: **19/19 passed** on the new file.

### Full affected-suite rerun

Normal mode:

```
.venv/bin/pytest tests/test_scheduler_invalidation_on_unsubscribe.py \
    tests/test_bot_chat_target_resolution.py tests/test_bot_channel_name_parser.py \
    tests/test_bot_confirm_flow.py tests/test_f4b_deferred_surface_guard.py \
    tests/test_f11_bot_tools.py tests/test_subscribe_idempotency.py \
    tests/test_f6_scheduled_digests.py
=> 336 passed, 30 skipped
```

**Mandatory `TEST_POSTGRES=1` rerun** (per `docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`):

```
TEST_POSTGRES=1 .venv/bin/pytest \
    tests/test_scheduler_invalidation_on_unsubscribe.py tests/test_f6_scheduled_digests.py \
    tests/test_f11_mcp_tools.py tests/test_subscribe_idempotency.py \
    tests/test_api_digests.py tests/test_bot_chat_target_resolution.py \
    tests/test_bot_channel_name_parser.py tests/test_bot_confirm_flow.py \
    tests/test_f4b_deferred_surface_guard.py tests/test_f11_bot_tools.py
=> 407 passed, 1 skipped, 0 failed
```

The single skip is the pre-existing `test_concurrent_two_confirms_race_documented` integration-harness skip (tracked as TD-confirm-flow-concurrency-integration) — unrelated to this PR.

### `ruff` results

```
ruff check tg_parser/services/background_scheduler.py tg_parser/services/scheduler_service.py \
           tg_parser/mcp_server.py tg_parser/bot/tools.py \
           tests/test_scheduler_invalidation_on_unsubscribe.py
=> All checks passed!

ruff format --check (same five files)
=> 5 files already formatted
```

### Reconcile-loop invariant (defense-in-depth)

`reconcile_digest_subscriptions()` continues to handle two cases this PR does not address synchronously:

1. **External DB deletes** (psql, alembic migrations) that bypass both MCP and bot tools — reconcile catches the orphan within ≤ `digest_refresh_interval`.
2. **Cross-process MCP-side deletes** — the bot's reconcile loop still picks up the deletion within ≤ `digest_refresh_interval`. The tick-time DB re-check (`run_scheduled_digests_task` → `sub_repo.get(...) is None` → `status="not_found"`) prevents any stale delivery during that window.

Both are explicitly asserted by `TestReconcileLoopOrphanCleanup::test_reconcile_loop_removes_orphan_job_after_external_db_delete` and `TestTickTimeSafeguard::test_run_scheduled_digests_task_returns_not_found_after_db_delete` so accidental regressions in either path are caught at PR review time.

## References

- [`docs/notes/BUG_LOG.md` § BUG-035](docs/notes/BUG_LOG.md)
- [`docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md` § 3.1](docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md)
- [`docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md`](docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md) (Test C cleanup empirical trace)
- [`docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`](docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md) (`TEST_POSTGRES=1` rerun mandate)
- Recent merge precedent: `e50449b` (BUG-033 PR #108), `6ebad33` (BUG-034 PR #109), `66e8297` (BUG-031+032 PR #111)

## Operator action required

- **DO NOT MERGE** without sign-off (per `AGENTS.md` + handoff anti-patterns).
- Optional follow-up (not in scope): consider lowering `digest_refresh_interval` from 60s to 15-30s in production to shrink the cross-process convergence window further. Pure operational tuning — no code change required.
- Optional follow-up (not in scope): the empirical orphan delivery observed on 2026-05-24 ~21:00Z remains unexplained at the code level (the tick-time DB re-check should have caught it). The most likely culprit is a sub-second race between the DB delete commit and the cron-tick coroutine completing its `sub_repo.get(...)` lookup, but no production trace correlates that hypothesis with certainty. If the pattern recurs after this PR ships, a separate spike to add `SELECT FOR UPDATE` on the tick-time fetch (or a `BEGIN ISOLATION LEVEL REPEATABLE READ` envelope around delete) may be warranted.

Made with [Cursor](https://cursor.com)