### PR TITLE
Preserve Telegram entity URLs in raw payload and processed metadata

### DIFF
--- a/prompts/processing.yaml
+++ b/prompts/processing.yaml
@@ -7,7 +7,7 @@
 # Документация: docs/LLM_PROMPTS.md
 
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   description: "Prompts for processing Telegram messages"
   author: "TG_parser team"
   requirements:
@@ -35,6 +35,7 @@ system:
     }
 
     Important:
+    - Preserve all URLs and markdown links [text](url) verbatim; never drop the URL part.
     - text_clean is REQUIRED and should be the cleaned version of the original text
     - summary can be null if the message is too short or not meaningful
     - topics can be empty list if no clear topics

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -215,6 +215,55 @@ async def test_processing_pipeline_basic(
 
 
 @pytest.mark.asyncio
+async def test_processing_pipeline_preserves_urls_in_metadata(
+    mock_processed_doc_repo,
+):
+    """raw_payload urls are copied into ProcessedDocument.metadata without touching text_clean."""
+    urls = [
+        {
+            "url": "https://hidden.example/path",
+            "text": "click here",
+            "type": "text_url",
+        }
+    ]
+    message = RawTelegramMessage(
+        id="123",
+        message_type=MessageType.POST,
+        source_ref="tg:test_channel:post:123",
+        channel_id="test_channel",
+        date=datetime(2025, 12, 14, 10, 0, 0, tzinfo=UTC),
+        text="click here",
+        raw_payload={"message": "click here", "urls": urls},
+    )
+    llm_client = ProcessingMockLLM()
+    pipeline = ProcessingPipelineImpl(
+        llm_client=llm_client,
+        processed_doc_repo=mock_processed_doc_repo,
+        model_id="test-model",
+    )
+
+    result = await pipeline.process_message(message)
+
+    assert result.metadata["urls"] == urls
+
+
+@pytest.mark.asyncio
+async def test_processing_pipeline_no_urls_key_when_raw_payload_empty(
+    sample_raw_message,
+    mock_processed_doc_repo,
+):
+    """Messages without raw_payload urls do not add metadata.urls."""
+    pipeline = ProcessingPipelineImpl(
+        llm_client=ProcessingMockLLM(),
+        processed_doc_repo=mock_processed_doc_repo,
+    )
+
+    result = await pipeline.process_message(sample_raw_message)
+
+    assert "urls" not in result.metadata
+
+
+@pytest.mark.asyncio
 async def test_processing_pipeline_incrementality(
     sample_raw_message,
     mock_processed_doc_repo,
@@ -815,6 +864,45 @@ async def test_media_only_comment_photo_produces_synthetic_doc(
     assert result.metadata["prompt_id"] == "media_only_synthetic"
     assert result.language == "unknown"
     assert llm_client.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_media_only_preserves_urls_in_metadata(
+    mock_processed_doc_repo,
+):
+    """Media-only synthetic docs still carry urls from raw_payload metadata."""
+    urls = [
+        {
+            "url": "https://example.com/caption-link",
+            "text": "https://example.com/caption-link",
+            "type": "url",
+        }
+    ]
+    message = RawTelegramMessage(
+        id="154",
+        message_type=MessageType.COMMENT,
+        source_ref="tg:test_channel:comment:154",
+        channel_id="test_channel",
+        date=datetime(2025, 12, 14, 11, 5, 0, tzinfo=UTC),
+        text="",
+        thread_id="97",
+        parent_message_id="153",
+        raw_payload={
+            "id": 154,
+            "message": "",
+            "media": {"type": "MessageMediaPhoto", "has_photo": True},
+            "urls": urls,
+        },
+    )
+    pipeline = ProcessingPipelineImpl(
+        llm_client=ProcessingMockLLM(),
+        processed_doc_repo=mock_processed_doc_repo,
+    )
+
+    result = await pipeline.process_message(message, force=True)
+
+    assert result.metadata["urls"] == urls
+    assert result.metadata["media_only"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_raw_message_serialize_payload.py
+++ b/tests/test_raw_message_serialize_payload.py
@@ -1,0 +1,29 @@
+"""Unit tests for SARawMessageRepo._serialize_payload URL preservation on truncate."""
+
+import json
+from unittest.mock import MagicMock
+
+from tg_parser.storage.sqlalchemy.raw_message_repo import RAW_PAYLOAD_MAX_SIZE, SARawMessageRepo
+
+
+def test_serialize_payload_preserves_urls_on_truncate():
+    repo = SARawMessageRepo(session=MagicMock())
+    urls = [
+        {
+            "url": "https://example.com/hidden",
+            "text": "click here",
+            "type": "text_url",
+        }
+    ]
+    payload = {
+        "message": "x" * (RAW_PAYLOAD_MAX_SIZE + 1000),
+        "urls": urls,
+    }
+
+    payload_json, truncated, original_size = repo._serialize_payload(payload)
+
+    assert truncated is True
+    assert original_size > RAW_PAYLOAD_MAX_SIZE
+    loaded = json.loads(payload_json)
+    assert loaded["truncated"] is True
+    assert loaded["urls"] == urls

--- a/tests/test_telethon_client.py
+++ b/tests/test_telethon_client.py
@@ -62,6 +62,7 @@ class TestTelethonClient:
         mock_message.post_author = "Test Author"
         mock_message.grouped_id = None
         mock_message.media = None
+        mock_message.entities = None
 
         # Преобразуем
         raw_msg = await client._convert_message(
@@ -105,6 +106,7 @@ class TestTelethonClient:
         mock_message.post_author = None
         mock_message.grouped_id = None
         mock_message.media = None
+        mock_message.entities = None
 
         # Преобразуем
         raw_msg = await client._convert_message(

--- a/tests/test_telethon_extract_urls.py
+++ b/tests/test_telethon_extract_urls.py
@@ -1,0 +1,193 @@
+"""
+Unit tests for TelethonClient._extract_urls and URL preservation in _convert_message.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+from telethon.tl.types import MessageEntityTextUrl, MessageEntityUrl
+
+from tg_parser.config.settings import Settings
+from tg_parser.domain.models import MessageType
+from tg_parser.ingestion.telegram import TelethonClient
+
+
+@pytest.fixture
+def client() -> TelethonClient:
+    return TelethonClient(
+        Settings(
+            telegram_api_id=12345,
+            telegram_api_hash="test_hash",
+            telegram_phone="+1234567890",
+        )
+    )
+
+
+def _make_message(*, message: str, entities) -> Mock:
+    mock_message = Mock()
+    mock_message.id = 1
+    mock_message.text = message
+    mock_message.message = message
+    mock_message.date = datetime(2025, 12, 14, 10, 0, 0, tzinfo=UTC)
+    mock_message.reply_to = None
+    mock_message.views = None
+    mock_message.forwards = None
+    mock_message.replies = None
+    mock_message.edit_date = None
+    mock_message.post_author = None
+    mock_message.grouped_id = None
+    mock_message.media = None
+    mock_message.entities = entities
+    return mock_message
+
+
+class TestExtractUrls:
+    def test_entities_none_returns_empty(self, client):
+        message = _make_message(message="plain text", entities=None)
+        assert client._extract_urls(message) == []
+
+    def test_text_url_entity(self, client):
+        plain = "Read more here"
+        message = _make_message(
+            message=plain,
+            entities=[
+                MessageEntityTextUrl(
+                    offset=0,
+                    length=14,
+                    url="https://example.com/article",
+                )
+            ],
+        )
+        assert client._extract_urls(message) == [
+            {
+                "url": "https://example.com/article",
+                "text": "Read more here",
+                "type": "text_url",
+            }
+        ]
+
+    def test_bare_url_entity(self, client):
+        plain = "Visit https://example.com today"
+        url = "https://example.com"
+        offset = len("Visit ".encode("utf-16-le")) // 2
+        length = len(url.encode("utf-16-le")) // 2
+        message = _make_message(
+            message=plain,
+            entities=[MessageEntityUrl(offset=offset, length=length)],
+        )
+        assert client._extract_urls(message) == [
+            {
+                "url": url,
+                "text": url,
+                "type": "url",
+            }
+        ]
+
+    def test_utf16_emoji_offset(self, client):
+        plain = "Hi 👋 link"
+        # "Hi " = 3 UTF-16 units, "👋" = 2, " " = 1, so "link" starts at offset 6
+        message = _make_message(
+            message=plain,
+            entities=[
+                MessageEntityTextUrl(
+                    offset=6,
+                    length=4,
+                    url="https://example.com/emoji-test",
+                )
+            ],
+        )
+        assert client._extract_urls(message) == [
+            {
+                "url": "https://example.com/emoji-test",
+                "text": "link",
+                "type": "text_url",
+            }
+        ]
+
+    def test_mixed_entities_preserves_order(self, client):
+        plain = "Site https://a.com and click"
+        url_offset = len("Site ".encode("utf-16-le")) // 2
+        url_length = len("https://a.com".encode("utf-16-le")) // 2
+        text_url_offset = len("Site https://a.com and ".encode("utf-16-le")) // 2
+        message = _make_message(
+            message=plain,
+            entities=[
+                MessageEntityUrl(offset=url_offset, length=url_length),
+                MessageEntityTextUrl(
+                    offset=text_url_offset,
+                    length=5,
+                    url="https://b.com/hidden",
+                ),
+            ],
+        )
+        assert client._extract_urls(message) == [
+            {
+                "url": "https://a.com",
+                "text": "https://a.com",
+                "type": "url",
+            },
+            {
+                "url": "https://b.com/hidden",
+                "text": "click",
+                "type": "text_url",
+            },
+        ]
+
+    def test_dedup_exact_url_repeats(self, client):
+        plain = "dup dup"
+        message = _make_message(
+            message=plain,
+            entities=[
+                MessageEntityTextUrl(offset=0, length=3, url="https://dup.example"),
+                MessageEntityTextUrl(offset=4, length=3, url="https://dup.example"),
+            ],
+        )
+        assert client._extract_urls(message) == [
+            {
+                "url": "https://dup.example",
+                "text": "dup",
+                "type": "text_url",
+            }
+        ]
+
+    def test_empty_entities_list(self, client):
+        message = _make_message(message="no links", entities=[])
+        assert client._extract_urls(message) == []
+
+
+class TestConvertMessageUrls:
+    @pytest.mark.asyncio
+    async def test_convert_message_adds_urls_to_raw_payload(self, client):
+        message = _make_message(
+            message="click me",
+            entities=[
+                MessageEntityTextUrl(
+                    offset=0,
+                    length=8,
+                    url="https://example.com/hidden",
+                )
+            ],
+        )
+        raw_msg = await client._convert_message(
+            message=message,
+            channel_id="test_channel",
+            message_type=MessageType.POST,
+        )
+        assert raw_msg.raw_payload["urls"] == [
+            {
+                "url": "https://example.com/hidden",
+                "text": "click me",
+                "type": "text_url",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_convert_message_omits_urls_key_when_empty(self, client):
+        message = _make_message(message="plain", entities=None)
+        raw_msg = await client._convert_message(
+            message=message,
+            channel_id="test_channel",
+            message_type=MessageType.POST,
+        )
+        assert "urls" not in raw_msg.raw_payload

--- a/tg_parser/ingestion/telegram/telethon_client.py
+++ b/tg_parser/ingestion/telegram/telethon_client.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 
 from telethon import TelegramClient as TelethonTelegramClient
 from telethon.errors import RPCError
-from telethon.tl.types import Message
+from telethon.tl.types import Message, MessageEntityTextUrl, MessageEntityUrl
 
 from tg_parser.config.settings import Settings
 from tg_parser.domain.ids import make_source_ref
@@ -239,6 +239,10 @@ class TelethonClient:
             "media": self._extract_media_metadata(message) if message.media else None,
         }
 
+        urls = self._extract_urls(message)
+        if urls:
+            raw_payload["urls"] = urls
+
         return RawTelegramMessage(
             id=msg_id,
             message_type=message_type,
@@ -251,6 +255,46 @@ class TelethonClient:
             language=None,  # TR-26: язык определяется на этапе processing
             raw_payload=raw_payload,
         )
+
+    @staticmethod
+    def _slice_message_text(text: str, offset: int, length: int) -> str:
+        """Slice message text by Telegram entity offset/length (UTF-16 code units)."""
+        if not text or length <= 0:
+            return ""
+        utf16 = text.encode("utf-16-le")
+        start = offset * 2
+        end = (offset + length) * 2
+        return utf16[start:end].decode("utf-16-le")
+
+    def _extract_urls(self, message: Message) -> list[dict]:
+        """
+        Extract external URLs from Telegram message entities.
+
+        Returns list of {"url", "text", "type"} where type is "text_url" or "url".
+        """
+        if not message.entities:
+            return []
+
+        text = message.message or ""
+        urls: list[dict] = []
+        seen_urls: set[str] = set()
+
+        for entity in message.entities:
+            if isinstance(entity, MessageEntityTextUrl):
+                visible_text = self._slice_message_text(text, entity.offset, entity.length)
+                entry = {"url": entity.url, "text": visible_text, "type": "text_url"}
+            elif isinstance(entity, MessageEntityUrl):
+                url_text = self._slice_message_text(text, entity.offset, entity.length)
+                entry = {"url": url_text, "text": url_text, "type": "url"}
+            else:
+                continue
+
+            if entry["url"] in seen_urls:
+                continue
+            seen_urls.add(entry["url"])
+            urls.append(entry)
+
+        return urls
 
     def _extract_media_metadata(self, message: Message) -> dict | None:
         """

--- a/tg_parser/processing/pipeline.py
+++ b/tg_parser/processing/pipeline.py
@@ -457,6 +457,10 @@ class ProcessingPipelineImpl(ProcessingPipeline):
         if is_comment and parent_context:
             metadata["has_parent_context"] = True
 
+        urls = (message.raw_payload or {}).get("urls") or []
+        if urls:
+            metadata["urls"] = urls
+
         # TR-41: id = "doc:" + source_ref
         doc_id = make_processed_document_id(message.source_ref)
 
@@ -549,6 +553,10 @@ class ProcessingPipelineImpl(ProcessingPipeline):
         if message.parent_message_id or message.thread_id:
             metadata["parent_message_id"] = message.parent_message_id
             metadata["thread_id"] = message.thread_id
+
+        urls = (message.raw_payload or {}).get("urls") or []
+        if urls:
+            metadata["urls"] = urls
 
         processed = ProcessedDocument(
             id=make_processed_document_id(message.source_ref),

--- a/tg_parser/processing/prompts.py
+++ b/tg_parser/processing/prompts.py
@@ -28,6 +28,7 @@ Output MUST be valid JSON matching this structure:
 }
 
 Important:
+- Preserve all URLs and markdown links [text](url) verbatim; never drop the URL part.
 - text_clean is REQUIRED and should be the cleaned version of the original text
 - summary can be null if the message is too short or not meaningful
 - topics can be empty list if no clear topics

--- a/tg_parser/storage/sqlalchemy/raw_message_repo.py
+++ b/tg_parser/storage/sqlalchemy/raw_message_repo.py
@@ -268,6 +268,8 @@ class SARawMessageRepo(RawMessageRepo):
             "original_size_bytes": original_size,
             # Можно добавить kept_fields/summary по необходимости
         }
+        if "urls" in payload:
+            truncated_payload["urls"] = payload["urls"]
 
         return stable_json_dumps(truncated_payload), True, original_size
 


### PR DESCRIPTION
## Summary
- Extract `MessageEntityUrl` / `MessageEntityTextUrl` during Telethon ingestion into `raw_payload["urls"]` (UTF-16-aware text slices, deduped by URL).
- Keep `urls` when raw payload is truncated for storage; copy into `ProcessedDocument.metadata["urls"]` for LLM and media-only paths.
- Bump processing prompt to 1.0.1 with explicit instruction to preserve URLs and markdown links verbatim.

## Test plan
- [x] `pytest tests/test_telethon_extract_urls.py tests/test_raw_message_serialize_payload.py tests/test_telethon_client.py tests/test_processing_pipeline.py -q`
- [x] Full suite (`pytest`) passes locally
- [x] Ruff clean on touched modules


Made with [Cursor](https://cursor.com)