### PR TITLE
fix(bot): suppress pagination D-4 loop for resolved channel token (BUG-052)

### DIFF
--- a/docs/notes/BUG_LOG.md
+++ b/docs/notes/BUG_LOG.md
@@ -3517,6 +3517,22 @@ So the truncation is LLM-side rendering of the preview, not a data defect; the s
 
 ---
 
+### BUG-052 (Medium — bot correctness) — PaginationFlow bare channel token D-4 fall-through duplicates read-clarify
+
+**Discovered:** 2026-06-02, production logs. After successful read-clarify → `list_topics` with `PaginationFlow` armed, user sends bare channel name «genotek» (not «ещё»). D-4 default clears pagination state and re-routes to the agent → LLM calls `list_topics(genotek)` again → duplicate clarify.
+
+**Root cause (HIGH confidence — code-traced):** `_handle_pagination_response` treats any non-«ещё»/non-«стоп» text as D-4 fall-through (`state.clear()` + recursive `handle_text`). A bare channel token matching the already-resolved channel from `pagination.args.channel_id` / `read_context.last_channel_id` is not recognized as a pagination no-op.
+
+**Impact:** Medium — confusing duplicate clarify / list after a successful read-clarify + paginated list; user must type «ещё» explicitly.
+
+**Status:** resolved (2026-06-02). **Fix:** before D-4 fall-through, when `_bare_channel_token(text)` matches the resolved channel (case-insensitive via `normalize_channel_id`), reply with «Для следующей страницы напишите «ещё». Чтобы остановить — «стоп».» and preserve `PaginationFlow`. NEXT_PAGE / «стоп» paths unchanged.
+
+**Regression tests:** `tests/test_bot_pagination_channel_token_bug052.py` (052-1 matching bare token no-op; 052-2 different channel still fall-through; 052-3 «стоп» guard).
+
+**Related:** BUG-004 (PaginationFlow), BUG-043 (read-clarify path that arms pagination), BUG-051 (duplicate-send race — separate class).
+
+---
+
 ## TD from Session D — code observations after PR #38
 
 **Назначение секции:** post-landing observations из self-review PR #38 (Session D, BUG-002 + BUG-004 closure). Не блокеры — но подходящие кандидаты для Session F или последующего housekeeping-sprint'а. Каждый item открыт как отдельный GH issue с label `tech-debt` + `priority/p1` per Phase 1/2 convention.

--- a/tests/test_bot_pagination_channel_token_bug052.py
+++ b/tests/test_bot_pagination_channel_token_bug052.py
@@ -1,0 +1,104 @@
+"""BUG-052 — PaginationFlow bare channel token must not D-4 fall through to agent."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from tg_parser.bot.handlers import _handle_pagination_response
+from tg_parser.bot.states import PaginationFlow
+
+
+def _make_state() -> FSMContext:
+    storage = MemoryStorage()
+    key = StorageKey(bot_id=42, chat_id=12345, user_id=67890)
+    return FSMContext(storage=storage, key=key)
+
+
+def _make_message(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.text = text
+    msg.chat = MagicMock()
+    msg.chat.id = 12345
+    msg.bot = MagicMock()
+    msg.answer = AsyncMock()
+    return msg
+
+
+async def _arm_genotek_pagination(state: FSMContext) -> None:
+    await state.set_state(PaginationFlow.has_active_list)
+    await state.update_data(
+        pagination={
+            "tool_name": "list_topics",
+            "args": {
+                "channel_id": "genotek",
+                "offset": 5,
+                "limit": 5,
+            },
+            "total": 25,
+            "offset": 5,
+            "limit": 5,
+        },
+        items_shown=5,
+        created_at=datetime.now(UTC).isoformat(),
+        read_context={
+            "last_channel_id": "genotek",
+            "last_tool": "list_topics",
+            "created_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_bare_matching_channel_is_noop_keeps_pagination() -> None:
+    state = _make_state()
+    await _arm_genotek_pagination(state)
+    msg = _make_message("genotek")
+    agent = MagicMock()
+    agent.process_message = AsyncMock()
+
+    with patch("tg_parser.bot.handlers.execute_tool", new=AsyncMock()) as mock_execute:
+        await _handle_pagination_response(msg, agent, state, current_user=None)
+
+    mock_execute.assert_not_called()
+    agent.process_message.assert_not_called()
+    assert await state.get_state() == PaginationFlow.has_active_list.state
+    msg.answer.assert_called_once()
+    assert "ещё" in msg.answer.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_bare_different_channel_still_falls_through() -> None:
+    state = _make_state()
+    await _arm_genotek_pagination(state)
+    msg = _make_message("other_channel")
+    agent = MagicMock()
+    agent.process_message = AsyncMock(return_value=MagicMock(response_text="ok"))
+
+    with patch("tg_parser.bot.handlers.execute_tool", new=AsyncMock()):
+        with patch("tg_parser.bot.handlers.handle_text", new=AsyncMock()) as mock_handle:
+            await _handle_pagination_response(msg, agent, state, current_user=None)
+
+    mock_handle.assert_called_once()
+    assert await state.get_state() is None
+
+
+@pytest.mark.asyncio
+async def test_next_page_and_stop_unchanged() -> None:
+    state = _make_state()
+    await _arm_genotek_pagination(state)
+    stop_msg = _make_message("стоп")
+    agent = MagicMock()
+    agent.process_message = AsyncMock()
+
+    with patch("tg_parser.bot.handlers.execute_tool", new=AsyncMock()) as mock_execute:
+        await _handle_pagination_response(stop_msg, agent, state, current_user=None)
+
+    mock_execute.assert_not_called()
+    assert await state.get_state() is None
+    assert "Остановлено" in stop_msg.answer.call_args[0][0]

--- a/tg_parser/bot/handlers.py
+++ b/tg_parser/bot/handlers.py
@@ -63,6 +63,7 @@ from tg_parser.bot.tools import (
     resolve_subscription_by_name,
     verify_channel_exists,
 )
+from tg_parser.utils.channel_id import normalize_channel_id
 
 if TYPE_CHECKING:
     from tg_parser.bot.agent import GeminiAgent
@@ -1301,6 +1302,25 @@ async def _handle_pagination_response(
             if _pagination_rc is not None:
                 await state.update_data(read_context=_pagination_rc)
         return
+
+    # BUG-052: a bare channel token matching the already-resolved list channel
+    # is a no-op — do NOT D-4 fall through to the agent (which would re-call
+    # list_topics and duplicate clarify after read-clarify → list → pagination).
+    bare = _bare_channel_token(text)
+    if bare is not None:
+        page_args: dict[str, Any] = pagination.get("args") or {}
+        resolved = normalize_channel_id(page_args.get("channel_id"))
+        if resolved is None and isinstance(_pagination_rc, dict):
+            resolved = normalize_channel_id(_pagination_rc.get("last_channel_id"))
+        if (
+            resolved
+            and normalize_channel_id(bare) is not None
+            and normalize_channel_id(bare).casefold() == resolved.casefold()
+        ):
+            await message.answer(
+                "Для следующей страницы напишите «ещё». Чтобы остановить — «стоп»."
+            )
+            return
 
     # Fall-through: D-4 default — clear state and re-route as a fresh
     # agent request. Restore read_context so handle_text can inject it.


### PR DESCRIPTION
## Summary
- When `PaginationFlow` is armed after read-clarify → `list_topics`, a bare channel token matching the already-resolved channel no longer triggers D-4 fall-through to the agent (which re-called `list_topics` and duplicated clarify).
- User gets a short hint to use «ещё» / «стоп»; pagination state is preserved.
- BUG_LOG BUG-052 marked resolved; regression tests added.

## Test plan
- [x] `uv run pytest tests/test_bot_pagination_channel_token_bug052.py`
- [ ] Manual: read-clarify → paginated list → send same channel name → hint only, no duplicate list/clarify
- [ ] Manual: «ещё» / «стоп» still work; different channel name still fall-throughs to agent


Made with [Cursor](https://cursor.com)