### PR TITLE
fix(ci): clear pre-existing ruff-format + dead-link failures

### DIFF
--- a/docs/notes/REVIEW_2026-05-24_WAVE1_STEP4_DONE.md
+++ b/docs/notes/REVIEW_2026-05-24_WAVE1_STEP4_DONE.md
@@ -16,7 +16,7 @@
 | Field | Value |
 |---|---|
 | **Sprint scope** | Wave 1 Step 4 — ADR 0008 polymorphic subscription target (channel-publish path for digests + watchlists) |
-| **PR** | [#93](https://github.com/AlexEfimov/openai/TG_parser/pull/93) — «feat(wave1-step4): shareable-digest / ADR-0008 polymorphic target» |
+| **PR** | [#93](https://github.com/AlexEfimov/TG_parser/pull/93) — «feat(wave1-step4): shareable-digest / ADR-0008 polymorphic target» |
 | **Merge commit** | `926a165` (squash-merged 2026-05-24T09:39:52Z by AlexEfimov) |
 | **Alembic head** | `a8b7c6d5e4f3` (single forward step from step-3 baseline `f1a2b3c4d5e6`; no dedupe required — step 4 migration has no natural-key UNIQUE constraints that could conflict with existing rows) |
 | **Deploy target** | PRODUCTION VPS (`redboxtgbot`, `212.72.189.15:2296`); local-stack parallel sibling watch in [`WATCH_WINDOW_WAVE1_STEP4_2026-05-24.md`](WATCH_WINDOW_WAVE1_STEP4_2026-05-24.md) |

--- a/docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md
+++ b/docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md
@@ -14,7 +14,7 @@
 
 **Closed:** _pending_ — close via аналог `START_PROMPT_SESSION_WATCH_CLOSURE_2026-05-25.md`.
 
-**Merge commit:** `926a165` — [PR #93](https://github.com/AlexEfimov/openai/TG_parser/pull/93) squash-merged 2026-05-24T09:39:52Z.
+**Merge commit:** `926a165` — [PR #93](https://github.com/AlexEfimov/TG_parser/pull/93) squash-merged 2026-05-24T09:39:52Z.
 
 **Pre-deploy VPS HEAD:** `26d03a5` (BUG-028 hotfix, PR #92 от 2026-05-23T16:57Z; **5 commits behind** `origin/main`). **Post-deploy HEAD:** `926a165` (Wave 1 step 4). Fast-forward pull, 39 файлов / +3448 / −146.
 

--- a/tests/test_enh001_last_checked_telemetry.py
+++ b/tests/test_enh001_last_checked_telemetry.py
@@ -114,9 +114,7 @@ def _make_interest(
 
 @pg_only
 @pytest.mark.asyncio
-async def test_check_interests_touches_last_checked_at_on_empty_tick(
-    interest_repo, user_repo
-):
+async def test_check_interests_touches_last_checked_at_on_empty_tick(interest_repo, user_repo):
     """A quiet tick (``new_doc_refs=[]``, candidates=0) advances
     ``last_checked_at`` for every ACTIVE interest of the channel, and leaves
     inactive interests untouched. Pre-ENH-001 this returned early without any

--- a/tests/test_grafana_alerting_provisioning.py
+++ b/tests/test_grafana_alerting_provisioning.py
@@ -56,9 +56,7 @@ PROMETHEUS_DS_UID = "prometheus"
 
 @pytest.fixture(scope="module")
 def provisioning() -> dict:
-    assert PROVISIONING_PATH.exists(), (
-        f"BUG-036 provisioning file missing: {PROVISIONING_PATH}"
-    )
+    assert PROVISIONING_PATH.exists(), f"BUG-036 provisioning file missing: {PROVISIONING_PATH}"
     with PROVISIONING_PATH.open(encoding="utf-8") as fh:
         loaded = yaml.safe_load(fh)
     assert isinstance(loaded, dict), "provisioning YAML must parse to a mapping"
@@ -113,9 +111,7 @@ def test_rule_has_nodatastate_ok(provisioning: dict, rule_title: str) -> None:
 @pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))
 def test_rule_has_for_5m(provisioning: dict, rule_title: str) -> None:
     rule = _rules_by_title(provisioning)[rule_title]
-    assert str(rule.get("for")) == "5m", (
-        f"{rule_title}: expected for: 5m, got {rule.get('for')!r}"
-    )
+    assert str(rule.get("for")) == "5m", f"{rule_title}: expected for: 5m, got {rule.get('for')!r}"
 
 
 @pytest.mark.parametrize("rule_title", sorted(EXPECTED_RULES))


### PR DESCRIPTION
## Summary
Two independent, pre-existing CI fixes that are unrelated to any feature work:
- **ruff format**: ran `ruff format` on `tests/test_enh001_last_checked_telemetry.py` and `tests/test_grafana_alerting_provisioning.py` (collapsed over-wrapped lines that were under the line-length limit).
- **dead link**: corrected a malformed GitHub URL with a spurious `/openai/` path segment in `docs/notes/REVIEW_2026-05-24_WAVE1_STEP4_DONE.md` and `docs/notes/WATCH_WINDOW_WAVE1_STEP4_VPS_2026-05-24.md` (`.../AlexEfimov/openai/TG_parser/pull/93` → `.../AlexEfimov/TG_parser/pull/93`).

## Why
Both checks were failing on **every** branch, turning CI red regardless of the change under review (including the clean BUG_LOG reconcile PR #150). Splitting them into this dedicated cleanup PR keeps the failures isolated and the fix reviewable.

## Verification
- `.venv/bin/ruff format --check .` → `350 files already formatted` (clean) locally with ruff 0.15.11.
- `grep AlexEfimov/openai` across the repo → no matches remain.
- No behavior change; only test-file formatting + a doc URL typo.

Made with [Cursor](https://cursor.com)