### PR TITLE
fix(bot): read-clarify fuzzy fallback for short channel prefix (BUG-053)

### DIFF
--- a/docs/notes/BUG_LOG.md
+++ b/docs/notes/BUG_LOG.md
@@ -3533,6 +3533,28 @@ So the truncation is LLM-side rendering of the preview, not a data defect; the s
 
 ---
 
+### BUG-053 (Medium — bot correctness) — short channel prefix breaks read-clarify («gen» → «genotek»)
+
+**Discovered:** 2026-06-02, production smoke after BUG-052 landing.
+
+**Symptom:** «покажи темы gen» → bot lists nothing / paraphrases without actionable clarify; follow-up «genotek» or «да» does not deterministically re-run `list_topics(genotek)` — user stuck in LLM loop with `read_context` pinned to the bad prefix «gen».
+
+**Root cause (HIGH confidence — code-traced):** `_channel_suggestion_lookup` (`tg_parser/bot/tools.py`) only fuzzy-matches at `_NO_RESULTS_FUZZY_CUTOFF`=0.7. The short token «gen» vs channel «genotek» scores below 0.7, so `_build_no_results_suggestion` emits no `clarify_pending`. The agent loop then feeds `total=0` back to Gemini (2nd paraphrase turn). Separately, `agent.py` appends every `list_topics(channel_id=…)` call to `read_tools_called` even on `total=0`, so `_refresh_read_context` sticks `last_channel_id="gen"` and poisons implicit context on the next turn.
+
+**Impact:** Medium — common short-prefix channel queries dead-end instead of arming the existing BUG-043 read-clarify FSM; follow-ups mis-route through stale read context.
+
+**Status:** fixed (branch `fix/bug053-read-clarify-short-prefix`).
+
+**Fix:**
+- **Fix A (primary):** `_channel_suggestion_lookup` — when `get_close_matches` @ 0.7 is empty, fallback @ `_SUGGEST_FUZZY_CUTOFF`=0.5 with **single match only** (parity with `_match_subscription_items` suggest tier).
+- **Fix B (secondary):** `tg_parser/bot/agent.py` — do not append to `read_tools_called` when `list_topics` returns `total=0`.
+
+**Regression tests:** `tests/test_bot_read_clarify_short_prefix_bug053.py` (053-lookup tiers, clarify «да»/bare token, agent read_context guard).
+
+**Related:** BUG-043 (read-clarify FSM), BUG-047 (`_SUGGEST_FUZZY_CUTOFF` subscription resolver), BUG-011 (`read_context` tracking).
+
+---
+
 ## TD from Session D — code observations after PR #38
 
 **Назначение секции:** post-landing observations из self-review PR #38 (Session D, BUG-002 + BUG-004 closure). Не блокеры — но подходящие кандидаты для Session F или последующего housekeeping-sprint'а. Каждый item открыт как отдельный GH issue с label `tech-debt` + `priority/p1` per Phase 1/2 convention.

--- a/tests/test_bot_read_clarify_short_prefix_bug053.py
+++ b/tests/test_bot_read_clarify_short_prefix_bug053.py
@@ -1,0 +1,297 @@
+"""Regression suite for BUG-053 — short channel prefix read-clarify.
+
+Real-fire trace: «покажи темы gen» → ``list_topics(gen)`` → ``total=0`` →
+``_channel_suggestion_lookup`` at cutoff 0.7 finds no ``gen``→``genotek`` match
+→ no ``clarify_pending`` → 2nd LLM paraphrase; ``read_context`` sticks on
+``gen`` so a follow-up «genotek»/«да» re-routes through implicit context.
+
+Fix A: ``_channel_suggestion_lookup`` falls back to ``_SUGGEST_FUZZY_CUTOFF``
+(0.5) when the 0.7 tier is empty (single match only).
+Fix B: ``agent.py`` skips ``read_tools_called`` when ``list_topics`` returns
+``total=0``.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from tg_parser.auth.models import CurrentUser
+from tg_parser.bot.agent import GeminiAgent
+from tg_parser.bot.handlers import _handle_clarification_response
+from tg_parser.bot.states import ClarifyFlow
+from tg_parser.bot.tools import (
+    _build_no_results_suggestion,
+    _channel_suggestion_lookup,
+)
+
+SHORT_PREFIX = "gen"
+FULL_CHANNEL = "genotek"
+OTHER_CHANNEL = "AgeManagment"
+DM_CHAT_ID = 100_500_053
+
+
+def _admin(user_id: str = "user-bug053") -> CurrentUser:
+    return CurrentUser(
+        id=user_id,
+        name="bug053",
+        role="admin",
+        allowed_channel_ids=None,
+        max_channels=100,
+    )
+
+
+def _make_state(bot_id: int = 42, chat_id: int = DM_CHAT_ID, user_id: int = 67890) -> FSMContext:
+    storage = MemoryStorage()
+    key = StorageKey(bot_id=bot_id, chat_id=chat_id, user_id=user_id)
+    return FSMContext(storage=storage, key=key)
+
+
+def _make_message(text: str, chat_id: int = DM_CHAT_ID) -> MagicMock:
+    msg = MagicMock()
+    msg.text = text
+    msg.chat = MagicMock()
+    msg.chat.id = chat_id
+    msg.bot = MagicMock()
+    msg.answer = AsyncMock()
+    msg.answer_chat_action = AsyncMock()
+    return msg
+
+
+class _FakeSource:
+    def __init__(self, channel_id: str) -> None:
+        self.channel_id = channel_id
+
+
+def _fake_state_repo_ctx(channel_ids: list[str]):
+    @asynccontextmanager
+    async def _ctx():
+        repo = MagicMock()
+        repo.list_sources = AsyncMock(return_value=[_FakeSource(c) for c in channel_ids])
+        yield (repo, MagicMock())
+
+    return _ctx
+
+
+def _read_clarify_action(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "kind": "read",
+        "tool_name": "list_topics",
+        "args": {"channel_id": SHORT_PREFIX, "limit": 20},
+        "channel_arg": "channel_id",
+        "suggestion": FULL_CHANNEL,
+        "message": (
+            f"Канал «{SHORT_PREFIX}» не найден. Возможно, вы имели в виду "
+            f"«{FULL_CHANNEL}»? Ответьте «да», чтобы продолжить."
+        ),
+    }
+    base.update(overrides)
+    return base
+
+
+def _gemini_function_call(name: str, args: dict) -> dict:
+    return {
+        "candidates": [{"content": {"parts": [{"functionCall": {"name": name, "args": args}}]}}]
+    }
+
+
+def _sent_text(msg: MagicMock) -> str:
+    return " ".join(str(c.args) for c in msg.answer.call_args_list)
+
+
+@pytest.mark.asyncio
+class TestBug053ChannelSuggestionLookupTiers:
+    async def test_short_prefix_resolves_via_suggest_tier(self):
+        """«gen» must fuzzy-match «genotek» at the 0.5 fallback tier."""
+        with patch(
+            "tg_parser.services.db_context.ingestion_state_repo",
+            _fake_state_repo_ctx([FULL_CHANNEL, OTHER_CHANNEL]),
+        ):
+            matched, available = await _channel_suggestion_lookup(SHORT_PREFIX, _admin())
+        assert matched == FULL_CHANNEL
+        assert FULL_CHANNEL in available
+
+    async def test_suggest_tier_skipped_when_multiple_matches(self):
+        """Two channels at 0.5 → no single suggestion (parity with subscription resolver)."""
+        with patch(
+            "tg_parser.services.db_context.ingestion_state_repo",
+            _fake_state_repo_ctx(["genotek", "genetics", OTHER_CHANNEL]),
+        ):
+            matched, _available = await _channel_suggestion_lookup(SHORT_PREFIX, _admin())
+        assert matched is None
+
+    async def test_build_no_results_attaches_read_clarify_for_short_prefix(self):
+        with patch(
+            "tg_parser.services.db_context.ingestion_state_repo",
+            _fake_state_repo_ctx([FULL_CHANNEL, OTHER_CHANNEL]),
+        ):
+            payload = await _build_no_results_suggestion(
+                SHORT_PREFIX,
+                _admin(),
+                tool_name="list_topics",
+                args={"channel_id": SHORT_PREFIX, "limit": 20},
+            )
+        clarify = payload["clarify_pending"]
+        assert clarify["kind"] == "read"
+        assert clarify["suggestion"] == FULL_CHANNEL
+        assert FULL_CHANNEL in clarify["message"]
+        assert "да" in clarify["message"].lower()
+
+
+@pytest.mark.asyncio
+class TestBug053ReadClarifyFollowUp:
+    async def test_affirmative_reruns_list_topics_with_suggested_channel(self):
+        state = _make_state()
+        await state.set_state(ClarifyFlow.awaiting_channel_clarification)
+        await state.update_data(
+            clarify_action=_read_clarify_action(),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        msg = _make_message("да")
+        agent = MagicMock()
+        agent.process_message = AsyncMock()
+
+        calls: list[tuple[str, dict]] = []
+
+        async def mock_execute(name: str, args: dict, **_kw):
+            calls.append((name, dict(args)))
+            return {
+                "total": 1,
+                "offset": 0,
+                "limit": 20,
+                "has_more": False,
+                "items": [
+                    {
+                        "n": 1,
+                        "id": "topic-gen-1",
+                        "title": "Genomics overview",
+                        "type": "thematic",
+                        "summary": "Summary.",
+                        "items_count": 1,
+                        "sources": [FULL_CHANNEL],
+                    }
+                ],
+            }
+
+        with (
+            patch("tg_parser.bot.handlers.execute_tool", new=mock_execute),
+            patch(
+                "tg_parser.bot.handlers.verify_channel_exists",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await _handle_clarification_response(msg, agent, state, current_user=_admin())
+
+        assert len(calls) == 1
+        name, args = calls[0]
+        assert name == "list_topics"
+        assert args["channel_id"] == FULL_CHANNEL
+        agent.process_message.assert_not_called()
+        assert "не совсем понимаю" not in _sent_text(msg).lower()
+
+    async def test_bare_genotek_token_reruns_list_topics(self):
+        state = _make_state()
+        await state.set_state(ClarifyFlow.awaiting_channel_clarification)
+        await state.update_data(
+            clarify_action=_read_clarify_action(),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        msg = _make_message(FULL_CHANNEL)
+        agent = MagicMock()
+        agent.process_message = AsyncMock()
+
+        invoked: list[tuple[str, dict]] = []
+
+        async def mock_execute(name: str, args: dict, **_kw):
+            invoked.append((name, dict(args)))
+            return {"total": 1, "offset": 0, "limit": 20, "has_more": False, "items": []}
+
+        with (
+            patch("tg_parser.bot.handlers.execute_tool", new=mock_execute),
+            patch(
+                "tg_parser.bot.handlers.verify_channel_exists",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await _handle_clarification_response(msg, agent, state, current_user=_admin())
+
+        assert invoked[0][0] == "list_topics"
+        assert invoked[0][1]["channel_id"] == FULL_CHANNEL
+        agent.process_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestBug053AgentReadContextGuard:
+    async def test_agent_short_circuits_with_read_clarify_for_gen(self):
+        agent = GeminiAgent(api_key="test-key")
+        read_clarify = _read_clarify_action()
+        tool_result = {
+            "total": 0,
+            "offset": 0,
+            "limit": 20,
+            "has_more": False,
+            "items": [],
+            "clarify_pending": read_clarify,
+        }
+        with (
+            patch.object(
+                agent,
+                "_call_gemini",
+                new=AsyncMock(
+                    side_effect=[_gemini_function_call("list_topics", {"channel_id": SHORT_PREFIX})]
+                ),
+            ),
+            patch(
+                "tg_parser.bot.agent.execute_tool",
+                new=AsyncMock(return_value=tool_result),
+            ),
+        ):
+            result = await agent.process_message("покажи темы gen")
+
+        assert result.clarify_pending is not None
+        assert result.clarify_pending["suggestion"] == FULL_CHANNEL
+        assert result.read_tools_called == []
+
+    async def test_successful_list_topics_still_updates_read_context(self):
+        agent = GeminiAgent(api_key="test-key")
+        call_count = 0
+
+        async def _fake_post(url, *, json, params):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.status_code = 200
+            if call_count == 1:
+                resp.json.return_value = _gemini_function_call(
+                    "list_topics", {"channel_id": FULL_CHANNEL, "limit": 20}
+                )
+            else:
+                resp.json.return_value = {
+                    "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}]
+                }
+            return resp
+
+        agent._client.post = _fake_post
+
+        with patch(
+            "tg_parser.bot.agent.execute_tool",
+            new_callable=AsyncMock,
+            return_value={
+                "total": 3,
+                "items": [],
+                "offset": 0,
+                "limit": 20,
+                "has_more": False,
+            },
+        ):
+            result = await agent.process_message("покажи темы genotek")
+
+        assert len(result.read_tools_called) == 1
+        assert result.read_tools_called[0][1]["channel_id"] == FULL_CHANNEL

--- a/tg_parser/bot/agent.py
+++ b/tg_parser/bot/agent.py
@@ -415,7 +415,19 @@ class GeminiAgent:
 
                 # BUG-011 (Session H): track channel_id-bearing read-tool
                 # calls so the handler can update FSMContext.read_context.
-                if tool_name in _READ_TOOLS_TRACKED_FOR_CONTEXT and tool_args.get("channel_id"):
+                # BUG-053: a ``list_topics`` that returned ``total=0`` is a
+                # failed channel lookup — do NOT stick the bad prefix into
+                # read_context (otherwise a follow-up «genotek»/«да» re-routes
+                # through implicit context back to ``list_topics(gen)``).
+                if (
+                    tool_name in _READ_TOOLS_TRACKED_FOR_CONTEXT
+                    and tool_args.get("channel_id")
+                    and not (
+                        tool_name == "list_topics"
+                        and isinstance(result, dict)
+                        and result.get("total") == 0
+                    )
+                ):
                     read_tools_called.append((tool_name, dict(tool_args)))
 
                 function_responses.append(

--- a/tg_parser/bot/tools.py
+++ b/tg_parser/bot/tools.py
@@ -1481,6 +1481,20 @@ async def _channel_suggestion_lookup(
             n=1,
             cutoff=_NO_RESULTS_FUZZY_CUTOFF,
         )
+        if not matches:
+            # BUG-053: short-prefix / partial channel tokens (e.g. «gen» →
+            # «genotek») fall below the read not-found cutoff (0.7) but still
+            # clear the subscription-resolver suggestion tier (0.5). Only
+            # propose when the lower tier yields a SINGLE match — parity with
+            # ``_match_subscription_items`` suggest path.
+            fallback = difflib.get_close_matches(
+                requested_channel_id,
+                all_ids,
+                n=10,
+                cutoff=_SUGGEST_FUZZY_CUTOFF,
+            )
+            if len(fallback) == 1:
+                matches = fallback
         if matches and matches[0] != requested_channel_id:
             suggestion = matches[0]
     return suggestion, available


### PR DESCRIPTION
## Summary
- **Fix A:** `_channel_suggestion_lookup` falls back to `_SUGGEST_FUZZY_CUTOFF` (0.5) when the 0.7 tier finds no match — single match only, parity with subscription resolver.
- **Fix B:** `agent.py` skips `read_tools_called` when `list_topics` returns `total=0`, so stale read context does not pin short prefixes like «gen».
- Adds `tests/test_bot_read_clarify_short_prefix_bug053.py` (7 tests) and BUG-053 entry in `BUG_LOG.md`.

## Test plan
- [x] `uv run pytest tests/test_bot_read_clarify_short_prefix_bug053.py -v` — 7 passed
- [x] `uvx ruff@0.15.11 format --check` + `check` on touched files
- [ ] Smoke: `/start` → «покажи темы gen» → clarify with «да» → `list_topics(genotek)` succeeds (no 2nd LLM paraphrase, no stale «gen» context)


Made with [Cursor](https://cursor.com)