### PR TITLE
fix(resummarize): strip markdown json fence before parsing (newer Sonnet models)

### DIFF
--- a/tests/test_f5c_resummarization_service.py
+++ b/tests/test_f5c_resummarization_service.py
@@ -290,6 +290,47 @@ class TestResummarizeTopic:
             assert updated.new_items_since_last_summary == 8
 
     @pytest.mark.asyncio
+    async def test_markdown_fenced_json_response_parses_to_ok(self, test_db):
+        """Regression: newer Sonnet models (claude-sonnet-4-5/-6) wrap their
+        JSON in a ```json markdown fence.  A bare ``json.loads`` failed at
+        char 0 with "Expecting value: line 1 column 1"; the service now
+        strips the fence via ``extract_json_from_response`` (same helper
+        topicization uses) so a fenced response yields a ``success`` outcome.
+        """
+        async with test_db.processing_storage_session() as session:
+            card_repo, bundle_repo = await _seed(session)
+            ver_repo = SATopicCardVersionRepo(session)
+
+            inner = json.dumps(
+                {
+                    "summary": "Fenced refreshed summary",
+                    "scope_in": ["fenced-a", "fenced-b"],
+                    "scope_out": ["fenced-out"],
+                }
+            )
+            fenced_payload = f"```json\n{inner}\n```"
+            with (
+                _patch_resolve(),
+                _patch_llm(_FakeLLMClient(fenced_payload)),
+                _patch_embed(),
+            ):
+                svc = ResummarizationService(
+                    topic_card_repo=card_repo,
+                    topic_bundle_repo=bundle_repo,
+                    topic_card_version_repo=ver_repo,
+                )
+                outcome = await svc.resummarize_topic("topic:tg:ch:post:1")
+
+            assert outcome["status"] == "ok"
+            assert outcome["version_no"] == 2
+
+            updated = await card_repo.get_by_id("topic:tg:ch:post:1")
+            assert updated is not None
+            assert updated.summary == "Fenced refreshed summary"
+            assert updated.scope_in == ["fenced-a", "fenced-b"]
+            assert updated.summary_version == 2
+
+    @pytest.mark.asyncio
     async def test_empty_scope_in_returns_empty_scope(self, test_db):
         async with test_db.processing_storage_session() as session:
             card_repo, bundle_repo = await _seed(session)

--- a/tg_parser/services/resummarization_service.py
+++ b/tg_parser/services/resummarization_service.py
@@ -46,6 +46,7 @@ from tg_parser.config import settings
 from tg_parser.domain.models import TopicCardVersion
 from tg_parser.processing.llm.errors import AnthropicBillingError
 from tg_parser.processing.llm.factory import create_llm_client, resolve_llm_config
+from tg_parser.processing.pipeline import extract_json_from_response
 from tg_parser.processing.prompt_loader import (
     PromptLoader,
     PromptLoaderError,
@@ -337,9 +338,12 @@ class ResummarizationService:
                 # we'll re-raise on the way out of the try block).
                 await client.close()
 
-        # 4. Parse + validate.
+        # 4. Parse + validate.  Newer Sonnet models wrap their JSON output in
+        # a ```json markdown fence; strip it the same way topicization does
+        # (extract_json_from_response) before json.loads, otherwise a fenced
+        # response fails at char 0 with "Expecting value: line 1 column 1".
         try:
-            parsed = json.loads(resp.text.strip())
+            parsed = json.loads(extract_json_from_response(resp.text))
             new_summary = str(parsed["summary"]).strip()
             new_scope_in = [str(s).strip() for s in parsed.get("scope_in", []) if str(s).strip()]
             new_scope_out = [str(s).strip() for s in parsed.get("scope_out", []) if str(s).strip()]


### PR DESCRIPTION
## Summary
- Newer Anthropic Sonnet models (`claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`) wrap their JSON output in a ```json markdown fence. The bare `json.loads(resp.text.strip())` in `resummarize_topic` (`tg_parser/services/resummarization_service.py`) failed at char 0 with `Expecting value: line 1 column 1` on a fenced response, so resummarize returned `status="llm_error"`. The retired `claude-sonnet-4-20250514` returned raw JSON, which masked the bug.
- Fix: reuse `extract_json_from_response` (the helper topicization already uses, in `tg_parser/processing/pipeline.py`) to strip the fence before `json.loads`. The existing parse-error fallback (`f5c_resummarize_parse_error` -> `record_resummarize_outcome(status="llm_error")`) is preserved for responses still invalid after extraction.
- This is the parser half that gates re-running the model-swap+persist resummarize remediation once the model is swapped off the retired model.

## Changes
- `tg_parser/services/resummarization_service.py`: import `extract_json_from_response`; replace bare `json.loads(resp.text.strip())` with `json.loads(extract_json_from_response(resp.text))`.
- `tests/test_f5c_resummarization_service.py`: add `test_markdown_fenced_json_response_parses_to_ok` (fenced ```json response -> `ok` outcome, new summary committed). Existing invalid-JSON -> `llm_error` path retained.

## Test plan
- [x] `TEST_POSTGRES=1 .venv/bin/python -m pytest tests/test_f5c_resummarization_service.py -q` -> 18 passed
- [x] `ruff check` clean on both changed files

Made with [Cursor](https://cursor.com)