### PR TITLE
fix(ops): grafana webhook provisioning defaults to stop crash-loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,8 +313,10 @@ services:
       # (docker/grafana/provisioning/alerting/wave1_step4.yaml). Values live in
       # the gitignored .env; never commit them. Grafana expands these at
       # provisioning load time.
-      - GRAFANA_WEBHOOK_URL=${GRAFANA_WEBHOOK_URL:-}
-      - GRAFANA_WEBHOOK_TOKEN=${GRAFANA_WEBHOOK_TOKEN:-}
+      # Empty defaults crash Grafana provisioning (invalid webhook url). Loopback
+      # no-op lets the container start; set real values in gitignored .env for prod.
+      - GRAFANA_WEBHOOK_URL=${GRAFANA_WEBHOOK_URL:-http://127.0.0.1:65535/}
+      - GRAFANA_WEBHOOK_TOKEN=${GRAFANA_WEBHOOK_TOKEN:-unset}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker/grafana/provisioning/alerting/wave1_step4.yaml
+++ b/docker/grafana/provisioning/alerting/wave1_step4.yaml
@@ -28,6 +28,10 @@
 # Both must be added to the gitignored `.env` AND are passed through to the
 # grafana container via docker-compose.yml (`grafana` service `environment:`).
 #
+# When unset in `.env`, docker-compose supplies loopback no-op defaults
+# (`http://127.0.0.1:65535/`, token `unset`) so URL validation passes and
+# Grafana can boot without secrets. Override both for production webhooks.
+#
 # METRIC-NAME ASSUMPTION (documented per BUG-036 deliverable)
 # ----------------------------------------------------------
 # The Wave-1-step-4 operator runbook


### PR DESCRIPTION
## Summary
- Default `GRAFANA_WEBHOOK_URL` / `GRAFANA_WEBHOOK_TOKEN` in `docker-compose.yml` to loopback no-op values when unset, so Grafana provisioning accepts the webhook contact point and the container stops crash-looping on empty URL.
- Document the compose fallback in `docker/grafana/provisioning/alerting/wave1_step4.yaml` operator comments.

## Test plan
- [x] `uv run pytest tests/test_grafana_alerting_provisioning.py -q`
- [ ] After merge/deploy: `docker compose up -d grafana` without webhook secrets in `.env` — container stays healthy (no restart loop)
- [ ] With real `GRAFANA_WEBHOOK_*` in `.env`, alerts still deliver to Cursor webhook ingress


Made with [Cursor](https://cursor.com)