### PR TITLE
fix(bot): emit bare token in delete candidate slicing (BUG-049)

### DIFF
--- a/docs/notes/BUG_LOG.md
+++ b/docs/notes/BUG_LOG.md
@@ -3462,9 +3462,11 @@ So the truncation is LLM-side rendering of the preview, not a data defect; the s
 
 **Impact:** Minor — one natural delete phrasing («удали подписку на <name>») fails to resolve a by-name delete. Pre-existing, not introduced by the BUG-047/048 work.
 
-**Status:** open. **Filed:** 2026-06-01. (backlog)
+**Status:** in-progress (branch `fix/bug049-delete-candidate-slicing`, not merged/deployed). **Filed:** 2026-06-01.
 
 **Proposed fix:** extend candidate generation in `_delete_name_candidates` to also emit the trailing bare token / strip leading prepositions like «на» (so «на genotek» also yields «genotek»), restoring the substring match against «Ежечасный дайджест Genotek». Add a regression case off the 2026-06-01 BUG-048 smoke trace.
+
+**Fix (2026-06-01, branch `fix/bug049-delete-candidate-slicing`):** added a small/conservative `_DELETE_PREPOSITION_PREFIX` (`на|об|от|про|по|о`) in `tg_parser/bot/handlers.py`; `_delete_name_candidates` now APPENDS a preposition-stripped bare-token candidate AFTER the existing shapes (so it acts only as a last-resort fallback — `_best_delete_match` prefers the first actionable outcome, so already-resolving inputs are unchanged). «удали подписку на genotek» now yields candidates `['подписку на genotek', 'на genotek', 'genotek']`; the bare «genotek» resolves via the existing `_SUGGEST_FUZZY_CUTOFF` substring tier and arms a `delete_suggest` clarify — same as «удали подписку genotek». Over-stripping avoided: only a leading preposition is removed (never an arbitrary trailing word), so multi-word names and names that legitimately start with a preposition still resolve via the higher-priority earlier candidates. Failing-first regression: `tests/test_bot_delete_candidate_slicing_bug049.py` (RED on `9ab998c`, GREEN after). Full suite + delete-routing/conversation suites green; `ruff@0.15.11 format --check . && check .` clean.
 
 **Related:** BUG-047 (the delete-routing cluster / owner-scoped name resolver this refines), BUG-048 (the intent-break work during whose live smoke this surfaced).
 

--- a/tests/test_bot_delete_candidate_slicing_bug049.py
+++ b/tests/test_bot_delete_candidate_slicing_bug049.py
@@ -1,0 +1,115 @@
+"""BUG-049 regression — delete-by-name candidate slicing drops the bare token.
+
+Symptom (live, post BUG-048 smoke): a digest subscription «Ежечасный дайджест
+Genotek» exists; «удали подписку на genotek» replies a plain «… не найдена»
+instead of offering the fuzzy/substring suggestion «Возможно, вы имели в виду
+«Ежечасный дайджест Genotek»?».
+
+Root cause: ``_delete_name_candidates`` strips the delete verb and ONE connector
+noun («подписку»), yielding «подписку на genotek» / «на genotek», but never
+strips the leading preposition «на» nor emits the bare trailing token «genotek»,
+so the substring match against «… Genotek» is never tested.
+
+This case is RED on ``9ab998c`` (plain not_found, FSM inert) and GREEN after the
+fix arms a ``delete_suggest`` clarify — exactly as «удали подписку genotek» does
+today. Helpers/fixtures are reused from ``test_bot_delete_routing_bug047``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from test_bot_delete_routing_bug047 import (  # type: ignore[import-not-found]  # noqa: E402
+    DIGEST_NAME,
+    SUB_ID,
+    _admin,
+    _digest,
+    _empty_repos,
+    _enter_all,
+    _exit_all,
+    _make_message,
+    _make_state,
+    _routing_patches,
+    _sent_text,
+)
+
+from tg_parser.bot.handlers import _delete_name_candidates, handle_text  # noqa: E402
+from tg_parser.bot.states import ClarifyFlow  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# 1. Candidate slicing unit — the bare token must be emitted
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateSlicingUnit:
+    def test_na_preposition_yields_bare_token(self) -> None:
+        """«удали подписку на genotek» must produce a bare «genotek» candidate so
+        the substring/fuzzy suggest tier can match «… Genotek»."""
+        cands = _delete_name_candidates("удали подписку на genotek")
+        assert "genotek" in cands, cands
+        # The bare token is a LAST-RESORT fallback (after the existing shapes).
+        assert cands[-1] == "genotek"
+        # Pre-existing shapes are preserved (no behavior change for them).
+        assert "подписку на genotek" in cands
+        assert "на genotek" in cands
+
+    def test_bare_token_path_unchanged(self) -> None:
+        """«удали подписку genotek» (works today) keeps its «genotek» candidate."""
+        cands = _delete_name_candidates("удали подписку genotek")
+        assert "genotek" in cands
+
+    def test_multiword_name_not_over_stripped(self) -> None:
+        """A multi-word name without a leading preposition must NOT be reduced to
+        its trailing token (no over-stripping)."""
+        cands = _delete_name_candidates("удали подписку Дайджест Genotek утро")
+        assert "Дайджест Genotek утро" in cands
+        # We never emit a bare trailing word for a prepositionless multi-word name.
+        assert "утро" not in cands
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end pre-router — «удали подписку на genotek» arms delete_suggest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestNaPrepositionArmsSuggest:
+    async def test_na_genotek_arms_delete_suggest(self):
+        """«удали подписку на genotek» (digest «Ежечасный дайджест Genotek»
+        exists) must ARM a ``delete_suggest`` clarify — NOT a plain not_found."""
+        digest_repo, ir, mr, svc, unregister = _empty_repos()
+        digest_repo.store[SUB_ID] = _digest(SUB_ID, DIGEST_NAME)
+
+        state = _make_state()
+        msg = _make_message("удали подписку на genotek")
+        agent = MagicMock()
+        agent.process_message = AsyncMock()
+
+        patches = _routing_patches(digest_repo, ir, mr, svc, unregister)
+        _enter_all(patches)
+        try:
+            await handle_text(msg, agent=agent, state=state, current_user=_admin())
+        finally:
+            _exit_all(patches)
+
+        agent.process_message.assert_not_called()
+        # A clarify FSM is ARMED (not a stateless not_found message).
+        assert await state.get_state() == ClarifyFlow.awaiting_channel_clarification.state
+        data = await state.get_data()
+        clarify = data["clarify_action"]
+        assert clarify["kind"] == "delete_suggest"
+        assert clarify["suggestion"]["id"] == SUB_ID
+        # The user-facing suggestion text is surfaced (fuzzy-suggest tier).
+        sent = _sent_text(msg)
+        assert "Возможно, вы имели в виду" in sent
+        assert "Ответьте «да»" in sent
+        assert DIGEST_NAME in sent
+        # Nothing deleted.
+        assert SUB_ID in digest_repo.store

--- a/tg_parser/bot/handlers.py
+++ b/tg_parser/bot/handlers.py
@@ -135,6 +135,19 @@ _DELETE_NOUN_PREFIX = re.compile(
     re.IGNORECASE,
 )
 
+# BUG-049 — a leading preposition («на genotek») hides the bare token from the
+# casefolded-substring / fuzzy suggest tier, so «удали подписку на genotek»
+# never reduces to «genotek» and falls to a plain not-found (vs «удали подписку
+# genotek», which DOES arm the suggest). Stripped ONLY to emit an additional
+# LAST-RESORT candidate (appended after the existing shapes). The set is kept
+# deliberately small/conservative and only fires when a meaningful remainder
+# survives, so a name that legitimately starts with a preposition (or a
+# multi-word name) still resolves via the earlier, higher-priority candidates.
+_DELETE_PREPOSITION_PREFIX = re.compile(
+    r"^(на|об|от|про|по|о)\s+",
+    re.IGNORECASE,
+)
+
 # BUG-048 (D2) — intent-break / escape detectors. An armed ConfirmFlow /
 # subscribe-read ClarifyFlow is "greedy": pre-fix it consumed ANY non-«нет»
 # reply as a confirm-token / channel-name, wedging the user when they actually
@@ -1512,6 +1525,15 @@ def _delete_name_candidates(text: str) -> list[str]:
     no_noun = _DELETE_NOUN_PREFIX.sub("", stripped).strip()
     if no_noun and no_noun != stripped and no_noun.casefold() not in _BARE_DELETE_NOUNS:
         out.append(no_noun)
+    # BUG-049: a leading preposition («на genotek») hides the bare token from the
+    # substring/fuzzy suggest tier. Append the preposition-stripped remainder as
+    # a LAST-RESORT fallback (AFTER the existing candidates) — `_best_delete_match`
+    # prefers the first actionable outcome, so this never changes behavior for
+    # inputs that already resolve / disambiguate / suggest on an earlier shape.
+    for base in (no_noun, stripped):
+        bare = _DELETE_PREPOSITION_PREFIX.sub("", base).strip()
+        if bare and bare != base and bare not in out and bare.casefold() not in _BARE_DELETE_NOUNS:
+            out.append(bare)
     return out
 
 


### PR DESCRIPTION
## Summary
BUG-049 (minor, pre-existing) — delete-by-name candidate slicing missed the bare channel/keyword token. `_delete_name_candidates` now appends a preposition-stripped bare-token fallback, so «удали подписку на genotek» → candidates `['подписку на genotek', 'на genotek', 'genotek']` and arms a `delete_suggest` clarify instead of a plain not-found.

- New candidate is appended LAST (conservative): `_best_delete_match` returns the first actionable outcome, so inputs that already resolve are bit-for-bit unchanged.
- Only a leading preposition is stripped (`на|об|от|про|по|о`) — never an arbitrary trailing word — so multi-word names aren't reduced to their last token.

## Tests
- New `tests/test_bot_delete_candidate_slicing_bug049.py` (failing-first red→green: bare-token emitted + `delete_suggest` armed; multi-word over-stripping guard).
- Full suite: 2725 passed, 345 skipped. Pinned ruff 0.15.11 format+check clean.
- Delete-routing / conversation-layer regression suites green (BUG-047/048/045/043/046/032).

## Notes
- Bot-Python/tests/docs only — NO DB migrations.

Made with [Cursor](https://cursor.com)