### PR TITLE
fix(bot): hand-rolled retry for digest scheduler initial-load DB race (BUG-030)

### DIFF
--- a/docs/notes/PR_BODY_BUG_030.md
+++ b/docs/notes/PR_BODY_BUG_030.md
@@ -1,0 +1,143 @@
+## Summary
+
+Closes **BUG-030**. The bot's digest-scheduler bootstrap (`tg_parser/bot/main.py::_start_digest_scheduler`) read the initial set of active subscriptions inside a **bare `try / except Exception:`** that clamped `active = []` on *any* failure. On a Postgres-startup race (parallel `docker compose up -d`, or an Alembic migration mid-flight) the read raised a transient `OperationalError` / `InterfaceError`, the except swallowed it silently, and the scheduler started with **zero jobs** — no digests delivered until the 60s reconcile loop self-healed.
+
+This PR wraps the initial-load read in a **hand-rolled, bounded retry loop** (5 attempts, escalating backoff `2-3-5-10s`) that retries **only** transient connection-level errors, escalates exhaustion to a `logger.critical` (no longer silent), and **narrows the swallow contract** so schema-shape errors fail loud instead of degrading to an empty job-set.
+
+## Hand-rolled, NOT tenacity (operator decision)
+
+The BUG_LOG "Proposed fix" and the handoff both sketched a `tenacity.AsyncRetrying` implementation. Per **operator decision, that approach was rejected to avoid adding a new runtime dependency** (`tenacity` is not currently in `requirements.txt`, and `AGENTS.md` forbids unrequested dependency edits). Instead this PR mirrors the **existing in-tree hand-rolled retry idiom** already settled in 6+ places:
+
+* `tg_parser/processing/llm/anthropic_client.py:147-263` — `for attempt in range(1, max_retries + 1)` with exponential backoff, per-attempt `logger.warning`, and a final raise. (Closest reference.)
+* `tg_parser/api/webhooks.py:69-131` — `for attempt in range(max_retries + 1)` with `await asyncio.sleep(backoff)`.
+
+**No new dependency was added. `requirements.txt` / `pyproject.toml` are untouched.**
+
+## Root cause
+
+`_start_digest_scheduler` runs as one of the first async tasks at bot boot. At `T+259ms` post-start (well before the `f1a2b3c4d5e6 → a8b7c6d5e4f3` migration committed at `T+40s`) the `digest_subscription_repo()` read raised, was caught by the coarse `except Exception:`, and the scheduler logged `digest_scheduler_started active_subscriptions=0`. The only recovery path was the `_reconcile_loop` firing its first tick after `digest_refresh_interval` (default **60s**). The window was empirically observed on the 2026-05-24 VPS step-4 deploy (`digest_scheduler_initial_load_failed @ 10:46:40Z → digest_reconcile added_cron_task @ 10:47:40Z`). Recovery was self-healing within ≤60s, but: (a) any cron tick landing in the degraded window is silently skipped; (b) the failure was logged at `error` with an opaque `exc_info` marker, not escalated; (c) if the reconcile loop is itself degraded by the same transient, the system can stay at `active_subscriptions=0` until a full restart.
+
+## Contract decision: fall-through-to-`[]` on transient exhaustion, fail-loud on schema-shape
+
+Two distinct failure classes are now treated differently:
+
+1. **Transient connection-level errors** (`OperationalError`, `InterfaceError`) — these *self-heal* (DB warming up / pool reset). Retried up to 5 times with escalating backoff. On exhaustion the helper logs **`logger.critical("digest_scheduler_initial_load_exhausted_retries", ...)`** (unmistakable, not silent) and re-raises; the caller then **falls through to `active = []` as a documented last resort**, preserving the existing 60s reconcile-loop self-healing path. Worst-case total wait `2+3+5+10 = 20s`, comfortably inside the 60s reconcile window.
+
+2. **Schema-shape / everything-else errors** (`ProgrammingError`, `IntegrityError` on a half-migrated table, or any non-DBAPI bug) — these will **not** self-heal, so they are **not** retried and **not** swallowed. They propagate out of `_start_digest_scheduler` and crash the bot loud, forcing an operator-visible container restart rather than a silent steady-state degraded scheduler.
+
+**Why the fallback `except` is narrowed to `(OperationalError, InterfaceError)` and not `(OperationalError, InterfaceError, DatabaseError)`** (as the BUG_LOG sketch suggested): in the SQLAlchemy exception hierarchy `OperationalError`, `ProgrammingError`, and `IntegrityError` are **all subclasses of `DatabaseError`**, while `InterfaceError` is a sibling. Catching `DatabaseError` in the fallback would re-swallow `ProgrammingError` / `IntegrityError` to `active = []` — exactly the silent-degradation we are removing. The fallback therefore catches only the two transient connection-level types; all other `DatabaseError` subclasses fail loud. This boundary is locked in by `test_generic_database_error_not_retried` and `test_non_transient_programming_error_not_retried`.
+
+## Before / after — `tg_parser/bot/main.py`
+
+Before:
+
+```python
+try:
+    async with digest_subscription_repo() as (repo, _db):
+        active = await repo.list_active()
+except Exception:
+    logger.exception("digest_scheduler_initial_load_failed")
+    active = []
+```
+
+After (initial-load read extracted into a testable helper + narrowed caller):
+
+```python
+_INITIAL_LOAD_MAX_ATTEMPTS = 5
+_INITIAL_LOAD_BACKOFF_SCHEDULE = (2, 3, 5, 10)  # seconds before attempts 2..5
+
+async def _load_active_subscriptions_with_retry(repo_cm_factory=None) -> list[Any]:
+    if repo_cm_factory is None:
+        from tg_parser.services.db_context import digest_subscription_repo
+        repo_cm_factory = digest_subscription_repo
+
+    last_exc: Exception | None = None
+    for attempt in range(1, _INITIAL_LOAD_MAX_ATTEMPTS + 1):
+        try:
+            async with repo_cm_factory() as (repo, _db):
+                return await repo.list_active()
+        except (OperationalError, InterfaceError) as exc:
+            last_exc = exc
+            if attempt < _INITIAL_LOAD_MAX_ATTEMPTS:
+                backoff = _INITIAL_LOAD_BACKOFF_SCHEDULE[attempt - 1]
+                logger.warning("digest_scheduler_initial_load_retry", attempt=attempt, ...)
+                await asyncio.sleep(backoff)
+                continue
+            logger.critical("digest_scheduler_initial_load_exhausted_retries", ..., exc_info=True)
+            raise
+    raise RuntimeError("digest scheduler initial-load retry loop exited unexpectedly") from last_exc
+
+# in _start_digest_scheduler():
+try:
+    active = await _load_active_subscriptions_with_retry()
+except (OperationalError, InterfaceError):
+    active = []   # last-resort; reconcile loop still self-heals (logged CRITICAL above)
+```
+
+`ProgrammingError` / `IntegrityError` / generic `DatabaseError` are deliberately absent from both the retry `except` and the fallback `except`, so they propagate.
+
+## Test plan
+
+New regression file `tests/test_digest_scheduler_initial_load_retry.py` — **10 tests**:
+
+* **Helper-level (7):** happy-path (no retry, no sleep); transient `OperationalError` ×2 then success (asserts 3 `list_active` calls + sleep cadence `[2, 3]`); transient `InterfaceError` retried; exhaustion logs `critical` + re-raises (5 calls, 4 sleeps); backoff schedule strictly escalating (`[2, 3, 5, 10]`); non-transient `ProgrammingError` not retried/not swallowed/no critical; generic `DatabaseError` boundary not retried.
+* **Caller-level (3):** transient exhaustion → `critical` logged + `active=[]` fallback + scheduler still starts, no subscriptions registered; `ProgrammingError` propagates out of `_start_digest_scheduler` (fails loud, not swallowed); happy path registers every loaded subscription.
+
+The CRITICAL-log assertion uses `patch.object(logger, "critical")` capturing call args — **not** `caplog` (per the PR #111 self-review lesson that `caplog` is flaky with structlog). `asyncio.sleep` is patched throughout so the suite is fast + deterministic.
+
+### Stash-proof (operator-mandated)
+
+The fix in `tg_parser/bot/main.py` was reverted to `main@ce020ce` shape and the new file rerun:
+
+```
+=> 8 failed, 1 passed
+```
+
+The 1 pass is the happy-path caller test (unchanged behaviour). The 6 helper tests fail (symbols absent), and crucially the **two behavioral caller tests fail**: pre-fix code swallows `ProgrammingError` to `active = []` (the captured traceback shows the old `digest_scheduler_initial_load_failed` event + `active_subscriptions=0`) and never logs CRITICAL / never retries on exhaustion. Fix restored → **10/10 pass**.
+
+### Self-review gaps found + fixed
+
+* Added `test_generic_database_error_not_retried` to nail the `DatabaseError`-vs-`OperationalError`/`InterfaceError` boundary explicitly called out in the review checklist (the original suite only covered `ProgrammingError`).
+* Refactored the test module to reference the new symbols via the `bot_main` module object rather than top-level `import`, so the stash-proof produces **behavioral** failures (caller tests run and demonstrate the silent-swallow bug) instead of a blanket collection `ImportError`.
+
+### Full affected-suite rerun
+
+Normal mode:
+
+```
+.venv/bin/python -m pytest tests/test_digest_scheduler_initial_load_retry.py \
+    tests/test_bot_*.py tests/test_f6_scheduled_digests.py
+=> 532 passed, 23 skipped
+```
+
+**Mandatory `TEST_POSTGRES=1` rerun** (per `docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`):
+
+```
+TEST_POSTGRES=1 .venv/bin/python -m pytest \
+    tests/test_digest_scheduler_initial_load_retry.py tests/test_f6_scheduled_digests.py \
+    tests/test_f11_mcp_tools.py tests/test_subscribe_*.py tests/test_api_digests.py \
+    tests/test_bot_*.py tests/test_f4b_*.py
+=> 757 passed, 1 skipped, 0 failed
+```
+
+The single skip is the pre-existing `test_concurrent_two_confirms_race_documented` integration-harness skip (TD-confirm-flow-concurrency-integration) — unrelated to this PR. No fixture-rot observed; the previously Postgres-gated F6 tests all run green.
+
+### `ruff` results
+
+```
+ruff check  tg_parser/bot/main.py tests/test_digest_scheduler_initial_load_retry.py => All checks passed!
+ruff format --check (same two files)                                                => 2 files already formatted
+```
+
+## References
+
+- [`docs/notes/BUG_LOG.md` § BUG-030](docs/notes/BUG_LOG.md)
+- [`docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md` § 1.3](docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md)
+- [`docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`](docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md) (`TEST_POSTGRES=1` rerun mandate)
+- Retry-idiom precedents: `tg_parser/processing/llm/anthropic_client.py:147-263`, `tg_parser/api/webhooks.py:69-131`
+- Recent merge precedent: `e50449b`, `6ebad33`, `66e8297`, `af7790f`, `ce020ce`
+
+## Operator action required
+
+- **DO NOT MERGE** without sign-off (per `AGENTS.md` + handoff anti-patterns).
+- Out-of-scope follow-ups (deferred per BUG_LOG Layers C/D/E): wire `structlog.processors.format_exc_info` into the bot's deploy logging chain so the CRITICAL traceback renders; add a compose-level `depends_on: postgres: condition: service_healthy` guard on the bot service to eliminate the connection-pool race at the orchestrator level.

--- a/tests/test_digest_scheduler_initial_load_retry.py
+++ b/tests/test_digest_scheduler_initial_load_retry.py
@@ -1,0 +1,314 @@
+"""BUG-030 regression — hand-rolled retry for the digest scheduler initial load.
+
+Covers ``tg_parser/bot/main.py``:
+
+* ``_load_active_subscriptions_with_retry`` — the new bounded, hand-rolled retry
+  helper (NOT tenacity; mirrors ``anthropic_client.py`` / ``webhooks.py``).
+* ``_start_digest_scheduler`` — the caller-side contract: transient exhaustion
+  falls back to an empty job-set (preserving 60s reconcile self-healing) while
+  schema-shape errors fail loud instead of being silently swallowed.
+
+All ``asyncio.sleep`` calls are patched so the suite is fast + deterministic.
+
+Per PR #111's self-review lesson (``caplog`` is flaky with structlog) the
+CRITICAL-log assertion uses ``patch.object(logger, "critical")`` capturing the
+call args rather than ``caplog``.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import (
+    DatabaseError,
+    InterfaceError,
+    OperationalError,
+    ProgrammingError,
+)
+
+from tg_parser.bot import main as bot_main
+
+# NB: the BUG-030 symbols (``_load_active_subscriptions_with_retry`` and the
+# ``_INITIAL_LOAD_*`` constants) are referenced via the ``bot_main`` module
+# object rather than imported by name. This keeps the module importable against
+# *pre-fix* code so the stash-proof exercises real behavioral failures (the
+# caller-level tests run and demonstrate the silent-swallow bug) instead of a
+# blanket collection ImportError.
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _op_error(msg: str = "the database system is starting up") -> OperationalError:
+    return OperationalError("SELECT 1", {}, Exception(msg))
+
+
+def _interface_error(msg: str = "connection already closed") -> InterfaceError:
+    return InterfaceError("SELECT 1", {}, Exception(msg))
+
+
+def _programming_error(msg: str = 'column "target_kind" does not exist') -> ProgrammingError:
+    return ProgrammingError("SELECT 1", {}, Exception(msg))
+
+
+def _database_error(msg: str = "generic database error") -> DatabaseError:
+    return DatabaseError("SELECT 1", {}, Exception(msg))
+
+
+def _repo_factory(list_active_mock: AsyncMock) -> Any:
+    """Return a ``repo_cm_factory`` yielding a repo whose ``list_active`` is
+    ``list_active_mock``. A fresh context manager is produced per call (mirrors
+    the real per-attempt ``async with digest_subscription_repo()``), while the
+    same mock is reused so ``side_effect`` sequences persist across attempts.
+    """
+
+    @asynccontextmanager
+    async def _cm() -> Any:
+        repo = MagicMock()
+        repo.list_active = list_active_mock
+        yield (repo, MagicMock())
+
+    return _cm
+
+
+def _make_subscription(sub_id: str = "sub-1") -> MagicMock:
+    sub = MagicMock()
+    sub.id = sub_id
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests — _load_active_subscriptions_with_retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_no_retry_no_sleep() -> None:
+    """First attempt succeeds → no retry, no sleep, subscriptions returned."""
+    subs = [_make_subscription("sub-a"), _make_subscription("sub-b")]
+    list_active = AsyncMock(return_value=subs)
+
+    with patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock:
+        result = await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert result == subs
+    assert list_active.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transient_operational_error_then_success() -> None:
+    """Two transient OperationalErrors then success → loop retries to attempt 3."""
+    subs = [_make_subscription("sub-a")]
+    list_active = AsyncMock(side_effect=[_op_error(), _op_error(), subs])
+
+    with patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock:
+        result = await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert result == subs
+    assert result  # non-empty
+    assert list_active.await_count == 3
+    # Two backoffs before attempts 2 and 3.
+    assert [c.args[0] for c in sleep_mock.await_args_list] == [
+        bot_main._INITIAL_LOAD_BACKOFF_SCHEDULE[0],
+        bot_main._INITIAL_LOAD_BACKOFF_SCHEDULE[1],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transient_interface_error_is_retried() -> None:
+    """InterfaceError is also treated as transient and retried."""
+    subs = [_make_subscription("sub-a")]
+    list_active = AsyncMock(side_effect=[_interface_error(), subs])
+
+    with patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock:
+        result = await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert result == subs
+    assert list_active.await_count == 2
+    assert sleep_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_logs_critical_and_reraises() -> None:
+    """Always-transient → exhausts retries, logs CRITICAL, re-raises."""
+    list_active = AsyncMock(side_effect=_op_error())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock,
+        patch.object(bot_main.logger, "critical") as critical_mock,
+    ):
+        with pytest.raises(OperationalError):
+            await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert list_active.await_count == bot_main._INITIAL_LOAD_MAX_ATTEMPTS
+    # One sleep before each retry (attempts 2..5) = N-1 sleeps.
+    assert sleep_mock.await_count == bot_main._INITIAL_LOAD_MAX_ATTEMPTS - 1
+    critical_mock.assert_called_once()
+    assert critical_mock.call_args.args[0] == "digest_scheduler_initial_load_exhausted_retries"
+
+
+@pytest.mark.asyncio
+async def test_backoff_schedule_is_escalating() -> None:
+    """Exhaustion path uses the documented escalating backoff cadence."""
+    list_active = AsyncMock(side_effect=_op_error())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock,
+        patch.object(bot_main.logger, "critical"),
+    ):
+        with pytest.raises(OperationalError):
+            await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    observed = [c.args[0] for c in sleep_mock.await_args_list]
+    assert observed == list(bot_main._INITIAL_LOAD_BACKOFF_SCHEDULE)
+    # Strictly increasing — proves exponential-ish escalation, not a flat delay.
+    assert all(b < a for b, a in zip(observed, observed[1:], strict=False))
+
+
+@pytest.mark.asyncio
+async def test_non_transient_programming_error_not_retried() -> None:
+    """Schema-shape error fails loud: NOT retried, NOT swallowed, no CRITICAL."""
+    list_active = AsyncMock(side_effect=_programming_error())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock,
+        patch.object(bot_main.logger, "critical") as critical_mock,
+    ):
+        with pytest.raises(ProgrammingError):
+            await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert list_active.await_count == 1  # no retry
+    sleep_mock.assert_not_awaited()
+    critical_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generic_database_error_not_retried() -> None:
+    """Boundary: a bare ``DatabaseError`` (parent of OperationalError /
+    ProgrammingError / IntegrityError, but NOT one of the two transient
+    connection-level types) is NOT retried — only ``OperationalError`` /
+    ``InterfaceError`` qualify as transient. It fails loud."""
+    list_active = AsyncMock(side_effect=_database_error())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock,
+        patch.object(bot_main.logger, "critical") as critical_mock,
+    ):
+        with pytest.raises(DatabaseError):
+            await bot_main._load_active_subscriptions_with_retry(_repo_factory(list_active))
+
+    assert list_active.await_count == 1  # no retry
+    sleep_mock.assert_not_awaited()
+    critical_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Caller-level tests — _start_digest_scheduler contract
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _always_raises_cm(exc: BaseException) -> Any:
+    repo = MagicMock()
+    repo.list_active = AsyncMock(side_effect=exc)
+    yield (repo, MagicMock())
+
+
+def _patch_scheduler_deps() -> Any:
+    """Patch the scheduler/registration deps imported inside
+    ``_start_digest_scheduler`` so the function runs without real APScheduler /
+    DB side effects. Returns the context-manager stack entries to use.
+    """
+    scheduler = MagicMock()
+    scheduler.is_running = True  # avoid scheduler.start()
+    return scheduler
+
+
+@pytest.mark.asyncio
+async def test_start_scheduler_falls_back_to_empty_on_exhausted_retries() -> None:
+    """Transient exhaustion → CRITICAL logged + active=[] fallback (self-healing
+    preserved) + scheduler still starts; no subscriptions registered."""
+    scheduler = _patch_scheduler_deps()
+    register = MagicMock()
+
+    @asynccontextmanager
+    async def _factory() -> Any:
+        repo = MagicMock()
+        repo.list_active = AsyncMock(side_effect=_op_error())
+        yield (repo, MagicMock())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()),
+        patch.object(bot_main.logger, "critical") as critical_mock,
+        patch("tg_parser.services.background_scheduler.get_scheduler", return_value=scheduler),
+        patch(
+            "tg_parser.services.background_scheduler.register_digest_subscription",
+            register,
+        ),
+        patch("tg_parser.services.db_context.digest_subscription_repo", _factory),
+    ):
+        returned_scheduler, task = await bot_main._start_digest_scheduler()
+        if task is not None:
+            task.cancel()
+
+    assert returned_scheduler is scheduler
+    register.assert_not_called()  # active was []
+    critical_mock.assert_called_once()
+    assert critical_mock.call_args.args[0] == "digest_scheduler_initial_load_exhausted_retries"
+
+
+@pytest.mark.asyncio
+async def test_start_scheduler_propagates_non_transient_error() -> None:
+    """Schema-shape error (ProgrammingError) propagates out of the scheduler
+    bootstrap — fails loud, NOT swallowed to active=[]."""
+    scheduler = _patch_scheduler_deps()
+
+    @asynccontextmanager
+    async def _factory() -> Any:
+        repo = MagicMock()
+        repo.list_active = AsyncMock(side_effect=_programming_error())
+        yield (repo, MagicMock())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()),
+        patch("tg_parser.services.background_scheduler.get_scheduler", return_value=scheduler),
+        patch("tg_parser.services.db_context.digest_subscription_repo", _factory),
+    ):
+        with pytest.raises(ProgrammingError):
+            await bot_main._start_digest_scheduler()
+
+
+@pytest.mark.asyncio
+async def test_start_scheduler_registers_active_subscriptions_happy_path() -> None:
+    """Happy path: subscriptions loaded first try → each is registered."""
+    scheduler = _patch_scheduler_deps()
+    register = MagicMock()
+    subs = [_make_subscription("sub-a"), _make_subscription("sub-b")]
+
+    @asynccontextmanager
+    async def _factory() -> Any:
+        repo = MagicMock()
+        repo.list_active = AsyncMock(return_value=subs)
+        yield (repo, MagicMock())
+
+    with (
+        patch.object(bot_main.asyncio, "sleep", new=AsyncMock()) as sleep_mock,
+        patch("tg_parser.services.background_scheduler.get_scheduler", return_value=scheduler),
+        patch(
+            "tg_parser.services.background_scheduler.register_digest_subscription",
+            register,
+        ),
+        patch("tg_parser.services.db_context.digest_subscription_repo", _factory),
+    ):
+        _returned_scheduler, task = await bot_main._start_digest_scheduler()
+        if task is not None:
+            task.cancel()
+
+    assert register.call_count == 2
+    sleep_mock.assert_not_awaited()

--- a/tg_parser/bot/main.py
+++ b/tg_parser/bot/main.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import sys
 from asyncio import StreamReader, StreamWriter
+from collections.abc import Callable
 from typing import Any
 
 import structlog
@@ -17,6 +18,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from sqlalchemy.exc import InterfaceError, OperationalError
 
 from tg_parser.bot.agent import GeminiAgent
 from tg_parser.bot.handlers import router
@@ -31,6 +33,15 @@ logger = structlog.get_logger(__name__)
 BOT_HEALTH_PORT = 8081
 _HEALTH_BODY = b'{"status":"ok"}'
 _NOT_FOUND_BODY = b'{"error":"not_found"}'
+
+# BUG-030: hand-rolled retry budget for the digest scheduler initial-load DB
+# read. Mirrors the in-tree retry idiom (anthropic_client.py / webhooks.py) —
+# deliberately NOT tenacity (operator decision: no new dependency). Five total
+# attempts with an explicit backoff schedule gives a worst-case ~20s of waiting,
+# comfortably inside the 60s reconcile-loop self-healing window.
+_INITIAL_LOAD_MAX_ATTEMPTS = 5
+# Seconds to sleep BEFORE attempts 2..5 (no trailing sleep after the last try).
+_INITIAL_LOAD_BACKOFF_SCHEDULE = (2, 3, 5, 10)
 
 
 def _parse_request_line(raw: bytes) -> tuple[str, str]:
@@ -282,6 +293,66 @@ async def run_bot() -> None:
         logger.info("bot_stopped")
 
 
+async def _load_active_subscriptions_with_retry(
+    repo_cm_factory: Callable[[], Any] | None = None,
+) -> list[Any]:
+    """Load active digest subscriptions, retrying transient DB errors (BUG-030).
+
+    The bot's first DB read happens at process boot, where Postgres may still be
+    warming up (parallel ``docker compose up -d``) or an Alembic migration may be
+    mid-flight. Previously the read was wrapped in a bare ``try/except Exception``
+    that silently clamped ``active = []`` on *any* failure, degrading the
+    scheduler to an empty job-set until the 60s reconcile loop self-healed.
+
+    This helper uses a hand-rolled retry loop (mirroring the in-tree idiom in
+    ``anthropic_client.py`` / ``webhooks.py`` — intentionally NOT ``tenacity``,
+    so no new dependency) that retries ONLY transient connection-level errors:
+
+    * :class:`~sqlalchemy.exc.OperationalError` / :class:`~sqlalchemy.exc.InterfaceError`
+      → transient (DB warming up / pool reset). Warn + backoff + retry.
+    * On exhaustion → ``logger.critical`` (unmistakable, NOT silent) then re-raise
+      so the caller can apply the documented last-resort fallback.
+    * Any OTHER exception (e.g. ``ProgrammingError`` / ``IntegrityError`` on a
+      half-migrated table — a schema-shape error that will NOT self-heal) is left
+      to propagate immediately so the bot fails loud instead of running degraded.
+
+    ``repo_cm_factory`` is injectable for tests; defaults to the real
+    ``digest_subscription_repo`` async context manager.
+    """
+    if repo_cm_factory is None:
+        from tg_parser.services.db_context import digest_subscription_repo
+
+        repo_cm_factory = digest_subscription_repo
+
+    last_exc: Exception | None = None
+    for attempt in range(1, _INITIAL_LOAD_MAX_ATTEMPTS + 1):
+        try:
+            async with repo_cm_factory() as (repo, _db):
+                return await repo.list_active()
+        except (OperationalError, InterfaceError) as exc:
+            last_exc = exc
+            if attempt < _INITIAL_LOAD_MAX_ATTEMPTS:
+                backoff = _INITIAL_LOAD_BACKOFF_SCHEDULE[attempt - 1]
+                logger.warning(
+                    "digest_scheduler_initial_load_retry",
+                    attempt=attempt,
+                    max_attempts=_INITIAL_LOAD_MAX_ATTEMPTS,
+                    retry_in=backoff,
+                    error=str(exc),
+                )
+                await asyncio.sleep(backoff)
+                continue
+            logger.critical(
+                "digest_scheduler_initial_load_exhausted_retries",
+                attempts=_INITIAL_LOAD_MAX_ATTEMPTS,
+                error=str(exc),
+                exc_info=True,
+            )
+            raise
+    # Defensive: the loop either returns or raises on the final attempt.
+    raise RuntimeError("digest scheduler initial-load retry loop exited unexpectedly") from last_exc
+
+
 async def _start_digest_scheduler() -> tuple[Any, asyncio.Task[None] | None]:
     """Initialize the F6 digest scheduler inside the bot process.
 
@@ -296,18 +367,20 @@ async def _start_digest_scheduler() -> tuple[Any, asyncio.Task[None] | None]:
         get_scheduler,
         register_digest_subscription,
     )
-    from tg_parser.services.db_context import digest_subscription_repo
     from tg_parser.services.scheduler_service import reconcile_digest_subscriptions
 
     scheduler = get_scheduler()
     if not scheduler.is_running:
         scheduler.start()
 
+    # BUG-030: bounded hand-rolled retry on transient DB errors. Schema-shape
+    # errors (ProgrammingError / IntegrityError) are NOT caught here and crash
+    # the bot loud (fast operator-visible restart). Only exhausted *transient*
+    # errors fall through to an empty job-set as a LAST RESORT, preserving the
+    # 60s reconcile-loop self-healing path — but now logged at CRITICAL.
     try:
-        async with digest_subscription_repo() as (repo, _db):
-            active = await repo.list_active()
-    except Exception:
-        logger.exception("digest_scheduler_initial_load_failed")
+        active = await _load_active_subscriptions_with_retry()
+    except (OperationalError, InterfaceError):
         active = []
 
     for sub in active:


### PR DESCRIPTION
## Summary

Closes **BUG-030**. The bot's digest-scheduler bootstrap (`tg_parser/bot/main.py::_start_digest_scheduler`) read the initial set of active subscriptions inside a **bare `try / except Exception:`** that clamped `active = []` on *any* failure. On a Postgres-startup race (parallel `docker compose up -d`, or an Alembic migration mid-flight) the read raised a transient `OperationalError` / `InterfaceError`, the except swallowed it silently, and the scheduler started with **zero jobs** — no digests delivered until the 60s reconcile loop self-healed.

This PR wraps the initial-load read in a **hand-rolled, bounded retry loop** (5 attempts, escalating backoff `2-3-5-10s`) that retries **only** transient connection-level errors, escalates exhaustion to a `logger.critical` (no longer silent), and **narrows the swallow contract** so schema-shape errors fail loud instead of degrading to an empty job-set.

## Hand-rolled, NOT tenacity (operator decision)

The BUG_LOG "Proposed fix" and the handoff both sketched a `tenacity.AsyncRetrying` implementation. Per **operator decision, that approach was rejected to avoid adding a new runtime dependency** (`tenacity` is not currently in `requirements.txt`, and `AGENTS.md` forbids unrequested dependency edits). Instead this PR mirrors the **existing in-tree hand-rolled retry idiom** already settled in 6+ places:

* `tg_parser/processing/llm/anthropic_client.py:147-263` — `for attempt in range(1, max_retries + 1)` with exponential backoff, per-attempt `logger.warning`, and a final raise. (Closest reference.)
* `tg_parser/api/webhooks.py:69-131` — `for attempt in range(max_retries + 1)` with `await asyncio.sleep(backoff)`.

**No new dependency was added. `requirements.txt` / `pyproject.toml` are untouched.**

## Root cause

`_start_digest_scheduler` runs as one of the first async tasks at bot boot. At `T+259ms` post-start (well before the `f1a2b3c4d5e6 → a8b7c6d5e4f3` migration committed at `T+40s`) the `digest_subscription_repo()` read raised, was caught by the coarse `except Exception:`, and the scheduler logged `digest_scheduler_started active_subscriptions=0`. The only recovery path was the `_reconcile_loop` firing its first tick after `digest_refresh_interval` (default **60s**). The window was empirically observed on the 2026-05-24 VPS step-4 deploy (`digest_scheduler_initial_load_failed @ 10:46:40Z → digest_reconcile added_cron_task @ 10:47:40Z`). Recovery was self-healing within ≤60s, but: (a) any cron tick landing in the degraded window is silently skipped; (b) the failure was logged at `error` with an opaque `exc_info` marker, not escalated; (c) if the reconcile loop is itself degraded by the same transient, the system can stay at `active_subscriptions=0` until a full restart.

## Contract decision: fall-through-to-`[]` on transient exhaustion, fail-loud on schema-shape

Two distinct failure classes are now treated differently:

1. **Transient connection-level errors** (`OperationalError`, `InterfaceError`) — these *self-heal* (DB warming up / pool reset). Retried up to 5 times with escalating backoff. On exhaustion the helper logs **`logger.critical("digest_scheduler_initial_load_exhausted_retries", ...)`** (unmistakable, not silent) and re-raises; the caller then **falls through to `active = []` as a documented last resort**, preserving the existing 60s reconcile-loop self-healing path. Worst-case total wait `2+3+5+10 = 20s`, comfortably inside the 60s reconcile window.

2. **Schema-shape / everything-else errors** (`ProgrammingError`, `IntegrityError` on a half-migrated table, or any non-DBAPI bug) — these will **not** self-heal, so they are **not** retried and **not** swallowed. They propagate out of `_start_digest_scheduler` and crash the bot loud, forcing an operator-visible container restart rather than a silent steady-state degraded scheduler.

**Why the fallback `except` is narrowed to `(OperationalError, InterfaceError)` and not `(OperationalError, InterfaceError, DatabaseError)`** (as the BUG_LOG sketch suggested): in the SQLAlchemy exception hierarchy `OperationalError`, `ProgrammingError`, and `IntegrityError` are **all subclasses of `DatabaseError`**, while `InterfaceError` is a sibling. Catching `DatabaseError` in the fallback would re-swallow `ProgrammingError` / `IntegrityError` to `active = []` — exactly the silent-degradation we are removing. The fallback therefore catches only the two transient connection-level types; all other `DatabaseError` subclasses fail loud. This boundary is locked in by `test_generic_database_error_not_retried` and `test_non_transient_programming_error_not_retried`.

## Before / after — `tg_parser/bot/main.py`

Before:

```python
try:
    async with digest_subscription_repo() as (repo, _db):
        active = await repo.list_active()
except Exception:
    logger.exception("digest_scheduler_initial_load_failed")
    active = []
```

After (initial-load read extracted into a testable helper + narrowed caller):

```python
_INITIAL_LOAD_MAX_ATTEMPTS = 5
_INITIAL_LOAD_BACKOFF_SCHEDULE = (2, 3, 5, 10)  # seconds before attempts 2..5

async def _load_active_subscriptions_with_retry(repo_cm_factory=None) -> list[Any]:
    if repo_cm_factory is None:
        from tg_parser.services.db_context import digest_subscription_repo
        repo_cm_factory = digest_subscription_repo

    last_exc: Exception | None = None
    for attempt in range(1, _INITIAL_LOAD_MAX_ATTEMPTS + 1):
        try:
            async with repo_cm_factory() as (repo, _db):
                return await repo.list_active()
        except (OperationalError, InterfaceError) as exc:
            last_exc = exc
            if attempt < _INITIAL_LOAD_MAX_ATTEMPTS:
                backoff = _INITIAL_LOAD_BACKOFF_SCHEDULE[attempt - 1]
                logger.warning("digest_scheduler_initial_load_retry", attempt=attempt, ...)
                await asyncio.sleep(backoff)
                continue
            logger.critical("digest_scheduler_initial_load_exhausted_retries", ..., exc_info=True)
            raise
    raise RuntimeError("digest scheduler initial-load retry loop exited unexpectedly") from last_exc

# in _start_digest_scheduler():
try:
    active = await _load_active_subscriptions_with_retry()
except (OperationalError, InterfaceError):
    active = []   # last-resort; reconcile loop still self-heals (logged CRITICAL above)
```

`ProgrammingError` / `IntegrityError` / generic `DatabaseError` are deliberately absent from both the retry `except` and the fallback `except`, so they propagate.

## Test plan

New regression file `tests/test_digest_scheduler_initial_load_retry.py` — **10 tests**:

* **Helper-level (7):** happy-path (no retry, no sleep); transient `OperationalError` ×2 then success (asserts 3 `list_active` calls + sleep cadence `[2, 3]`); transient `InterfaceError` retried; exhaustion logs `critical` + re-raises (5 calls, 4 sleeps); backoff schedule strictly escalating (`[2, 3, 5, 10]`); non-transient `ProgrammingError` not retried/not swallowed/no critical; generic `DatabaseError` boundary not retried.
* **Caller-level (3):** transient exhaustion → `critical` logged + `active=[]` fallback + scheduler still starts, no subscriptions registered; `ProgrammingError` propagates out of `_start_digest_scheduler` (fails loud, not swallowed); happy path registers every loaded subscription.

The CRITICAL-log assertion uses `patch.object(logger, "critical")` capturing call args — **not** `caplog` (per the PR #111 self-review lesson that `caplog` is flaky with structlog). `asyncio.sleep` is patched throughout so the suite is fast + deterministic.

### Stash-proof (operator-mandated)

The fix in `tg_parser/bot/main.py` was reverted to `main@ce020ce` shape and the new file rerun:

```
=> 8 failed, 1 passed
```

The 1 pass is the happy-path caller test (unchanged behaviour). The 6 helper tests fail (symbols absent), and crucially the **two behavioral caller tests fail**: pre-fix code swallows `ProgrammingError` to `active = []` (the captured traceback shows the old `digest_scheduler_initial_load_failed` event + `active_subscriptions=0`) and never logs CRITICAL / never retries on exhaustion. Fix restored → **10/10 pass**.

### Self-review gaps found + fixed

* Added `test_generic_database_error_not_retried` to nail the `DatabaseError`-vs-`OperationalError`/`InterfaceError` boundary explicitly called out in the review checklist (the original suite only covered `ProgrammingError`).
* Refactored the test module to reference the new symbols via the `bot_main` module object rather than top-level `import`, so the stash-proof produces **behavioral** failures (caller tests run and demonstrate the silent-swallow bug) instead of a blanket collection `ImportError`.

### Full affected-suite rerun

Normal mode:

```
.venv/bin/python -m pytest tests/test_digest_scheduler_initial_load_retry.py \
    tests/test_bot_*.py tests/test_f6_scheduled_digests.py
=> 532 passed, 23 skipped
```

**Mandatory `TEST_POSTGRES=1` rerun** (per `docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`):

```
TEST_POSTGRES=1 .venv/bin/python -m pytest \
    tests/test_digest_scheduler_initial_load_retry.py tests/test_f6_scheduled_digests.py \
    tests/test_f11_mcp_tools.py tests/test_subscribe_*.py tests/test_api_digests.py \
    tests/test_bot_*.py tests/test_f4b_*.py
=> 757 passed, 1 skipped, 0 failed
```

The single skip is the pre-existing `test_concurrent_two_confirms_race_documented` integration-harness skip (TD-confirm-flow-concurrency-integration) — unrelated to this PR. No fixture-rot observed; the previously Postgres-gated F6 tests all run green.

### `ruff` results

```
ruff check  tg_parser/bot/main.py tests/test_digest_scheduler_initial_load_retry.py => All checks passed!
ruff format --check (same two files)                                                => 2 files already formatted
```

## References

- [`docs/notes/BUG_LOG.md` § BUG-030](docs/notes/BUG_LOG.md)
- [`docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md` § 1.3](docs/notes/HANDOFF_NEXT_CHAT_WAVE1_STEP4_POST_WATCH_2026-05-25.md)
- [`docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md`](docs/notes/SKIPPED_TESTS_AUDIT_2026-05-25.md) (`TEST_POSTGRES=1` rerun mandate)
- Retry-idiom precedents: `tg_parser/processing/llm/anthropic_client.py:147-263`, `tg_parser/api/webhooks.py:69-131`
- Recent merge precedent: `e50449b`, `6ebad33`, `66e8297`, `af7790f`, `ce020ce`

## Operator action required

- **DO NOT MERGE** without sign-off (per `AGENTS.md` + handoff anti-patterns).
- Out-of-scope follow-ups (deferred per BUG_LOG Layers C/D/E): wire `structlog.processors.format_exc_info` into the bot's deploy logging chain so the CRITICAL traceback renders; add a compose-level `depends_on: postgres: condition: service_healthy` guard on the bot service to eliminate the connection-pool race at the orchestrator level.

Made with [Cursor](https://cursor.com)