### PR TITLE
fix(resummarize): record llm_error metric on LLM-call exception

### DIFF
--- a/tests/test_f5c_resummarization_service.py
+++ b/tests/test_f5c_resummarization_service.py
@@ -406,8 +406,7 @@ class TestResummarizeTopic:
             # The billing error must propagate without any outcome being
             # recorded by the call-exception path.
             assert not any(
-                call.kwargs.get("status") == "llm_error"
-                for call in record_mock.call_args_list
+                call.kwargs.get("status") == "llm_error" for call in record_mock.call_args_list
             )
 
     @pytest.mark.asyncio

--- a/tests/test_f5c_resummarization_service.py
+++ b/tests/test_f5c_resummarization_service.py
@@ -333,6 +333,84 @@ class TestResummarizeTopic:
                     await svc.resummarize_topic("topic:tg:ch:post:1")
 
     @pytest.mark.asyncio
+    async def test_llm_call_exception_records_llm_error_and_propagates(self, test_db):
+        """Observability gap fix: when ``generate_with_usage`` raises a
+        generic exception (e.g. the prod httpx 404 from a retired model),
+        ``record_resummarize_outcome`` must be called once with
+        ``status='llm_error'`` (so ``ResummarizeLLMErrorRate`` can see a
+        full-failure outage) AND the original exception must still propagate
+        so ``run_for_channel``'s local accounting is unchanged."""
+
+        class _Http404(Exception):
+            pass
+
+        async with test_db.processing_storage_session() as session:
+            card_repo, bundle_repo = await _seed(session)
+            ver_repo = SATopicCardVersionRepo(session)
+
+            err = _Http404("404 model_not_found: the model has been retired")
+            with (
+                _patch_resolve(),
+                _patch_llm(_FakeLLMClient(err)),
+                patch(
+                    "tg_parser.services.resummarization_service.record_resummarize_outcome"
+                ) as record_mock,
+            ):
+                svc = ResummarizationService(
+                    topic_card_repo=card_repo,
+                    topic_bundle_repo=bundle_repo,
+                    topic_card_version_repo=ver_repo,
+                )
+                with pytest.raises(_Http404):
+                    await svc.resummarize_topic("topic:tg:ch:post:1")
+
+            record_mock.assert_called_once()
+            kwargs = record_mock.call_args.kwargs
+            assert kwargs["status"] == "llm_error"
+            assert kwargs["topic_id"] == "topic:tg:ch:post:1"
+            assert kwargs["channel_id"] == "ch"
+            assert kwargs["trigger"] == "counter"
+            assert kwargs["model"] == "openai/gpt-4o-mini"
+
+            # No new summary committed; counter untouched on failure.
+            updated = await card_repo.get_by_id("topic:tg:ch:post:1")
+            assert updated is not None
+            assert updated.summary_version == 1
+            assert updated.new_items_since_last_summary == 8
+
+    @pytest.mark.asyncio
+    async def test_billing_error_not_reclassified_as_llm_error(self, test_db):
+        """Decision #13: ``AnthropicBillingError`` must re-raise UNCHANGED —
+        the call-exception path must NOT record an ``llm_error`` outcome for
+        it (that would mask the billing-pause signal)."""
+        async with test_db.processing_storage_session() as session:
+            card_repo, bundle_repo = await _seed(session)
+            ver_repo = SATopicCardVersionRepo(session)
+
+            err = AnthropicBillingError("credit balance too low")
+            with (
+                _patch_resolve(provider="anthropic", model="claude-sonnet"),
+                _patch_llm(_FakeLLMClient(err)),
+                patch(
+                    "tg_parser.services.resummarization_service.record_resummarize_outcome"
+                ) as record_mock,
+            ):
+                svc = ResummarizationService(
+                    topic_card_repo=card_repo,
+                    topic_bundle_repo=bundle_repo,
+                    topic_card_version_repo=ver_repo,
+                )
+                with pytest.raises(AnthropicBillingError):
+                    await svc.resummarize_topic("topic:tg:ch:post:1")
+
+            # The billing error must propagate without any outcome being
+            # recorded by the call-exception path.
+            assert not any(
+                call.kwargs.get("status") == "llm_error"
+                for call in record_mock.call_args_list
+            )
+
+    @pytest.mark.asyncio
     async def test_locked_status_when_advisory_lock_unavailable(self, test_db, monkeypatch):
         """Gotcha #5: ``pg_try_advisory_xact_lock`` returns false when
         another worker holds the lock — re-summarize must short-circuit

--- a/tg_parser/services/resummarization_service.py
+++ b/tg_parser/services/resummarization_service.py
@@ -329,6 +329,26 @@ class ResummarizationService:
                 system_prompt=sys_prompt,
                 **model_settings,
             )
+        except AnthropicBillingError:
+            # Decision #13 / Gotcha #16: never reclassify as llm_error and
+            # never record an outcome here — it must propagate untouched so
+            # the scheduler hook pauses the source for billing.
+            raise
+        except Exception:
+            # Any other LLM-call failure (e.g. the prod 404 from a retired
+            # model) must still hit tg_resummarize_total{outcome="llm_error"}
+            # so ResummarizeLLMErrorRate can see a full-failure outage. The
+            # in-function parse / template-missing branches already record
+            # llm_error; this is the previously-missing call-exception path.
+            record_resummarize_outcome(
+                topic_id=topic_id,
+                status="llm_error",
+                channel_id=metric_channel,
+                trigger=metric_trigger,
+                duration_s=time.perf_counter() - t0,
+                model=f"{provider}/{model}",
+            )
+            raise
         finally:
             duration_s = time.perf_counter() - t0
             with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

When `resummarize_topic` (`tg_parser/services/resummarization_service.py`) calls `client.generate_with_usage(...)`, the call was wrapped in `try/finally` with **no `except`**. On an LLM-call exception (e.g. the current prod **404 from a retired model**) the exception propagated without ever calling `record_resummarize_outcome`. The caller `run_for_channel` caught it but only bumped a local dict (`skipped["llm_error"]`), never the Prometheus counter — so `tg_resummarize_total{outcome="llm_error"}` stayed flat and the **`ResummarizeLLMErrorRate` alert was blind to a 100%-failure outage**.

The in-function `llm_error` branches (parse error, template-missing) already recorded the metric; only the LLM-call-exception path was missing it.

### Fix (minimal, surgical)
- Add an `except` around the LLM call that records `status="llm_error"` with the same labels the other `llm_error` branches use (`channel_id=metric_channel`, `trigger=metric_trigger`, `topic_id`, `duration_s`, `model=f"{provider}/{model}"`), then **re-raises** the original exception so `run_for_channel`'s existing local accounting and control flow are unchanged.
- `AnthropicBillingError` is re-raised **UNCHANGED** ahead of the generic handler — preserving the Decision #13 / Gotcha #16 billing-pause behavior (never reclassified, no outcome recorded for it).
- The `finally` (duration + `client.close()`) is left intact.

This is the **observability half** of the retired-model incident; the prod model fix is handled separately.

## Test plan
Added two pg-gated tests in `tests/test_f5c_resummarization_service.py`:
- `test_llm_call_exception_records_llm_error_and_propagates` — a generic (httpx 404-style) exception records `record_resummarize_outcome(status="llm_error")` exactly once with the correct labels, and the exception still propagates; no summary committed.
- `test_billing_error_not_reclassified_as_llm_error` — `AnthropicBillingError` re-raises without any `llm_error` outcome being recorded.

```
TEST_POSTGRES=1 .venv/bin/python -m pytest \
  tests/test_f5c_resummarization_service.py \
  tests/test_resummarize_metrics.py \
  tests/test_f5c_scheduler_hook.py -q
# 38 passed
```

`ruff check` clean on both changed files.

Do **not** merge yet.

Made with [Cursor](https://cursor.com)