### PR TITLE
fix(grafana): provision wave1-step4 alert rules as code with noDataState=OK (BUG-036)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,12 @@ services:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
+      # BUG-036: secrets for the provisioned cursor-watch-webhook contact point
+      # (docker/grafana/provisioning/alerting/wave1_step4.yaml). Values live in
+      # the gitignored .env; never commit them. Grafana expands these at
+      # provisioning load time.
+      - GRAFANA_WEBHOOK_URL=${GRAFANA_WEBHOOK_URL:-}
+      - GRAFANA_WEBHOOK_TOKEN=${GRAFANA_WEBHOOK_TOKEN:-}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker/grafana/provisioning/alerting/wave1_step4.yaml
+++ b/docker/grafana/provisioning/alerting/wave1_step4.yaml
@@ -1,0 +1,302 @@
+# BUG-036 — Wave 1 step 4 Grafana alert rules provisioned as code.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# These three alert rules (`tg_parser_bot_down`, `tg_parser_api_down`,
+# `tg_api_5xx_spike`) were originally created by hand in the Grafana UI during
+# the Wave-1-step-4 VPS watch. UI-created rules do NOT persist their
+# `noDataState` reliably across Grafana eval cycles / container restarts, so
+# the `noDataState` kept drifting back to `Alerting/NoData` and re-emitted
+# spurious `DatasourceNoData` webhook issues (fingerprint 47991b0914dd7148,
+# GitHub issues #96/#98/#100/#101/#102/#103/#104). Provisioning them as code
+# with an explicit `noDataState: OK` makes the state authoritative and
+# restart-idempotent — Grafana re-applies this file on every start.
+#
+# This directory (./docker/grafana/provisioning) is bind-mounted read-only to
+# /etc/grafana/provisioning:ro (see docker-compose.yml `grafana` service), so
+# Grafana auto-loads this file on boot.
+#
+# SECRETS / ENV VARS (operator action required)
+# ---------------------------------------------
+# The contact-point webhook URL + auth token are NEVER hardcoded here (`.env`
+# is gitignored, must not commit secrets). They are referenced as environment
+# variables that Grafana expands at provisioning load time:
+#   * GRAFANA_WEBHOOK_URL   — full Cursor automation webhook ingress URL
+#                             (e.g. https://api2.cursor.sh/automations/webhook/<id>)
+#   * GRAFANA_WEBHOOK_TOKEN — bearer token (the `crsr_...` value, same token as
+#                             $TG_PARSER_WATCH_WEBHOOK_AUTH on the VPS).
+# Both must be added to the gitignored `.env` AND are passed through to the
+# grafana container via docker-compose.yml (`grafana` service `environment:`).
+#
+# METRIC-NAME ASSUMPTION (documented per BUG-036 deliverable)
+# ----------------------------------------------------------
+# The Wave-1-step-4 operator runbook
+# (docs/runbooks/WAVE1_STEP4_VPS_OPERATOR_MANUAL_ACTIONS.md) listed the 5xx
+# expr as `sum(rate(tg_api_requests_total{path=~...,status=~"5.."}[5m])) > 0`.
+# That metric/label pair does NOT exist in this codebase. The real HTTP
+# request counter is `tg_parser_http_requests_total` (emitted by
+# prometheus-fastapi-instrumentator with namespace `tg_parser`/subsystem
+# `http`; see tg_parser/api/metrics.py + docker/grafana/dashboards/system.json
+# which queries `tg_parser_http_requests_total{status=~"4..|5.."}`). The path
+# is exposed via the `handler` label (templated route), not `path`. The 5xx
+# expr below uses the real metric/labels. The `up{job=...}` exprs match the
+# Prometheus scrape jobs declared in docker/prometheus.yml.
+
+apiVersion: 1
+
+# ---------------------------------------------------------------------------
+# Alert rule groups
+# ---------------------------------------------------------------------------
+groups:
+  - orgId: 1
+    name: wave1_step4_watch
+    folder: wave1-step4-watch
+    # Group evaluation cadence. `for: 5m` below means a condition must hold for
+    # 5 minutes (>= 5 eval ticks at 1m) before the rule transitions to firing.
+    interval: 1m
+    rules:
+      # -- Rule 1: bot process down -------------------------------------------
+      # Fires when the tg_bot Prometheus scrape target reports up == 0 for 5m.
+      # `up` is 0 when the target is configured but unreachable; it is ENTIRELY
+      # ABSENT only if the scrape job is removed — that absence maps to NoData,
+      # which `noDataState: OK` deliberately suppresses (no spurious webhook).
+      - uid: bug036_tg_parser_bot_down
+        title: tg_parser_bot_down
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "tg_parser bot is down"
+          description: "Prometheus scrape target job=tg_parser_bot has reported up==0 for 5m."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: up{job="tg_parser_bot"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              conditions:
+                - type: query
+                  evaluator:
+                    type: lt
+                    params: [1]
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                    params: []
+
+      # -- Rule 2: API service down -------------------------------------------
+      - uid: bug036_tg_parser_api_down
+        title: tg_parser_api_down
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: "tg_parser API is down"
+          description: "Prometheus scrape target job=tg_parser_api has reported up==0 for 5m."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: up{job="tg_parser_api"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              conditions:
+                - type: query
+                  evaluator:
+                    type: lt
+                    params: [1]
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                    params: []
+
+      # -- Rule 3: 5xx spike on digests/watchlists API ------------------------
+      # Real metric name (see header assumption note): tg_parser_http_requests_total
+      # filtered to 5xx responses on the digests/watchlists routes. status=~"5.."
+      # matches both grouped ("5xx") and ungrouped ("500") status labels because
+      # `.` also matches the literal 'x'.
+      - uid: bug036_tg_api_5xx_spike
+        title: tg_api_5xx_spike
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+        annotations:
+          summary: "5xx responses on POST /api/v1/(digests|watchlists)"
+          description: "tg_parser_http_requests_total 5xx rate on digests/watchlists is > 0 for 5m."
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: sum(rate(tg_parser_http_requests_total{handler=~"/api/v1/(digests|watchlists).*",status=~"5.."}[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              conditions:
+                - type: query
+                  evaluator:
+                    type: gt
+                    params: [0]
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                    params: []
+
+# ---------------------------------------------------------------------------
+# Contact point — Cursor automation webhook ingress (GitHub-issue bridge).
+# URL + token come from env vars (never committed). Provisioning it here makes
+# the contact point survive container restarts (BUG-036 deliverable #2).
+# ---------------------------------------------------------------------------
+contactPoints:
+  - orgId: 1
+    name: cursor-watch-webhook
+    receivers:
+      - uid: bug036_cursor_watch_webhook
+        type: webhook
+        disableResolveMessage: false
+        settings:
+          url: ${GRAFANA_WEBHOOK_URL}
+          httpMethod: POST
+          authorization_scheme: Bearer
+          authorization_credentials: ${GRAFANA_WEBHOOK_TOKEN}
+
+# ---------------------------------------------------------------------------
+# Notification policy — bind the root route to cursor-watch-webhook so the 3
+# rules above (and any other alert) are delivered to the Cursor webhook. This
+# mirrors the operator's manual "Default contact point: cursor-watch-webhook"
+# step and makes it restart-idempotent.
+#
+# NOTE: provisioning `policies` replaces the root notification policy tree.
+# There is no other policy-provisioning file in this repo, so this is safe.
+# ---------------------------------------------------------------------------
+policies:
+  - orgId: 1
+    receiver: cursor-watch-webhook
+    group_by:
+      - grafana_folder
+      - alertname
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/tests/test_grafana_alerting_provisioning.py
+++ b/tests/test_grafana_alerting_provisioning.py
@@ -1,0 +1,180 @@
+"""
+BUG-036 regression test: Grafana Wave-1-step-4 alert rules provisioned as code.
+
+Background
+----------
+The alert rules ``tg_parser_bot_down`` / ``tg_parser_api_down`` /
+``tg_api_5xx_spike`` were originally hand-created in the Grafana UI. UI state
+did not persist ``noDataState`` across Grafana eval cycles / container
+restarts, so the rules kept drifting back to ``Alerting/NoData`` and
+re-emitted spurious ``DatasourceNoData`` webhook issues (fingerprint
+``47991b0914dd7148``; GitHub #96/#98/#100/#101/#102/#103/#104).
+
+The fix provisions all three rules + the ``cursor-watch-webhook`` contact
+point as code at
+``docker/grafana/provisioning/alerting/wave1_step4.yaml`` with explicit
+``noDataState: OK`` and ``for: 5m``.
+
+What this test does (and does NOT do)
+-------------------------------------
+This is a *static* validation/idempotency guard: it parses the provisioning
+YAML and asserts the schema essentials that make the fix correct, so a future
+edit cannot silently re-introduce the drift (e.g. drop ``noDataState: OK`` or
+unbind the contact point).
+
+It does NOT spin up a live Grafana — true restart-idempotency requires a
+running container and is documented as a manual verification step in the
+BUG-036 PR description / runbook. ``yaml`` (PyYAML) is already a project
+dependency (see pyproject.toml), so no new deps are introduced.
+
+Placement note: the repo keeps infra/config tests at the top level of
+``tests/`` (e.g. ``test_compose_env_propagation.py``,
+``test_alembic_ini_consistency.py``), so this test lives there too rather
+than in a new ``tests/infra/`` package.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROVISIONING_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docker"
+    / "grafana"
+    / "provisioning"
+    / "alerting"
+    / "wave1_step4.yaml"
+)
+
+EXPECTED_RULES = {"tg_parser_bot_down", "tg_parser_api_down", "tg_api_5xx_spike"}
+CONTACT_POINT_NAME = "cursor-watch-webhook"
+PROMETHEUS_DS_UID = "prometheus"
+
+
+@pytest.fixture(scope="module")
+def provisioning() -> dict:
+    assert PROVISIONING_PATH.exists(), (
+        f"BUG-036 provisioning file missing: {PROVISIONING_PATH}"
+    )
+    with PROVISIONING_PATH.open(encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh)
+    assert isinstance(loaded, dict), "provisioning YAML must parse to a mapping"
+    return loaded
+
+
+def _all_rules(provisioning: dict) -> list[dict]:
+    groups = provisioning.get("groups") or []
+    assert groups, "provisioning must declare at least one alert-rule group"
+    rules: list[dict] = []
+    for group in groups:
+        rules.extend(group.get("rules") or [])
+    return rules
+
+
+def _rules_by_title(provisioning: dict) -> dict[str, dict]:
+    by_title: dict[str, dict] = {}
+    for rule in _all_rules(provisioning):
+        title = rule.get("title")
+        assert title, f"every rule needs a title: {rule!r}"
+        by_title[title] = rule
+    return by_title
+
+
+# ---------------------------------------------------------------------------
+# Schema essentials
+# ---------------------------------------------------------------------------
+
+
+def test_api_version_is_1(provisioning: dict) -> None:
+    assert provisioning.get("apiVersion") == 1, (
+        "Grafana file-based provisioning requires apiVersion: 1"
+    )
+
+
+def test_all_three_rules_present(provisioning: dict) -> None:
+    titles = set(_rules_by_title(provisioning))
+    missing = EXPECTED_RULES - titles
+    assert not missing, f"missing provisioned alert rules: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))
+def test_rule_has_nodatastate_ok(provisioning: dict, rule_title: str) -> None:
+    """The core BUG-036 invariant: noDataState must be explicitly OK."""
+    rule = _rules_by_title(provisioning)[rule_title]
+    assert rule.get("noDataState") == "OK", (
+        f"{rule_title}: noDataState must be 'OK' to stop DatasourceNoData "
+        f"webhook drift (BUG-036), got {rule.get('noDataState')!r}"
+    )
+
+
+@pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))
+def test_rule_has_for_5m(provisioning: dict, rule_title: str) -> None:
+    rule = _rules_by_title(provisioning)[rule_title]
+    assert str(rule.get("for")) == "5m", (
+        f"{rule_title}: expected for: 5m, got {rule.get('for')!r}"
+    )
+
+
+@pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))
+def test_rule_uses_prometheus_datasource(provisioning: dict, rule_title: str) -> None:
+    rule = _rules_by_title(provisioning)[rule_title]
+    data = rule.get("data") or []
+    ds_uids = {q.get("datasourceUid") for q in data}
+    assert PROMETHEUS_DS_UID in ds_uids, (
+        f"{rule_title}: must query the '{PROMETHEUS_DS_UID}' datasource uid, "
+        f"got {sorted(u for u in ds_uids if u)}"
+    )
+
+
+@pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))
+def test_rule_has_condition_and_expr(provisioning: dict, rule_title: str) -> None:
+    rule = _rules_by_title(provisioning)[rule_title]
+    assert rule.get("condition"), f"{rule_title}: missing condition refId"
+    exprs = [
+        q.get("model", {}).get("expr")
+        for q in (rule.get("data") or [])
+        if q.get("datasourceUid") == PROMETHEUS_DS_UID
+    ]
+    assert any(exprs), f"{rule_title}: no PromQL expr on the prometheus query"
+
+
+# ---------------------------------------------------------------------------
+# Contact point + binding
+# ---------------------------------------------------------------------------
+
+
+def test_contact_point_defined(provisioning: dict) -> None:
+    contact_points = provisioning.get("contactPoints") or []
+    names = {cp.get("name") for cp in contact_points}
+    assert CONTACT_POINT_NAME in names, (
+        f"contact point '{CONTACT_POINT_NAME}' must be provisioned, got {sorted(names)}"
+    )
+
+
+def test_contact_point_webhook_not_hardcoded(provisioning: dict) -> None:
+    """The webhook URL/token must be env-var references, never plaintext secrets."""
+    contact_points = provisioning.get("contactPoints") or []
+    cp = next(c for c in contact_points if c.get("name") == CONTACT_POINT_NAME)
+    receivers = cp.get("receivers") or []
+    assert receivers, f"{CONTACT_POINT_NAME}: must declare at least one receiver"
+    url = receivers[0].get("settings", {}).get("url", "")
+    assert "${" in url or "$__env" in url, (
+        f"{CONTACT_POINT_NAME}: webhook url must reference an env var "
+        f"(no hardcoded secret), got {url!r}"
+    )
+
+
+def test_contact_point_bound_in_policies(provisioning: dict) -> None:
+    policies = provisioning.get("policies") or []
+    receivers = {p.get("receiver") for p in policies}
+    # also allow nested route bindings
+    for p in policies:
+        for route in p.get("routes") or []:
+            receivers.add(route.get("receiver"))
+    assert CONTACT_POINT_NAME in receivers, (
+        f"contact point '{CONTACT_POINT_NAME}' must be bound as a policy "
+        f"receiver so it survives restarts, got {sorted(r for r in receivers if r)}"
+    )


### PR DESCRIPTION
## Summary
Provisions the 3 Wave-1-step-4 Grafana alert rules (`tg_parser_bot_down`, `tg_parser_api_down`, `tg_api_5xx_spike`) as code so their `noDataState` no longer drifts back to firing across Grafana eval cycles / container restarts (recurring spurious GitHub issues, fingerprint `47991b0914dd7148`; #96/#98/#100/#101/#102/#103/#104). Closes the actionable part of **BUG-036**.

- New file `docker/grafana/provisioning/alerting/wave1_step4.yaml` (Grafana file-based alerting provisioning, `apiVersion: 1`). Each rule has explicit `noDataState: OK` and `for: 5m`. The `cursor-watch-webhook` contact point is provisioned and bound via the root notification policy, so it survives restarts.
- Webhook URL + bearer token are **env-var references** (`GRAFANA_WEBHOOK_URL`, `GRAFANA_WEBHOOK_TOKEN`), never hardcoded. Passed through to the grafana container in `docker-compose.yml`.
- Static validation test `tests/test_grafana_alerting_provisioning.py` (stdlib + already-present PyYAML).

### Rule exprs
| Rule | PromQL (datasource uid `prometheus`) | Condition | for | noDataState |
|---|---|---|---|---|
| `tg_parser_bot_down` | `up{job="tg_parser_bot"}` | reduce(last) < 1 | 5m | OK |
| `tg_parser_api_down` | `up{job="tg_parser_api"}` | reduce(last) < 1 | 5m | OK |
| `tg_api_5xx_spike` | `sum(rate(tg_parser_http_requests_total{handler=~"/api/v1/(digests\|watchlists).*",status=~"5.."}[5m]))` | reduce(last) > 0 | 5m | OK |

### Metric-name assumption (documented)
The Wave-1-step-4 operator runbook listed the 5xx expr as `tg_api_requests_total{path=~...}`, which **does not exist** in this codebase. The real HTTP counter is `tg_parser_http_requests_total` (prometheus-fastapi-instrumentator, namespace `tg_parser`/subsystem `http`; see `tg_parser/api/metrics.py` and the existing `system.json` dashboard query `tg_parser_http_requests_total{status=~"4..|5.."}`). The path is the `handler` label, not `path`. The expr above uses the real metric/labels. `status=~"5.."` matches both grouped (`5xx`) and ungrouped (`500`) status labels (`.` also matches the literal `x`).

## Operator action required (.env, gitignored)
Add to `.env` on the VPS and ensure they reach the grafana container (already wired in `docker-compose.yml`):
```
GRAFANA_WEBHOOK_URL=https://api2.cursor.sh/automations/webhook/7b35ca01-a7d1-4c3a-bb8b-940918e506d6
GRAFANA_WEBHOOK_TOKEN=crsr_<same token as $TG_PARSER_WATCH_WEBHOOK_AUTH>
```

## Test plan
- [x] `python3.12 -m pytest tests/test_grafana_alerting_provisioning.py -q` → 17 passed.
- [x] Self-review: flipped `noDataState` → `Alerting`, reran → `test_rule_has_nodatastate_ok[*]` failed (3 failed), then reverted → 17 passed.
- [ ] **Manual restart-idempotency verification** (needs live Grafana):
```bash
# 1. provisioning file in place + GRAFANA_WEBHOOK_URL/_TOKEN in .env
docker compose -f docker-compose.yml up -d --no-deps grafana
# 2. wait for provisioning load, then confirm noDataState persists via Grafana API
curl -s -u "$GRAFANA_ADMIN_USER:$GRAFANA_ADMIN_PASSWORD" \
  http://127.0.0.1:3000/api/v1/provisioning/alert-rules \
  | jq -r '.[] | select(.title|test("tg_parser_bot_down|tg_parser_api_down|tg_api_5xx_spike")) | "\(.title): noDataState=\(.noDataState)"'
# expect all three -> noDataState=OK
# 3. docker restart tg_parser_grafana && re-run step 2 -> still OK (idempotent)
```

## Notes
- Do NOT merge without operator sign-off (per task constraints).
- `policies:` provisioning replaces the root notification policy tree; there is no other policy-provisioning file in this repo, so this is safe.

Made with [Cursor](https://cursor.com)